### PR TITLE
feat: enhance Slowpics upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ to screenshot files by relative path next to the report; when `report.embed_imag
 is enabled, screenshot bytes are embedded in the HTML payload. The viewer persists
 browser-local view mode, clip selection, viewport/zoom, reveal, and alignment state
 per report; it supports frame/category navigation, pan and wheel zoom controls, and
-collapsed report, clip, and frame metadata panels.
+an info modal that keeps report, clip, and current-frame metadata accessible.
 
 ### Overlays
 

--- a/VISUAL_AUDIT_REPORT.md
+++ b/VISUAL_AUDIT_REPORT.md
@@ -24,21 +24,25 @@ All dimension scores are compressed toward the center (3 to 7) to keep evaluatio
 ## Detailed Audit Findings
 
 ### 1. Dropdown Options Theme Mismatch
+
 *   **Location**: `.rv-controls select` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
 *   **Description**: Option text color inherits `--text-primary` (almost white) but the dropdown popover background defaults to native light colors on some OSes/browsers. This renders text white-on-white.
 *   **Recommendation**: Add `color-scheme: dark` to `:root` and explicitly style `select option` to use dark backgrounds.
 
 ### 2. Redundant Category Labels
+
 *   **Location**: `.rv-filmstrip-label` / [renderer.py](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/renderer.py) & [display.py](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/display.py)
 *   **Description**: If a frame belongs to the "Motion" category, the text label renders as `Motion • Motion`. Similarly, the bottom info bar displays both the label and category as duplicate strings (`Motion • MOTION`).
 *   **Recommendation**: Change the default frame label to use the frame number (e.g., `Frame 3127`) instead of the category name, producing clean groupings (e.g., `Frame 3127 • Motion`).
 
 ### 3. Cluttered Timecode/Timestamp Strings
+
 *   **Location**: `frame_detail_for_source_frame` / [display.py](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/display.py)
 *   **Description**: Frame details display a detailed timecode string (`00:02:10.422`) inside parentheses. This clutters the UI and is less intuitive for comparisons than standard frame numbers.
 *   **Recommendation**: Remove the timestamp details from the default frame display text, letting frame numbers serve as the primary navigator.
 
 ### 4. HTML Clip Label Overlay & Baked-in Metadata Collision (All Modes)
+
 *   **Location**: `.rv-overlay-label` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
 *   **Description**: The absolute-positioned left HTML label `.rv-overlay-label` (displaying e.g. "Reference") is positioned at `top: 12px; left: 12px;`. This overlaps directly with the baked-in VapourSynth frame metadata text block (e.g., `Frame 11 of 16`). This collision occurs in Slider mode, Overlay mode, and Blink mode.
 *   **Recommendation**:
@@ -46,36 +50,43 @@ All dimension scores are compressed toward the center (3 to 7) to keep evaluatio
     - Recenter the stage info badge (`.rv-stage-overlay-info`) to the bottom-middle (`bottom: 16px; left: 50%; transform: translateX(-50%);`) to avoid collision and balance the UI symmetry.
 
 ### 5. Diff Mode Stage Click Bug (Black Screen)
+
 *   **Location**: `cycleClip` & `pointerInteraction` / [viewer.js](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.js)
 *   **Description**: In `diff` mode, clicking on the image stage cycles the active compare clip. If there are only 2 clips, the right (compare) clip cycles to match the left (base) clip (e.g., `Reference` vs `Reference`). This renders a completely black difference screen, confusing the user.
 *   **Recommendation**: Modify `cycleClip()` for split modes (`diff` and `blink`) to skip `leftClipIdx` during the cycle loop, ensuring Left and Right comparison clips are never identical.
 
 ### 6. Firefox Range Slider Thumb Styling
+
 *   **Location**: `#zoom-range` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
 *   **Description**: Custom range slider styling is defined only for `-webkit-slider-thumb`. On Firefox, the zoom range slider thumb defaults to an unstyled grey box.
 *   **Recommendation**: Add duplicate rules targeting `::-moz-range-thumb` to ensure cross-browser styling parity.
 
 ### 7. Native Number Input Spin Buttons
+
 *   **Location**: `.rv-number-input` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
 *   **Description**: Browser-native increment/decrement arrows on number inputs clutter the compact manual offset fields in the alignment popover.
 *   **Recommendation**: Add CSS rules to suppress `-webkit-outer-spin-button` and `-webkit-inner-spin-button`, setting `-moz-appearance: textfield` to clean up the fields.
 
 ### 8. Browser-Native Form Controls
+
 *   **Location**: `.rv-controls select` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
 *   **Description**: Select controls use default browser dropdown arrows, which look clunky and differ across platforms.
 *   **Recommendation**: Suppress default styling using `appearance: none` and use a clean inline vector chevron SVG as a background image.
 
 ### 9. Category Filter Visual Accents
+
 *   **Location**: `.rv-filter-chip` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
 *   **Description**: Bottom filter chips are simple buttons that do not share the color-coded accent identifiers used by filmstrip cards.
 *   **Recommendation**: Prepend a small CSS pseudo-element (`::before`) dot styled with the respective category color code.
 
 ### 10. Standard Font Fallbacks
+
 *   **Location**: `:root { --font-sans }` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
 *   **Description**: Using system default sans-serif fonts gives the UI a generic look.
 *   **Recommendation**: Integrate a modern Google Font like `Inter` to clean up the metadata list and titles.
 
 ### 11. Zoom Interpolation Blur
+
 *   **Location**: `.rv-image` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
 *   **Description**: Zooming in on frames uses default bilinear filtering, which blurs individual pixel boundaries.
 *   **Recommendation**: Set `image-rendering: pixelated` when zoom levels increase to allow detailed pixel comparisons.
@@ -85,13 +96,16 @@ All dimension scores are compressed toward the center (3 to 7) to keep evaluatio
 ## Workflow Feature Suggestions
 
 ### A. Quick-Swap Clips Button & Shortcut
+
 *   **Description**: There is currently no quick way to swap the left and right clips (`L` and `R` streams) to inspect subtle difference changes. Swapping them requires opening two separate dropdown selects.
 *   **Proposal**: Add a swap button `⇄` in the controls bar between the Left and Right select elements, and bind the `X` key to toggle/swap the clip selection indices.
 
 ### B. Toggle Overlays Visibility (Hide UI overlays)
+
 *   **Description**: In Diff mode, bright white HTML overlay text boxes distract from inspecting dark differences in the corners.
 *   **Proposal**: Bind the `H` key to toggle the visibility of all HTML overlays (labels and stage info badge) on and off, allowing a clean, distraction-free view of the differences.
 
 ### C. Touch & Gesture Support
+
 *   **Description**: Pinch-to-zoom and pan gestures are not natively integrated into the viewer stage for mobile, tablet, or trackpad users. Additionally, there is no double-click shortcut to zoom/reset.
 *   **Proposal**: Listen for touch/pointer events to calculate zoom pinch scales, and map double-clicks to reset the stage's viewport zoom and pan state to 100%.

--- a/VISUAL_AUDIT_REPORT.md
+++ b/VISUAL_AUDIT_REPORT.md
@@ -1,0 +1,97 @@
+# Visual Audit & Critique Report: Local Report Viewer
+
+This report presents a comprehensive critique of the updated local report viewer UI based on the visual layout, user feedback, and code inspection.
+
+---
+
+## Evaluation Summary
+
+All dimension scores are compressed toward the center (3 to 7) to keep evaluations balanced.
+
+| Dimension | Score (1-10) | Key Finding |
+| :--- | :---: | :--- |
+| **Thematic Consistency** | 4 / 10 | The native select dropdown options revert to standard browser light-mode colors, breaking contrast. |
+| **Text Clutter & Redundancy** | 3 / 10 | Labels display duplicate category text (e.g., `Motion • Motion`) and include verbose timestamp strings. |
+| **Layout & Collisions** | 3 / 10 | The top-left HTML clip label (`.rv-overlay-label`) overlaps directly with the baked-in frame metadata in all modes (Slider, Overlay, Blink). |
+| **Typography & Hierarchy** | 6 / 10 | System font fallbacks are used, leading to a basic default look. |
+| **Interactive Polish** | 5 / 10 | Form elements rely on basic browser controls, and bottom filters lack visual cues. |
+| **Cross-Browser Consistency** | 5 / 10 | The range slider thumb lacks Firefox-specific styling, and Chrome-native number input arrows clutter the popover. |
+| **Viewport rendering** | 6 / 10 | Zooming in on frames uses default bilinear scaling, introducing blur. |
+| **Diff Mode Usability** | 3 / 10 | Clicking the stage in Diff mode makes the screen pure black, and bright white labels distract from dark diff detail inspections. |
+
+---
+
+## Detailed Audit Findings
+
+### 1. Dropdown Options Theme Mismatch
+*   **Location**: `.rv-controls select` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
+*   **Description**: Option text color inherits `--text-primary` (almost white) but the dropdown popover background defaults to native light colors on some OSes/browsers. This renders text white-on-white.
+*   **Recommendation**: Add `color-scheme: dark` to `:root` and explicitly style `select option` to use dark backgrounds.
+
+### 2. Redundant Category Labels
+*   **Location**: `.rv-filmstrip-label` / [renderer.py](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/renderer.py) & [display.py](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/display.py)
+*   **Description**: If a frame belongs to the "Motion" category, the text label renders as `Motion • Motion`. Similarly, the bottom info bar displays both the label and category as duplicate strings (`Motion • MOTION`).
+*   **Recommendation**: Change the default frame label to use the frame number (e.g., `Frame 3127`) instead of the category name, producing clean groupings (e.g., `Frame 3127 • Motion`).
+
+### 3. Cluttered Timecode/Timestamp Strings
+*   **Location**: `frame_detail_for_source_frame` / [display.py](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/display.py)
+*   **Description**: Frame details display a detailed timecode string (`00:02:10.422`) inside parentheses. This clutters the UI and is less intuitive for comparisons than standard frame numbers.
+*   **Recommendation**: Remove the timestamp details from the default frame display text, letting frame numbers serve as the primary navigator.
+
+### 4. HTML Clip Label Overlay & Baked-in Metadata Collision (All Modes)
+*   **Location**: `.rv-overlay-label` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
+*   **Description**: The absolute-positioned left HTML label `.rv-overlay-label` (displaying e.g. "Reference") is positioned at `top: 12px; left: 12px;`. This overlaps directly with the baked-in VapourSynth frame metadata text block (e.g., `Frame 11 of 16`). This collision occurs in Slider mode, Overlay mode, and Blink mode.
+*   **Recommendation**:
+    - Move `.rv-overlay-label` (left) to the bottom-left (`bottom: 16px; left: 16px; top: auto;`) and `.rv-overlay-label.right` to the bottom-right (`bottom: 16px; right: 16px; top: auto; left: auto;`).
+    - Recenter the stage info badge (`.rv-stage-overlay-info`) to the bottom-middle (`bottom: 16px; left: 50%; transform: translateX(-50%);`) to avoid collision and balance the UI symmetry.
+
+### 5. Diff Mode Stage Click Bug (Black Screen)
+*   **Location**: `cycleClip` & `pointerInteraction` / [viewer.js](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.js)
+*   **Description**: In `diff` mode, clicking on the image stage cycles the active compare clip. If there are only 2 clips, the right (compare) clip cycles to match the left (base) clip (e.g., `Reference` vs `Reference`). This renders a completely black difference screen, confusing the user.
+*   **Recommendation**: Modify `cycleClip()` for split modes (`diff` and `blink`) to skip `leftClipIdx` during the cycle loop, ensuring Left and Right comparison clips are never identical.
+
+### 6. Firefox Range Slider Thumb Styling
+*   **Location**: `#zoom-range` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
+*   **Description**: Custom range slider styling is defined only for `-webkit-slider-thumb`. On Firefox, the zoom range slider thumb defaults to an unstyled grey box.
+*   **Recommendation**: Add duplicate rules targeting `::-moz-range-thumb` to ensure cross-browser styling parity.
+
+### 7. Native Number Input Spin Buttons
+*   **Location**: `.rv-number-input` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
+*   **Description**: Browser-native increment/decrement arrows on number inputs clutter the compact manual offset fields in the alignment popover.
+*   **Recommendation**: Add CSS rules to suppress `-webkit-outer-spin-button` and `-webkit-inner-spin-button`, setting `-moz-appearance: textfield` to clean up the fields.
+
+### 8. Browser-Native Form Controls
+*   **Location**: `.rv-controls select` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
+*   **Description**: Select controls use default browser dropdown arrows, which look clunky and differ across platforms.
+*   **Recommendation**: Suppress default styling using `appearance: none` and use a clean inline vector chevron SVG as a background image.
+
+### 9. Category Filter Visual Accents
+*   **Location**: `.rv-filter-chip` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
+*   **Description**: Bottom filter chips are simple buttons that do not share the color-coded accent identifiers used by filmstrip cards.
+*   **Recommendation**: Prepend a small CSS pseudo-element (`::before`) dot styled with the respective category color code.
+
+### 10. Standard Font Fallbacks
+*   **Location**: `:root { --font-sans }` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
+*   **Description**: Using system default sans-serif fonts gives the UI a generic look.
+*   **Recommendation**: Integrate a modern Google Font like `Inter` to clean up the metadata list and titles.
+
+### 11. Zoom Interpolation Blur
+*   **Location**: `.rv-image` / [viewer.css](file:///c:/Software/video/frame-compare/src/frame_compare/services/report/assets/viewer.css)
+*   **Description**: Zooming in on frames uses default bilinear filtering, which blurs individual pixel boundaries.
+*   **Recommendation**: Set `image-rendering: pixelated` when zoom levels increase to allow detailed pixel comparisons.
+
+---
+
+## Workflow Feature Suggestions
+
+### A. Quick-Swap Clips Button & Shortcut
+*   **Description**: There is currently no quick way to swap the left and right clips (`L` and `R` streams) to inspect subtle difference changes. Swapping them requires opening two separate dropdown selects.
+*   **Proposal**: Add a swap button `⇄` in the controls bar between the Left and Right select elements, and bind the `X` key to toggle/swap the clip selection indices.
+
+### B. Toggle Overlays Visibility (Hide UI overlays)
+*   **Description**: In Diff mode, bright white HTML overlay text boxes distract from inspecting dark differences in the corners.
+*   **Proposal**: Bind the `H` key to toggle the visibility of all HTML overlays (labels and stage info badge) on and off, allowing a clean, distraction-free view of the differences.
+
+### C. Touch & Gesture Support
+*   **Description**: Pinch-to-zoom and pan gestures are not natively integrated into the viewer stage for mobile, tablet, or trackpad users. Additionally, there is no double-click shortcut to zoom/reset.
+*   **Proposal**: Listen for touch/pointer events to calculate zoom pinch scales, and map double-clicks to reset the stage's viewport zoom and pan state to 100%.

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -209,7 +209,8 @@ report-confirmed workflow before post-upload URL actions are considered.
 
 `frame_compare.services.report` owns the static offline report payload and viewer
 assets. The generated viewer exposes slider, overlay, diff, and pair-based blink
-modes; frame/category navigation; progressive report, clip, and frame metadata;
+modes; frame/category navigation; an info modal for report and clip metadata plus
+current-frame metadata in the stage overlay;
 browser-local view mode, clip selection, viewport/zoom, reveal, and alignment state
 scoped by report identity; viewport pan, zoom, and fit controls; and adjacent-frame
 preloading. It does not own slow.pics upload policy, prompting, or browser side

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -26,7 +26,7 @@ The main run path is:
 5. Create a fresh run folder when configured.
 6. Load or compute clip probe data.
 7. Execute orchestration phases in order:
-   `frame_plan -> analyze -> align -> render -> metadata -> dovi -> publish -> report`
+   `frame_plan -> analyze -> align -> render -> metadata -> dovi -> publish -> report -> post_report_cleanup`
 
 `frame_compare.orchestration.context.RunContext` carries the shared run state across phases.
 Phase task functions return explicit phase-output DTOs, and `execution.py` applies those
@@ -131,6 +131,18 @@ Keep these integrations at their current owners:
 - HTML report generation: `frame_compare.services.report`
 - VS loading and HDR/tonemap logic: `frame_compare.vs.*`
 - packaging/install/update flow: `tools/windows_portable/**`
+
+slow.pics publishing is service-owned. `frame_compare.services.publishers` owns
+the browser-compatible slow.pics client flow: `GET /comparison`,
+`POST /upload/comparison`, and planned `POST /upload/image/{imageUuid}` image
+requests. `frame_compare.services.slowpics_upload_plan` owns the explicit
+upload-plan seam for current render artifacts, row/image names, and upload
+ordering; the final upload path uses that plan and does not scan the screenshot
+directory for membership. After a successful upload, orchestration carries the
+exact uploaded planned local file paths into `post_report_cleanup`. That cleanup
+phase owns report-safe local deletion policy for `slowpics.delete_after_upload`
+and never reconstructs deletion membership from directories, labels, or render
+artifacts after upload.
 
 `frame_compare.services.report` owns the static offline report payload and viewer
 assets. The generated viewer exposes slider, overlay, diff, and pair-based blink

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -136,6 +136,8 @@ Keep these integrations at their current owners:
   `frame_compare.services.tmdb_resolution` owns resolver policy and
   `frame_compare.services.tmdb_lookup` owns low-level TMDB HTTP and response mapping
 - publishing: `frame_compare.services.publishers`
+- slow.pics post-upload shortcut/webhook policy and action aggregation:
+  `frame_compare.services.slowpics_post_upload`
 - browser auto-open for generated reports, slow.pics browser opening, clipboard
   copy, report-confirmed upload prompting, and report/slow.pics browser
   precedence rules:
@@ -155,12 +157,13 @@ upload-plan seam for current render artifacts, row/image names, and upload
 ordering; the final upload path uses that plan and does not scan the screenshot
 directory for membership. After a successful upload, orchestration carries the
 exact uploaded planned local file paths into `post_report_cleanup` and carries
-typed post-upload action results plus warnings from shortcut and webhook owners
-into the final `RunResult`. Orchestration does not own clipboard, browser,
-shortcut, or webhook side-effect policy. That cleanup phase owns report-safe
-local deletion policy for `slowpics.delete_after_upload` and never reconstructs
-deletion membership from directories, labels, render artifacts, or shortcut
-outputs after upload. The `.url` shortcut is not cleanup membership.
+typed post-upload action results plus warnings returned by
+`frame_compare.services.slowpics_post_upload` into the final `RunResult`.
+Orchestration does not own clipboard, browser, shortcut, or webhook side-effect
+policy. That cleanup phase owns report-safe local deletion policy for
+`slowpics.delete_after_upload` and never reconstructs deletion membership from
+directories, labels, render artifacts, or shortcut outputs after upload. The
+`.url` shortcut is not cleanup membership.
 
 Report-confirmed slow.pics upload uses a CLI-owned confirmation callback seam
 carried on `RunDependencies.confirm_slowpics_upload`. Orchestration owns the

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -28,6 +28,12 @@ The main run path is:
 7. Execute orchestration phases in order:
    `frame_plan -> analyze -> align -> render -> metadata -> dovi -> publish -> report -> post_report_cleanup`
 
+When effective config enables both `slowpics.auto_upload` and
+`slowpics.confirm_upload_after_report`, the opted-in interactive path changes
+only the post-render ordering:
+`frame_plan -> analyze -> align -> render -> metadata -> dovi -> report -> confirm_slowpics_upload -> publish -> post_report_cleanup`.
+The non-confirmed flow keeps the normal ordering above.
+
 `frame_compare.orchestration.context.RunContext` carries the shared run state across phases.
 Phase task functions return explicit phase-output DTOs, and `execution.py` applies those
 outputs back to `ExecutionState`, `RunContext`, or collected artifacts at phase boundaries.
@@ -131,7 +137,8 @@ Keep these integrations at their current owners:
   `frame_compare.services.tmdb_lookup` owns low-level TMDB HTTP and response mapping
 - publishing: `frame_compare.services.publishers`
 - browser auto-open for generated reports, slow.pics browser opening, clipboard
-  copy, and report-open precedence after interactive slow.pics URL opening:
+  copy, report-confirmed upload prompting, and report/slow.pics browser
+  precedence rules:
   `frame_compare.cli.entry`
 - slow.pics URL shortcut creation: `frame_compare.services.slowpics_shortcut`
 - isolated slow.pics post-upload webhook delivery:
@@ -155,6 +162,25 @@ local deletion policy for `slowpics.delete_after_upload` and never reconstructs
 deletion membership from directories, labels, render artifacts, or shortcut
 outputs after upload. The `.url` shortcut is not cleanup membership.
 
+Report-confirmed slow.pics upload uses a CLI-owned confirmation callback seam
+carried on `RunDependencies.confirm_slowpics_upload`. Orchestration owns the
+typed request, decision, confirmation-status state, phase ordering, and upload
+skip decisions; it does not import Typer, open browsers, read stdin, or print
+prompt text. If a report-confirmed runtime path reaches orchestration without
+the callback, orchestration raises a typed config error before publish rather
+than silently uploading. When report generation warns, fails, or produces no
+report path, `confirm_slowpics_upload` records `report_unavailable`, emits the
+skip warning, and prevents slow.pics upload. When the user declines through the
+CLI callback, `publish` is skipped and `slowpics_url` stays `None`.
+
+In the report-confirmed workflow, the local report is generated before upload
+and is not regenerated after upload. The report payload therefore has no
+slow.pics URL even if the later upload succeeds; the CLI summary is the owner
+for presenting the uploaded URL. CLI report presentation happens before the
+confirmation prompt and before any later post-upload slow.pics browser opening.
+The existing non-confirmed rule remains: an attempted slow.pics browser open
+suppresses generated-report auto-open for that run.
+
 `frame_compare.services.slowpics_shortcut` owns deterministic `.url` output for
 successful slow.pics uploads. It selects the current run folder when present, or
 the safe common parent of the resolved screenshots/generated directories when
@@ -175,13 +201,16 @@ Webhook failures are warning-only and redact configured URL details.
 slow.pics URL copy/browser actions and the precedence rule between slow.pics
 browser opening and generated-report auto-open. Those actions run only for
 human, non-quiet, TTY stdout runs; JSON stdout stays a single object.
+The same CLI owner presents the local report and asks for confirmation in the
+report-confirmed workflow before post-upload URL actions are considered.
 
 `frame_compare.services.report` owns the static offline report payload and viewer
 assets. The generated viewer exposes slider, overlay, diff, and pair-based blink
 modes; frame/category navigation; progressive report, clip, and frame metadata;
 browser-local view mode, clip selection, viewport/zoom, reveal, and alignment state
 scoped by report identity; viewport pan, zoom, and fit controls; and adjacent-frame
-preloading.
+preloading. It does not own slow.pics upload policy, prompting, or browser side
+effects.
 
 Screenshot rendering owns its geometry and writer policy inside `frame_compare.render`:
 `frame_compare.render.geometry` plans optional aligned crop/scale/pad geometry, render

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -117,7 +117,10 @@ External runtime boundaries:
 - VapourSynth runtime and plugins
 - TMDB HTTP API
 - slow.pics HTTP API
+- outbound slow.pics post-upload webhooks
 - default browser auto-open for generated reports
+- default browser open for slow.pics URLs in interactive CLI runs
+- clipboard integration for slow.pics URLs in interactive CLI runs
 - Docker build/test runtime
 - Windows PowerShell installer and updater scripts
 
@@ -127,7 +130,12 @@ Keep these integrations at their current owners:
   `frame_compare.services.tmdb_resolution` owns resolver policy and
   `frame_compare.services.tmdb_lookup` owns low-level TMDB HTTP and response mapping
 - publishing: `frame_compare.services.publishers`
-- browser auto-open for generated reports: `frame_compare.cli.entry`
+- browser auto-open for generated reports, slow.pics browser opening, clipboard
+  copy, and report-open precedence after interactive slow.pics URL opening:
+  `frame_compare.cli.entry`
+- slow.pics URL shortcut creation: `frame_compare.services.slowpics_shortcut`
+- isolated slow.pics post-upload webhook delivery:
+  `frame_compare.services.slowpics_webhook`
 - HTML report generation: `frame_compare.services.report`
 - VS loading and HDR/tonemap logic: `frame_compare.vs.*`
 - packaging/install/update flow: `tools/windows_portable/**`
@@ -139,10 +147,34 @@ requests. `frame_compare.services.slowpics_upload_plan` owns the explicit
 upload-plan seam for current render artifacts, row/image names, and upload
 ordering; the final upload path uses that plan and does not scan the screenshot
 directory for membership. After a successful upload, orchestration carries the
-exact uploaded planned local file paths into `post_report_cleanup`. That cleanup
-phase owns report-safe local deletion policy for `slowpics.delete_after_upload`
-and never reconstructs deletion membership from directories, labels, or render
-artifacts after upload.
+exact uploaded planned local file paths into `post_report_cleanup` and carries
+typed post-upload action results plus warnings from shortcut and webhook owners
+into the final `RunResult`. Orchestration does not own clipboard, browser,
+shortcut, or webhook side-effect policy. That cleanup phase owns report-safe
+local deletion policy for `slowpics.delete_after_upload` and never reconstructs
+deletion membership from directories, labels, render artifacts, or shortcut
+outputs after upload. The `.url` shortcut is not cleanup membership.
+
+`frame_compare.services.slowpics_shortcut` owns deterministic `.url` output for
+successful slow.pics uploads. It selects the current run folder when present, or
+the safe common parent of the resolved screenshots/generated directories when
+run folders are disabled. The service rejects unsafe parent choices outside the
+workspace root, filesystem anchors, drive/share roots, and the user home
+directory; filename selection is deterministic and repeated writes overwrite the
+same path.
+
+`frame_compare.services.slowpics_webhook` owns isolated outbound webhook
+delivery for successful slow.pics uploads. It validates strict external HTTPS
+targets, rejects disallowed IP literals and DNS answers, connects to a
+prevalidated pinned address while preserving TLS verification for the original
+hostname, sends the JSON `content` payload without redirects, and does not reuse
+slow.pics client cookies, headers, proxy/environment trust, or transport state.
+Webhook failures are warning-only and redact configured URL details.
+
+`frame_compare.cli.entry` and its run-command helper own interactive-only
+slow.pics URL copy/browser actions and the precedence rule between slow.pics
+browser opening and generated-report auto-open. Those actions run only for
+human, non-quiet, TTY stdout runs; JSON stdout stays a single object.
 
 `frame_compare.services.report` owns the static offline report payload and viewer
 assets. The generated viewer exposes slider, overlay, diff, and pair-based blink

--- a/docs/current-cli-contract.md
+++ b/docs/current-cli-contract.md
@@ -22,6 +22,8 @@ documents that promise elsewhere.
     gating, and command-level CLI behavior.
   - `tests/cli/test_run_slowpics_options.py` for the slow.pics `run` option
     surface.
+  - `tests/cli/test_run_output.py` for human output, JSON stdout cleanliness,
+    and slow.pics post-upload presentation behavior.
   - `tests/config/test_schema.py` for config schema/defaults, including the
     exact slow.pics field set.
   - `tests/config/test_overrides.py` for CLI override mapping semantics.
@@ -38,6 +40,7 @@ Update this document in the same pass when changing:
 - CLI flag to config mapping or persistence rules
 - JSON output schema for `run --json` or `doctor --json`
 - browser/report-opening rules
+- slow.pics post-upload side-effect behavior or warning placement
 
 ## Command Surface
 
@@ -128,6 +131,8 @@ exists.
 
 - HTML report generation is owned by `frame_compare.services.report`.
 - Browser auto-open for a generated report is owned by `frame_compare.cli.entry`.
+- Clipboard copy and slow.pics browser opening are also CLI-owned interactive
+  post-run actions.
 - The CLI only attempts to open a report when all of these are true:
   - the run succeeded and produced `report_path`
   - `--json` was not used
@@ -138,6 +143,10 @@ exists.
 
 There is currently no dedicated `run` flag for `report.auto_open`; it is a config-only
 surface.
+
+If an enabled slow.pics browser open is attempted for the same successful run,
+report auto-open is suppressed for that run. If slow.pics browser open is not
+attempted, the existing report auto-open rules above still apply.
 
 ### slow.pics Upload Behavior
 
@@ -168,13 +177,63 @@ surface.
 - Local uploaded-file deletion errors do not fail an otherwise successful run.
   They are surfaced as run warnings and logs. In `run --json`, warnings remain
   off stdout so the stdout payload stays a single JSON object.
-- The current runtime upload behavior does not execute post-upload side effects
-  for copying the URL, opening slow.pics, creating a shortcut, or posting a
-  webhook. The matching `[slowpics]` fields are currently parsed config surface
-  only; they do not add `run --json` fields or human output.
+- After a successful slow.pics upload, enabled post-upload actions run according
+  to their owners:
+  - `copy_url_to_clipboard` copies the slow.pics URL through the CLI only when
+    `--json` was not used, `--quiet` was not used, and stdout is attached to a
+    TTY.
+  - `open_in_browser` opens the slow.pics URL through the CLI under the same
+    interactive-only conditions as clipboard copy.
+  - `create_url_shortcut` writes a deterministic `.url` shortcut after upload
+    whenever configured, including `--json` and `--quiet` runs.
+  - `webhook_url` posts the slow.pics URL to the configured webhook after upload
+    whenever configured, including `--json` and `--quiet` runs.
+- Post-upload side-effect failures do not fail an otherwise successful run.
+  They are warning-only. In `run --json`, warnings remain off stdout and no
+  post-upload action fields are added to the JSON payload.
+- Human output shows enabled successful post-upload action outcomes and warnings.
+  Disabled or skipped post-upload actions are not listed by default.
 - The current public upload surface does not include collection suffix/name,
   image format or optimization toggles, tags, hentai flag, or remote
   remove-after behavior.
+
+### slow.pics Shortcut Policy
+
+- Shortcut creation is owned by `frame_compare.services.slowpics_shortcut`.
+- The shortcut is a Windows InternetShortcut-compatible `.url` file containing
+  the uploaded slow.pics comparison URL.
+- The shortcut output directory is deterministic:
+  - the current run folder when run folders are enabled
+  - otherwise the safe common parent of the resolved screenshots and generated
+    output directories
+- Without a run folder, the common parent must be under the resolved workspace
+  root and must not be a drive root, filesystem anchor, UNC/share root, or the
+  user home directory. Paths on different drives or anchors have no safe common
+  parent.
+- The filename is derived from current run metadata or upload title, with a
+  stable fallback from the slow.pics URL key.
+- Repeated writes overwrite the same deterministic shortcut path.
+- Shortcut files are not members of `slowpics.delete_after_upload` cleanup.
+- Shortcut write or path-selection failures are warning-only.
+
+### slow.pics Webhook Policy
+
+- Webhook delivery is owned by `frame_compare.services.slowpics_webhook`.
+- The payload is exactly `{"content":"<slowpics_url>"}` serialized as JSON.
+- The configured webhook URL must be a strict external HTTPS endpoint:
+  non-HTTPS URLs, localhost names, loopback, private, link-local, multicast,
+  reserved, unspecified, and otherwise non-public IP targets are rejected.
+- Hostname targets are rejected when DNS resolution fails, returns no addresses,
+  includes an unparseable address, or includes any disallowed address.
+- Delivery prevents validation-to-connect DNS rebinding by connecting to a
+  prevalidated pinned IP address while preserving TLS certificate verification
+  and SNI for the original hostname.
+- Delivery uses no redirects, a fixed 10 second timeout, and 3 attempts.
+- The webhook request path is isolated from the slow.pics upload client: it does
+  not reuse slow.pics cookies, headers, client state, redirect policy, proxy
+  settings, or environment trust.
+- Webhook URL details are redacted from warnings and logs.
+- Delivery failures are warning-only and do not write to JSON stdout.
 
 ## CLI Flag To Config Mapping
 
@@ -219,9 +278,17 @@ non-embedded reports and for warn-only report failures. It does not request
 slow.pics remote removal and does not map to remote `removeAfter`.
 
 `copy_url_to_clipboard`, `open_in_browser`, `create_url_shortcut`, and
-`webhook_url` are approved config fields for slow.pics legacy UX parity. In the
-current implementation slice, they are parsed and defaulted only. They do not add
-new `run` flags, wizard prompts, stdout fields, or post-upload side effects.
+`webhook_url` are implemented config fields for slow.pics legacy UX parity. They
+do not add new `run` flags, wizard prompts, or `run --json` stdout fields.
+
+`copy_url_to_clipboard` and `open_in_browser` are interactive CLI-owned actions:
+they run only after a successful upload in human non-quiet TTY runs. Clipboard
+and slow.pics browser failures are warning-only. If slow.pics browser opening is
+attempted, generated-report auto-open is suppressed for that run.
+
+`create_url_shortcut` and `webhook_url` run after successful upload whenever
+configured, including `--json` and `--quiet`. Their warning-only failures remain
+off JSON stdout and do not fail the run.
 
 There are no current slow.pics config fields for collection suffix/name, image
 format or optimization toggles, tags, hentai flag, or remote remove-after

--- a/docs/current-cli-contract.md
+++ b/docs/current-cli-contract.md
@@ -20,6 +20,10 @@ documents that promise elsewhere.
 - Primary executable contract checks include:
   - `tests/cli/test_cli_commands.py` for help text, JSON payloads, report auto-open
     gating, and command-level CLI behavior.
+  - `tests/cli/test_run_slowpics_options.py` for the slow.pics `run` option
+    surface.
+  - `tests/config/test_schema.py` for config schema/defaults, including the
+    exact slow.pics field set.
   - `tests/config/test_overrides.py` for CLI override mapping semantics.
   - `tests/e2e/test_cli_version.py` for the public `version` command contract.
   - `tests/cli/test_exit_codes.py` for exit-code behavior.
@@ -80,6 +84,8 @@ exists.
 ### Output Modes
 
 - `--json` writes a single JSON object to stdout and suppresses human-readable summaries.
+- In that JSON object, `slowpics_url` is the only machine-readable slow.pics
+  result field. No copy/open/shortcut/webhook result fields are emitted.
 - `--json` is incompatible with interactive alignment. If the effective config enables
   `audio_alignment.use_vspreview` or `audio_alignment.force_interactive`, the CLI exits
   with the standard config-error payload and exit code before entering the runtime
@@ -133,6 +139,39 @@ exists.
 There is currently no dedicated `run` flag for `report.auto_open`; it is a config-only
 surface.
 
+### slow.pics Upload Behavior
+
+- slow.pics publishing is disabled by default. Users must set
+  `slowpics.auto_upload = true` in config or through the wizard before `run`
+  uploads generated screenshots.
+- When enabled and not suppressed by `--no-upload`, the current upload path uses
+  the browser-compatible slow.pics flow owned by
+  `frame_compare.services.publishers`: fetch `/comparison`, create metadata at
+  `/upload/comparison`, then upload each planned image to
+  `/upload/image/{imageUuid}`.
+- Upload membership comes from the explicit current-render upload plan, not from
+  scanning the screenshot directory. The plan is built from selected frames,
+  current render artifacts, and clip order.
+- `delete_after_upload` is local-only and report-safe. It is not mapped to
+  slow.pics `removeAfter`; the current remote metadata request sends an empty
+  `removeAfter` value.
+- When `delete_after_upload = true`, Frame Compare deletes only the exact
+  planned local screenshot files that were successfully uploaded. Deletion runs
+  after the report phase, not inside the slow.pics publisher, and never scans the
+  screenshot directory for deletion membership.
+- Local uploaded-file deletion runs only when the slow.pics upload completed and
+  report handling is safe: reports are disabled, or report generation completed
+  with `report.embed_images = true`. When reports are enabled with
+  `report.embed_images = false`, deletion is skipped because the report
+  references screenshot files on disk. If report generation warns/fails,
+  deletion is skipped.
+- Local uploaded-file deletion errors do not fail an otherwise successful run.
+  They are surfaced as run warnings and logs. In `run --json`, warnings remain
+  off stdout so the stdout payload stays a single JSON object.
+- The current public upload surface does not include collection suffix/name,
+  image format or optimization toggles, tags, hentai flag, remote remove-after,
+  copy URL, open slow.pics after upload, shortcut creation, or webhook behavior.
+
 ## CLI Flag To Config Mapping
 
 These `run` flags currently map into config values through `CLI_OVERRIDE_MAP`:
@@ -146,11 +185,34 @@ These `run` flags currently map into config values through `CLI_OVERRIDE_MAP`:
 | `--frame-count` | `analysis.frame_count` | Frame-selection override. |
 | `--seed` | `analysis.random_seed` | Deterministic frame-selection seed override. |
 | `--overlay` | `screenshots.overlay_mode` | Overlay mode override. |
-| `--no-upload` | `slowpics.auto_upload` | Inverted flag: passing it persists `auto_upload = false`. |
+| `--no-upload` | `slowpics.auto_upload` | Inverted flag: passing it sets effective `auto_upload = false`, and persists that value when combined with `--write-config`. |
 | `--force-interactive-alignment` | `audio_alignment.force_interactive` | Also forces `audio_alignment.use_vspreview = true`. |
 
-slow.pics publishing is disabled by default. Users must set `slowpics.auto_upload = true`
-in config or through the wizard before `run` uploads generated screenshots.
+`--no-upload` is the only slow.pics-specific `run` flag. No runtime-only
+slow.pics `run` flags exist.
+
+## Config-Only slow.pics Surface
+
+These five fields are the full current public `[slowpics]` config surface:
+
+- `auto_upload = false`
+- `visibility = "unlisted"`
+- `delete_after_upload = false`
+- `timeout_seconds = 60.0`
+- `max_retries = 3`
+
+`visibility` accepts only `public` and `unlisted`.
+
+`delete_after_upload` is local-only and report-safe: it removes only the exact
+planned local screenshot files that were successfully uploaded, and only after
+report processing is complete. Deletion is allowed when reports are disabled or
+when an embedded-image report is generated successfully. Deletion is skipped for
+non-embedded reports and for warn-only report failures. It does not request
+slow.pics remote removal and does not map to remote `removeAfter`.
+
+There are no current slow.pics config fields for collection suffix/name, image
+format or optimization toggles, tags, hentai flag, remote remove-after, copy URL,
+open-after-upload, shortcut creation, or webhook behavior.
 
 ## Config-Only Screenshot Surface
 

--- a/docs/current-cli-contract.md
+++ b/docs/current-cli-contract.md
@@ -89,11 +89,21 @@ exists.
 - `--json` writes a single JSON object to stdout and suppresses human-readable summaries.
 - In that JSON object, `slowpics_url` is the only machine-readable slow.pics
   result field. No copy/open/shortcut/webhook result fields are emitted.
+  Report-confirmed upload confirmation status is also not emitted; the success
+  schema remains unchanged and `slowpics_url` remains the only machine-readable
+  slow.pics result field.
 - `--json` is incompatible with interactive alignment. If the effective config enables
   `audio_alignment.use_vspreview` or `audio_alignment.force_interactive`, the CLI exits
   with the standard config-error payload and exit code before entering the runtime
   pipeline.
+- `--json` is incompatible with report-confirmed slow.pics upload when that
+  prompt would be needed. If effective config has `slowpics.auto_upload = true`
+  and `slowpics.confirm_upload_after_report = true`, the CLI rejects `--json`
+  before entering the runtime pipeline with the standard config-error JSON
+  payload on stdout.
 - `--quiet` suppresses the at-a-glance summary but still allows a minimal success summary.
+- `--quiet` is incompatible with report-confirmed slow.pics upload when that
+  prompt would be needed.
 - When the at-a-glance summary reports optional VSPreview probe failures, it uses a
   sanitized summary rather than raw probe exception text.
 - The at-a-glance workspace paths are resolved base paths. When
@@ -130,7 +140,8 @@ exists.
 ### Report Auto-Open Ownership
 
 - HTML report generation is owned by `frame_compare.services.report`.
-- Browser auto-open for a generated report is owned by `frame_compare.cli.entry`.
+- Browser auto-open and report-path presentation for a generated report are
+  owned by `frame_compare.cli.entry` and its run-command helper.
 - Clipboard copy and slow.pics browser opening are also CLI-owned interactive
   post-run actions.
 - The CLI only attempts to open a report when all of these are true:
@@ -148,11 +159,23 @@ If an enabled slow.pics browser open is attempted for the same successful run,
 report auto-open is suppressed for that run. If slow.pics browser open is not
 attempted, the existing report auto-open rules above still apply.
 
+Report-confirmed slow.pics upload is the exception to that precedence rule. In
+that opted-in workflow, the CLI presents the local report before prompting for
+upload, regardless of whether a later confirmed upload will open the slow.pics
+URL in a browser. The same report auto-open rules decide whether the report is
+opened. If it is not opened, the CLI prints the report path before prompting.
+
 ### slow.pics Upload Behavior
 
 - slow.pics publishing is disabled by default. Users must set
   `slowpics.auto_upload = true` in config or through the wizard before `run`
   uploads generated screenshots.
+- Users may additionally opt into report-confirmed upload with the config-only
+  field `slowpics.confirm_upload_after_report = true`. The field is inert unless
+  effective `slowpics.auto_upload = true`.
+- There is no dedicated `run` flag for report-confirmed upload. `--no-upload`
+  remains the only slow.pics-specific `run` flag and still forces effective
+  `slowpics.auto_upload = false`.
 - When enabled and not suppressed by `--no-upload`, the current upload path uses
   the browser-compatible slow.pics flow owned by
   `frame_compare.services.publishers`: fetch `/comparison`, create metadata at
@@ -161,6 +184,26 @@ attempted, the existing report auto-open rules above still apply.
 - Upload membership comes from the explicit current-render upload plan, not from
   scanning the screenshot directory. The plan is built from selected frames,
   current render artifacts, and clip order.
+- The normal non-confirmed phase order remains:
+  `frame_plan -> analyze -> align -> render -> metadata -> dovi -> publish -> report -> post_report_cleanup`.
+- Report-confirmed upload changes only the opted-in interactive path:
+  `frame_plan -> analyze -> align -> render -> metadata -> dovi -> report -> confirm_slowpics_upload -> publish -> post_report_cleanup`.
+- Report-confirmed upload requires an interactive report-enabled run when the
+  prompt would be needed. If effective `slowpics.auto_upload = true` and
+  `slowpics.confirm_upload_after_report = true`, the CLI rejects the run before
+  runtime when any of these are true: `--json` was passed, `--quiet` was passed,
+  stdin is not attached to a TTY, stdout is not attached to a TTY, or
+  `report.enable = false`.
+- In the report-confirmed workflow, the report is generated before upload and is
+  not regenerated after upload. The generated report payload has
+  `slowpics_url = null`; after a confirmed upload, the CLI summary remains the
+  place where the uploaded slow.pics URL is shown.
+- If the report phase warns, fails, or produces no `report_path`, confirmation
+  does not prompt and slow.pics upload is skipped with the deterministic warning
+  `slow.pics upload skipped because report confirmation was unavailable`.
+- If the user declines the prompt, the run still succeeds, no slow.pics upload
+  side effects run, human output includes `slow.pics upload skipped by
+  confirmation`, and `slowpics_url` remains `None`.
 - `delete_after_upload` is local-only and report-safe. It is not mapped to
   slow.pics `removeAfter`; the current remote metadata request sends an empty
   `removeAfter` value.
@@ -174,6 +217,12 @@ attempted, the existing report auto-open rules above still apply.
   `report.embed_images = false`, deletion is skipped because the report
   references screenshot files on disk. If report generation warns/fails,
   deletion is skipped.
+- In the report-confirmed workflow, reports are required, so delete-after-upload
+  can run only after a confirmed successful upload when the already-generated
+  report embedded images. With `report.embed_images = false`, deletion is
+  skipped because the report references local screenshot files. If upload is
+  declined or report confirmation is unavailable, no files are considered
+  uploaded and no slow.pics delete-after-upload cleanup runs.
 - Local uploaded-file deletion errors do not fail an otherwise successful run.
   They are surfaced as run warnings and logs. In `run --json`, warnings remain
   off stdout so the stdout payload stays a single JSON object.
@@ -193,6 +242,8 @@ attempted, the existing report auto-open rules above still apply.
   post-upload action fields are added to the JSON payload.
 - Human output shows enabled successful post-upload action outcomes and warnings.
   Disabled or skipped post-upload actions are not listed by default.
+- Confirmed report-first upload still runs the existing post-upload actions
+  after a successful upload according to their normal owners and gating.
 - The current public upload surface does not include collection suffix/name,
   image format or optimization toggles, tags, hentai flag, or remote
   remove-after behavior.
@@ -256,9 +307,10 @@ slow.pics `run` flags exist.
 
 ## Config-Only slow.pics Surface
 
-These nine fields are the full current public `[slowpics]` config surface:
+These ten fields are the full current public `[slowpics]` config surface:
 
 - `auto_upload = false`
+- `confirm_upload_after_report = false`
 - `visibility = "unlisted"`
 - `delete_after_upload = false`
 - `timeout_seconds = 60.0`
@@ -269,6 +321,12 @@ These nine fields are the full current public `[slowpics]` config surface:
 - `webhook_url = null`
 
 `visibility` accepts only `public` and `unlisted`.
+
+`confirm_upload_after_report` is a config-only, interactive-only opt-in. It only
+has effect when effective `auto_upload = true`; it adds no `run` flag, no wizard
+prompt, and no `run --json` stdout field. When the prompt would be needed, it is
+incompatible with `--json`, `--quiet`, non-TTY stdin, non-TTY stdout, and
+`report.enable = false`.
 
 `delete_after_upload` is local-only and report-safe: it removes only the exact
 planned local screenshot files that were successfully uploaded, and only after
@@ -289,6 +347,9 @@ attempted, generated-report auto-open is suppressed for that run.
 `create_url_shortcut` and `webhook_url` run after successful upload whenever
 configured, including `--json` and `--quiet`. Their warning-only failures remain
 off JSON stdout and do not fail the run.
+
+The JSON output schema remains unchanged by report-confirmed upload:
+`slowpics_url` is still the only machine-readable slow.pics result field.
 
 There are no current slow.pics config fields for collection suffix/name, image
 format or optimization toggles, tags, hentai flag, or remote remove-after

--- a/docs/current-cli-contract.md
+++ b/docs/current-cli-contract.md
@@ -168,9 +168,13 @@ surface.
 - Local uploaded-file deletion errors do not fail an otherwise successful run.
   They are surfaced as run warnings and logs. In `run --json`, warnings remain
   off stdout so the stdout payload stays a single JSON object.
+- The current runtime upload behavior does not execute post-upload side effects
+  for copying the URL, opening slow.pics, creating a shortcut, or posting a
+  webhook. The matching `[slowpics]` fields are currently parsed config surface
+  only; they do not add `run --json` fields or human output.
 - The current public upload surface does not include collection suffix/name,
-  image format or optimization toggles, tags, hentai flag, remote remove-after,
-  copy URL, open slow.pics after upload, shortcut creation, or webhook behavior.
+  image format or optimization toggles, tags, hentai flag, or remote
+  remove-after behavior.
 
 ## CLI Flag To Config Mapping
 
@@ -193,13 +197,17 @@ slow.pics `run` flags exist.
 
 ## Config-Only slow.pics Surface
 
-These five fields are the full current public `[slowpics]` config surface:
+These nine fields are the full current public `[slowpics]` config surface:
 
 - `auto_upload = false`
 - `visibility = "unlisted"`
 - `delete_after_upload = false`
 - `timeout_seconds = 60.0`
 - `max_retries = 3`
+- `copy_url_to_clipboard = true`
+- `open_in_browser = true`
+- `create_url_shortcut = true`
+- `webhook_url = null`
 
 `visibility` accepts only `public` and `unlisted`.
 
@@ -210,9 +218,14 @@ when an embedded-image report is generated successfully. Deletion is skipped for
 non-embedded reports and for warn-only report failures. It does not request
 slow.pics remote removal and does not map to remote `removeAfter`.
 
+`copy_url_to_clipboard`, `open_in_browser`, `create_url_shortcut`, and
+`webhook_url` are approved config fields for slow.pics legacy UX parity. In the
+current implementation slice, they are parsed and defaulted only. They do not add
+new `run` flags, wizard prompts, stdout fields, or post-upload side effects.
+
 There are no current slow.pics config fields for collection suffix/name, image
-format or optimization toggles, tags, hentai flag, remote remove-after, copy URL,
-open-after-upload, shortcut creation, or webhook behavior.
+format or optimization toggles, tags, hentai flag, or remote remove-after
+behavior.
 
 ## Config-Only Screenshot Surface
 

--- a/docs/plans/2026-06-01-report-confirmed-slowpics-upload-starter-spec.md
+++ b/docs/plans/2026-06-01-report-confirmed-slowpics-upload-starter-spec.md
@@ -1,0 +1,73 @@
+Status: Historical
+Scope: Reference-only starter spec for a future report-confirmed slow.pics upload workflow
+Owner: Historical slow.pics UX planning session
+
+# Report-Confirmed slow.pics Upload Starter Spec
+
+This is not an active implementation plan. It records a future product idea that
+was raised while planning slow.pics legacy UX parity:
+
+- generate the local HTML report first
+- keep the CLI waiting when local report review and slow.pics upload are both
+  desired
+- let the user inspect the local report
+- then let the user confirm in the CLI whether the comparison should be
+  uploaded to slow.pics
+
+The active slow.pics legacy UX parity plan is
+`docs/plans/2026-06-01-slowpics-legacy-ux-parity-plan.md`. That plan must not
+implement this workflow unless it is explicitly replanned.
+
+This current workstream does not implement report UI controls, report-owned
+upload services, local services, background processes, custom protocol handlers,
+browser extensions, or any other mechanism for triggering slow.pics upload from
+the generated report.
+
+## Product Intent
+
+The intent is to avoid uploading an unwanted comparison before the user has seen
+the generated local report. This is different from simple post-upload browser
+opening: it changes the runtime order from "upload, then report/output UX" to a
+review gate where the user can decide after inspecting local artifacts.
+
+The minimum future workflow should be:
+
+1. Run renders screenshots and generates the local report.
+2. The CLI opens or prints the local report path according to the existing
+   report auto-open rules.
+3. The CLI waits for explicit user confirmation before slow.pics upload.
+4. If confirmed, the CLI uploads the already-rendered artifacts to slow.pics and
+   runs any approved post-upload UX.
+5. If declined, the run completes successfully without slow.pics upload.
+
+## Deliberate Non-Goals
+
+- Do not add report UI upload controls in the legacy UX parity workstream.
+- Do not add report-owned upload services in the legacy UX parity workstream.
+- Do not add a local web service, background process, custom protocol handler,
+  or browser extension in the legacy UX parity workstream.
+- Do not make the static HTML report responsible for reading local screenshot
+  files and uploading them after the CLI exits.
+- Do not change the current `run --json` contract without a separate plan.
+
+## Future Design Questions
+
+- Is this a config-only behavior, a runtime-only CLI flag, or both?
+- How should it interact with unattended runs, `--json`, `--quiet`, and non-TTY
+  execution?
+- Does report auto-open become mandatory for the confirmation flow, or can the
+  CLI print the path and wait?
+- What timeout or cancellation behavior should apply while the CLI waits?
+- Should decline be silent success, a warning, or a distinct output state?
+- Should confirmed upload reuse the existing slow.pics publish phase, or should
+  orchestration split report and publish ordering behind a new explicit phase
+  plan?
+- How should this interact with `slowpics.delete_after_upload` and reports that
+  reference local screenshot files?
+
+## Required Future Planning
+
+A future implementation must start with a separate active tracked plan and
+adversarial review. It should treat this as a high-risk CLI/runtime workflow
+change because it can affect phase ordering, report auto-open behavior,
+interactive prompting, JSON mode, upload timing, and cleanup semantics.

--- a/docs/plans/2026-06-01-slowpics-legacy-ux-parity-plan.md
+++ b/docs/plans/2026-06-01-slowpics-legacy-ux-parity-plan.md
@@ -51,8 +51,8 @@ RISK_TIER: high
 REVIEW_TARGET: active tracked plan
 PLAN_OR_ARTIFACT: docs/plans/2026-06-01-slowpics-legacy-ux-parity-plan.md
 REFERENCE_HANDOFF: docs/plans/2026-06-01-slowpics-legacy-ux-followup-handoff.md
-FILES_IN_SCOPE: src/frame_compare/config/schema_models.py; src/frame_compare/config/defaults.py; src/frame_compare/config/schema.py; src/frame_compare/cli/entry.py; src/frame_compare/cli/run_command.py; src/frame_compare/cli/output.py; src/frame_compare/orchestration/types.py; src/frame_compare/orchestration/execution.py; src/frame_compare/orchestration/phase_tasks.py; src/frame_compare/services/publishers.py or focused sibling service modules; pyproject.toml; uv.lock; tests/config/test_schema.py; tests/cli/test_run_slowpics_options.py; tests/cli/test_run_command.py; tests/cli/test_run_output.py; tests/cli/test_run_report_open.py; tests/services/test_publishers.py or focused sibling service tests; tests/orchestration/test_phase_tasks_outputs.py; tests/test_cli_contract_docs.py; docs/current-cli-contract.md; docs/current-architecture.md
-FILES_OUT_OF_SCOPE: src/frame_compare/render/**; src/frame_compare/vs/**; src/frame_compare/analysis/**; tools/windows_portable/**; Dockerfile; docker-compose.yml; live mutating slow.pics tests; generated HTML report upload controls except the reference-only starter spec named in Unit 8
+FILES_IN_SCOPE: src/frame_compare/config/schema_models.py; src/frame_compare/config/defaults.py; src/frame_compare/config/schema.py; src/frame_compare/cli/entry.py; src/frame_compare/cli/run_command.py; src/frame_compare/cli/output.py; src/frame_compare/orchestration/types.py; src/frame_compare/orchestration/execution.py; src/frame_compare/orchestration/coordinator.py; src/frame_compare/orchestration/phase_tasks.py; src/frame_compare/services/publishers.py or focused sibling service modules; pyproject.toml; uv.lock; tests/config/test_schema.py; tests/cli/test_run_slowpics_options.py; tests/cli/test_run_command.py; tests/cli/test_run_output.py; tests/cli/test_run_report_open.py; tests/services/test_publishers.py or focused sibling service tests; tests/orchestration/test_phase_tasks_outputs.py; tests/test_cli_contract_docs.py; docs/current-cli-contract.md; docs/current-architecture.md
+FILES_OUT_OF_SCOPE: src/frame_compare/render/**; src/frame_compare/vs/**; src/frame_compare/analysis/**; tools/windows_portable/**; Dockerfile; docker-compose.yml; live mutating slow.pics tests; generated HTML report upload controls except the reference-only starter spec named in Unit 7
 KEY_INVARIANTS: no new run flags; no wizard prompt expansion; run --json stdout remains one JSON object with slowpics_url as the only machine-readable slow.pics result field; post-upload side-effect failures are warning-only; browser/report opening stays CLI-owned; webhook delivery is Frame Compare-owned outbound integration with strict external HTTPS and redaction; shortcut creation is deterministic filesystem output and is not part of uploaded-file cleanup
 VERIFICATION_RUN: plan review only; implementation units must run focused tests plus the runbook full verification gate before closeout
 KNOWN_RISKS: CLI/config contract drift; unexpected browser or clipboard side effects in automation; shortcut path ambiguity with run folders disabled; webhook SSRF/DNS rebinding gaps; JSON stdout contamination; dependency lockfile churn; report auto-open behavior conflict
@@ -176,6 +176,8 @@ units below.
 ### Unit 3: Post-Upload Result Plumbing
 
 - Add typed internal status and warning plumbing for post-upload actions.
+- Include the narrow coordinator assembly handoff that carries retained
+  post-upload action results from `RunArtifacts` into `RunResult`.
 - Do not add JSON output keys.
 - Preserve import-layer contracts and lazy CLI import behavior.
 - Keep side-effect results stable enough for CLI output and tests, but do not
@@ -248,7 +250,7 @@ units below.
   cookie/header isolation, redirect refusal, timeout/retry behavior, payload
   shape, redaction, and `--quiet`/`--json` warning placement.
 
-### Unit 7: Human Output And Authority Docs
+### Unit 7: Human Output, Authority Docs, And Future Starter Spec
 
 - Show only enabled action outcomes in the human result summary.
 - Keep disabled/skipped states out of normal output unless needed as warnings.
@@ -260,9 +262,6 @@ units below.
   shortcut filesystem output, webhook external boundary, and CLI-owned browser
   opening behavior.
 - Update `tests/test_cli_contract_docs.py` to lock docs to the live surface.
-
-### Unit 8: Starter Spec For Future Report-Confirmed Upload
-
 - The reference-only starter spec exists at
   `docs/plans/2026-06-01-report-confirmed-slowpics-upload-starter-spec.md`.
 - Keep that spec non-active and not implemented by this plan.

--- a/docs/plans/2026-06-01-slowpics-legacy-ux-parity-plan.md
+++ b/docs/plans/2026-06-01-slowpics-legacy-ux-parity-plan.md
@@ -1,0 +1,349 @@
+Status: Active
+Scope: Restore slow.pics legacy post-upload UX for clipboard copy, browser open, .url shortcut, and webhook delivery
+Owner: Next Codex feature-loop session
+
+# slow.pics Legacy UX Parity Plan
+
+## Purpose
+
+This plan freezes the approved workflow and product decisions for restoring the
+deferred slow.pics legacy post-upload UX recorded in
+`docs/plans/2026-06-01-slowpics-legacy-ux-followup-handoff.md`.
+
+The target is to restore user-facing convenience behavior after a successful
+slow.pics upload without changing the current slow.pics upload protocol,
+rewriting report generation, or expanding the `run --json` machine contract.
+
+The next implementation session must start with adversarial plan review before
+any code changes, then execute one approved unit at a time through the Frame
+Compare feature workflow.
+
+## Workflow Entry
+
+Use `frame-compare-cleanup-loop` as the controller pattern because there is no
+separate feature-loop controller skill. Use the feature skills in each
+controller slot:
+
+- plan/refine: `frame-compare-feature-plan`
+- review: `frame-compare-feature-review` plus `review-request`
+- implementation: `frame-compare-feature-implement`
+- findings: `review-adjudication`
+- closeout: `closeout-verification`
+
+Expected loop entry:
+
+1. Load this active plan file.
+2. Keep authoritative live state in `update_plan`.
+3. Request adversarial review of this plan with `frame-compare-feature-review`
+   plus `review-request`.
+4. Adjudicate plan findings before implementation.
+5. Execute one approved implementation unit at a time.
+6. Review each implementation unit before moving to the next unit.
+7. Use `closeout-verification` before marking this plan historical.
+
+Initial review packet for the next session:
+
+```text
+REVIEW_REQUEST
+TASK: slow.pics legacy post-upload UX parity
+TASK_FAMILY: feature/public CLI-config-runtime integration
+RISK_TIER: high
+REVIEW_TARGET: active tracked plan
+PLAN_OR_ARTIFACT: docs/plans/2026-06-01-slowpics-legacy-ux-parity-plan.md
+REFERENCE_HANDOFF: docs/plans/2026-06-01-slowpics-legacy-ux-followup-handoff.md
+FILES_IN_SCOPE: src/frame_compare/config/schema_models.py; src/frame_compare/config/defaults.py; src/frame_compare/config/schema.py; src/frame_compare/cli/entry.py; src/frame_compare/cli/run_command.py; src/frame_compare/cli/output.py; src/frame_compare/orchestration/types.py; src/frame_compare/orchestration/execution.py; src/frame_compare/orchestration/phase_tasks.py; src/frame_compare/services/publishers.py or focused sibling service modules; pyproject.toml; uv.lock; tests/config/test_schema.py; tests/cli/test_run_slowpics_options.py; tests/cli/test_run_command.py; tests/cli/test_run_output.py; tests/cli/test_run_report_open.py; tests/services/test_publishers.py or focused sibling service tests; tests/orchestration/test_phase_tasks_outputs.py; tests/test_cli_contract_docs.py; docs/current-cli-contract.md; docs/current-architecture.md
+FILES_OUT_OF_SCOPE: src/frame_compare/render/**; src/frame_compare/vs/**; src/frame_compare/analysis/**; tools/windows_portable/**; Dockerfile; docker-compose.yml; live mutating slow.pics tests; generated HTML report upload controls except the reference-only starter spec named in Unit 8
+KEY_INVARIANTS: no new run flags; no wizard prompt expansion; run --json stdout remains one JSON object with slowpics_url as the only machine-readable slow.pics result field; post-upload side-effect failures are warning-only; browser/report opening stays CLI-owned; webhook delivery is Frame Compare-owned outbound integration with strict external HTTPS and redaction; shortcut creation is deterministic filesystem output and is not part of uploaded-file cleanup
+VERIFICATION_RUN: plan review only; implementation units must run focused tests plus the runbook full verification gate before closeout
+KNOWN_RISKS: CLI/config contract drift; unexpected browser or clipboard side effects in automation; shortcut path ambiguity with run folders disabled; webhook SSRF/DNS rebinding gaps; JSON stdout contamination; dependency lockfile churn; report auto-open behavior conflict
+```
+
+## Task Family And Risk Tier
+
+- Task family: feature/public CLI-config-runtime integration
+- Runbook tier: High
+
+Why high risk:
+
+- The work changes the documented `[slowpics]` config surface.
+- The work adds a runtime dependency for clipboard integration.
+- The work adds OS/browser side effects, filesystem output, and outbound webhook
+  behavior after upload.
+- The work touches CLI output, JSON-mode guardrails, browser-opening behavior,
+  and slow.pics integration ownership.
+- Authority docs must be updated in the same pass as the public behavior.
+
+## Frozen Product Decisions
+
+These decisions are approved and must not be reinvented during implementation.
+
+1. Restore all four deferred legacy UX features:
+   - copy the slow.pics URL to the clipboard
+   - open the slow.pics URL in a browser
+   - create a `.url` shortcut for the slow.pics comparison
+   - post the slow.pics URL to a configured webhook
+2. Keep the feature surface config-only.
+3. Do not add new `run` flags.
+4. Do not expand `wizard` prompts.
+5. Add these `[slowpics]` config fields:
+   - `copy_url_to_clipboard = true`
+   - `open_in_browser = true`
+   - `create_url_shortcut = true`
+   - `webhook_url = null`
+6. Add `pyperclip` as a runtime dependency for clipboard support.
+7. Keep `run --json` unchanged:
+   - stdout remains a single JSON object
+   - `slowpics_url` remains the only machine-readable slow.pics result field
+   - no copy/open/shortcut/webhook telemetry fields are added
+8. Treat post-upload side-effect failures as warning-only.
+9. Clipboard copy and slow.pics browser opening run only in interactive CLI mode:
+   not `--json`, not `--quiet`, and stdout is a TTY.
+10. Shortcut creation and webhook delivery run whenever configured after a
+    successful slow.pics upload, including `--json` and `--quiet`; warnings must
+    stay off JSON stdout.
+11. If slow.pics browser-open and report auto-open both apply, prefer opening
+    slow.pics for this plan and suppress report auto-open for that run.
+12. Human output should show enabled outcomes only, using the existing organized
+    Rich result-summary style. Do not list disabled states by default.
+13. CLI-owned clipboard copy and slow.pics browser-open actions must execute
+    after a successful run result is available and before the human result
+    summary is printed, so enabled outcomes and warning-only failures can be
+    rendered with the summary. These action results are local CLI presentation
+    state only and must not be added to `run --json`.
+14. In `--quiet`, enabled success outcomes for copy/open/shortcut/webhook remain
+    suppressed with the rest of the rich summary. Warning-only side-effect
+    failures must be emitted only on stderr/log channels, never on stdout.
+    In `--json`, no side-effect outcome or warning text may be written to
+    stdout; stdout remains the single JSON object.
+
+## Owner Seams
+
+- Config schema/defaults: `frame_compare.config.*`.
+- CLI command routing, interactive gating, browser-opening, JSON cleanliness,
+  and human result formatting: `frame_compare.cli.*`.
+- slow.pics upload remains owned by `frame_compare.services.publishers`.
+- New webhook and shortcut behavior should live in a focused service owner or a
+  narrow sibling of `publishers`, not inside report generation or render code.
+- Webhook delivery must be owned by a focused service module that does not reuse
+  the slow.pics upload `httpx.AsyncClient`, cookies, headers, or transport state.
+  The service may own a short-lived isolated HTTP/TLS request path or an
+  injected testable client/factory, but the implementation contract must keep
+  cookies empty, redirects disabled, proxies/environment trust disabled, and
+  slow.pics request headers unavailable to webhook delivery.
+- Orchestration may carry typed post-upload status and warnings, but must not
+  become the owner of clipboard, browser, shortcut, or webhook policy.
+- Generated HTML reports remain static offline artifacts under
+  `frame_compare.services.report`; report-triggered upload is not implemented in
+  this workstream.
+
+## Unit 1 Review Adjudication
+
+Adversarial plan review found three blockers. All are accepted and resolved in
+this plan before implementation may begin:
+
+- Webhook DNS/SSRF policy is tightened so hostname targets are rejected when any
+  resolved address is non-public, and webhook connection code must avoid the
+  validation-to-connect DNS rebinding gap by either connecting to a pinned
+  prevalidated address while preserving HTTPS certificate verification for the
+  original hostname, or by stopping and replanning before Unit 6.
+- Webhook HTTP ownership is frozen as an isolated Frame Compare-owned service
+  path. Reusing the slow.pics upload client, cookies, headers, redirect policy,
+  proxy/environment trust, or transport state is out of scope and invalid.
+- CLI copy/open actions must run before the human result summary so enabled
+  outcomes and warning-only failures have a defined presentation path. They
+  remain interactive-only and local to CLI presentation, with no JSON fields.
+
+The accepted verification additions are included in the affected implementation
+units below.
+
+## Implementation Units
+
+### Unit 1: Plan Review And Contract Freeze
+
+- Run adversarial review of this active plan.
+- Adjudicate all findings before implementation.
+- Stop if review finds unresolved product decisions, unclear owner seams, or
+  insufficient webhook security policy.
+
+### Unit 2: Config And Dependency Surface
+
+- Add the approved `[slowpics]` config fields and defaults.
+- Add `pyperclip` to runtime dependencies and update the lockfile.
+- Update config schema/default tests and current CLI contract docs.
+- Preserve the current root config `extra="ignore"` behavior unless explicitly
+  replanned.
+
+### Unit 3: Post-Upload Result Plumbing
+
+- Add typed internal status and warning plumbing for post-upload actions.
+- Do not add JSON output keys.
+- Preserve import-layer contracts and lazy CLI import behavior.
+- Keep side-effect results stable enough for CLI output and tests, but do not
+  expose them as a public import-level API.
+
+### Unit 4: Clipboard And Browser UX
+
+- Implement clipboard copy through `pyperclip.copy` at the approved CLI-owned
+  interactive seam.
+- Implement slow.pics browser opening at the CLI-owned interactive seam.
+- Execute copy/open before printing the human result summary, collect enabled
+  action outcomes and warning-only failures as CLI-local presentation state, and
+  pass that state into the summary/warning renderer without changing `RunResult`
+  JSON serialization.
+- Do not launch real browsers or mutate the real clipboard in tests.
+- Preserve report-generation ownership and keep report browser auto-open
+  separate from slow.pics URL opening.
+- Add tests for summary ordering, clipboard/browser warning placement,
+  interactive-only gating, and report auto-open suppression when slow.pics open
+  applies.
+
+### Unit 5: Shortcut Filesystem Behavior
+
+- Create a deterministic `.url` shortcut after successful upload when
+  `slowpics.create_url_shortcut = true`.
+- Write the shortcut at the run-level output parent:
+  - `workspace.run_dir` when run folders are enabled
+  - otherwise the common parent for the resolved screenshots/generated output
+    when they share one
+  - stop and replan if legacy-mode screenshots/generated paths do not have a
+    safe common parent
+- Treat a legacy-mode common parent as unsafe when it resolves to a drive root,
+  filesystem anchor, UNC/share root, home directory, or any parent that is not
+  under the resolved workspace root. Treat paths on different drives or anchors
+  as having no safe common parent.
+- Derive a filesystem-safe filename from current run metadata or upload title,
+  with a stable fallback from the slow.pics URL key.
+- Overwrite the same deterministic shortcut path on repeated writes.
+- Do not delete the shortcut during `slowpics.delete_after_upload` cleanup.
+- Surface write failures as warnings only.
+
+### Unit 6: Webhook Delivery
+
+- Add Frame Compare-owned webhook delivery after successful slow.pics upload
+  when `slowpics.webhook_url` is set.
+- Use payload shape `{"content": "<slowpics_url>"}`.
+- Use fixed webhook policy for v1:
+  - timeout: 10 seconds
+  - attempts: 3
+  - no redirects
+  - isolated cookie-free request
+  - no reuse of slow.pics cookies or headers
+  - no proxy/environment trust
+- Require strict external HTTPS:
+  - reject non-HTTPS URLs
+  - reject localhost, loopback, private, link-local, multicast, reserved, and
+    otherwise non-public IP literal targets
+  - reject DNS targets when any resolved address is disallowed or when resolution
+    fails, returns no usable addresses, or mixes public and non-public addresses
+  - prevent DNS rebinding between validation and connection by pinning the
+    connection to a prevalidated public address while preserving HTTPS
+    certificate verification and SNI for the original hostname
+  - stop and replan before implementation if the chosen HTTP owner cannot
+    implement pinned-address HTTPS correctly without a larger network-policy
+    owner
+- Redact webhook URL details in logs, warnings, and errors.
+- Treat delivery failures as warnings only.
+- Add tests for mixed allowed/disallowed DNS answers, all-disallowed answers,
+  IP literal rejection, pinned-address connection behavior, slow.pics
+  cookie/header isolation, redirect refusal, timeout/retry behavior, payload
+  shape, redaction, and `--quiet`/`--json` warning placement.
+
+### Unit 7: Human Output And Authority Docs
+
+- Show only enabled action outcomes in the human result summary.
+- Keep disabled/skipped states out of normal output unless needed as warnings.
+- Keep `--json` stdout parseable as one JSON object.
+- Update `docs/current-cli-contract.md` for config fields, defaults, JSON
+  non-change, no new flags, no wizard prompts, warning-only behavior, and
+  browser-open precedence.
+- Update `docs/current-architecture.md` for the new post-upload UX owner seam,
+  shortcut filesystem output, webhook external boundary, and CLI-owned browser
+  opening behavior.
+- Update `tests/test_cli_contract_docs.py` to lock docs to the live surface.
+
+### Unit 8: Starter Spec For Future Report-Confirmed Upload
+
+- The reference-only starter spec exists at
+  `docs/plans/2026-06-01-report-confirmed-slowpics-upload-starter-spec.md`.
+- Keep that spec non-active and not implemented by this plan.
+- Preserve these starter intentions:
+  - when local report review and slow.pics upload are both desired, the user can
+    inspect the generated report before uploading
+  - the CLI may wait for confirmation in that future workflow
+  - report-triggered upload after CLI exit would require a separate design,
+    such as a local service, protocol handler, or other explicit runtime owner
+- Do not implement report UI upload controls, background services, or protocol
+  handlers in this workstream.
+
+## Verification Strategy
+
+Primary verification modes:
+
+- `contract-first` for CLI/config/JSON/docs behavior.
+- `integration-ops` for OS/browser, filesystem shortcut, and outbound webhook
+  boundaries.
+- `manual-runtime` only for proof that cannot be automated without launching a
+  real browser or mutating a real clipboard; default automated tests must mock
+  those boundaries.
+
+Required focused tests:
+
+- Config schema/default tests for the new `[slowpics]` fields.
+- CLI option tests proving no new slow.pics `run` flags.
+- Wizard tests proving no prompt expansion.
+- CLI JSON tests proving stdout remains a single JSON object and no new
+  slow.pics telemetry fields appear.
+- CLI/browser-open tests proving slow.pics open is interactive-only and wins
+  over report auto-open when both apply.
+- Clipboard tests with mocked `pyperclip.copy`.
+- Shortcut tests for directory selection, filename sanitization, deterministic
+  overwrite, write failure warnings, and cleanup interaction.
+- Webhook tests for URL validation, disallowed hosts/IPs, DNS resolution policy,
+  redirect refusal, timeout/retry behavior, payload shape, cookie isolation,
+  redaction, and warning-only failure semantics.
+- Human output tests for enabled outcomes only and warning placement.
+- Explicit quiet/json warning-placement tests for shortcut and webhook
+  side-effect failures.
+- Authority doc lockstep tests.
+
+Full runbook verification before closeout:
+
+```bash
+.venv/bin/pyright --warnings
+.venv/bin/ruff check .
+.venv/bin/bandit -c pyproject.toml -r src --severity-level medium
+.venv/bin/pytest -q
+UV_CACHE_DIR=./.uv_cache uv run --no-sync lint-imports --config importlinter.ini
+```
+
+On Windows, equivalent `uv run --no-sync ...` commands are acceptable when the
+direct `.venv/bin/*` paths are unavailable, but the proof surface must remain
+the same.
+
+## Stop And Replan Triggers
+
+Stop and return to planning if any of these occur:
+
+- Implementation requires new `run` flags or wizard prompts.
+- `run --json` needs copy/open/shortcut/webhook telemetry fields.
+- Clipboard support cannot be implemented with `pyperclip` without breaking
+  supported packaging or import-time behavior.
+- Slow.pics browser opening cannot remain CLI-owned.
+- Shortcut directory selection is ambiguous for legacy-mode paths.
+- Webhook SSRF, DNS rebinding, redirect, timeout, retry, or redaction policy
+  cannot be implemented safely in the chosen owner.
+- Post-upload side-effect failures need to become fail-fast.
+- Report-confirmed upload starts requiring report UI, a local service,
+  background process, or protocol handler in this workstream.
+- Authority docs conflict with observed code in a way that cannot be resolved in
+  the same pass.
+
+## Closeout
+
+Before closing this workstream:
+
+- Run the full verification gate or record exact documented-only gaps.
+- Confirm authority docs match implemented behavior.
+- Confirm no live network, real browser launch, or real clipboard mutation is
+  required by default tests.
+- Change this plan to `Status: Historical` in the same pass as closeout.

--- a/docs/plans/2026-06-01-slowpics-legacy-ux-parity-plan.md
+++ b/docs/plans/2026-06-01-slowpics-legacy-ux-parity-plan.md
@@ -1,6 +1,6 @@
-Status: Active
+Status: Historical
 Scope: Restore slow.pics legacy post-upload UX for clipboard copy, browser open, .url shortcut, and webhook delivery
-Owner: Next Codex feature-loop session
+Owner: Completed Codex feature-loop session
 
 # slow.pics Legacy UX Parity Plan
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pillow>=12.2.0",
     "guessit>=3.8.0",
     "anitopy>=2.1.1",
+    "pyperclip>=1.11.0",
 ]
 
 [project.optional-dependencies]

--- a/src/frame_compare/cli/cli_helpers.py
+++ b/src/frame_compare/cli/cli_helpers.py
@@ -61,6 +61,18 @@ def maybe_open_report(report_path: Path) -> None:
         return
 
 
+def copy_text_to_clipboard(text: str) -> None:
+    """Copy text to the clipboard while keeping pyperclip import lazy."""
+    import pyperclip
+
+    pyperclip.copy(text)
+
+
+def open_url_in_browser(url: str) -> bool:
+    """Open a URL in the default browser and report whether a handler accepted it."""
+    return webbrowser.open(url)
+
+
 def handle_error(
     error: Exception,
     *,

--- a/src/frame_compare/cli/cli_helpers.py
+++ b/src/frame_compare/cli/cli_helpers.py
@@ -44,21 +44,22 @@ class FrameCompareTyperGroup(TyperGroup):
         return super().main(*args, **kwargs)
 
 
-def maybe_open_report(report_path: Path) -> None:
+def maybe_open_report(report_path: Path) -> bool:
     """Best-effort open of a generated HTML report in the default browser."""
     if os.name == "nt" and hasattr(os, "startfile"):
         try:
             os.startfile(str(report_path))  # type: ignore[attr-defined]  # nosec B606
-            return
+            return True
         except OSError:
-            with contextlib.suppress(OSError, webbrowser.Error):
-                webbrowser.open(report_path.resolve().as_uri())
-            return
+            try:
+                return webbrowser.open(report_path.resolve().as_uri())
+            except (OSError, webbrowser.Error):
+                return False
 
     try:
-        webbrowser.open(report_path.resolve().as_uri())
+        return webbrowser.open(report_path.resolve().as_uri())
     except (OSError, webbrowser.Error):
-        return
+        return False
 
 
 def copy_text_to_clipboard(text: str) -> None:

--- a/src/frame_compare/cli/entry.py
+++ b/src/frame_compare/cli/entry.py
@@ -13,7 +13,9 @@ from rich.console import Console
 
 from frame_compare.cli.cli_helpers import (
     FrameCompareTyperGroup,
+    copy_text_to_clipboard,
     handle_error,
+    open_url_in_browser,
     prepare_toml_payload,
     resolve_root_and_config,
     stabilize_typer_help_width,
@@ -94,6 +96,8 @@ app = typer.Typer(
 _stabilize_typer_help_width = stabilize_typer_help_width
 _prepare_toml_payload = prepare_toml_payload
 _resolve_root_and_config = resolve_root_and_config
+_copy_text_to_clipboard = copy_text_to_clipboard
+_open_url_in_browser = open_url_in_browser
 _doctor_report_json = doctor_report_json
 _print_doctor_report = print_doctor_report
 _prompt_input_dir = prompt_input_dir
@@ -201,6 +205,8 @@ def run(
         configure_logging=configure_logging,
         console_factory=Console,
         open_report=_maybe_open_report,
+        copy_to_clipboard=_copy_text_to_clipboard,
+        open_url=_open_url_in_browser,
         stdout_is_tty=sys.stdout.isatty(),
         no_color_env_present="NO_COLOR" in os.environ,
     )

--- a/src/frame_compare/cli/entry.py
+++ b/src/frame_compare/cli/entry.py
@@ -110,6 +110,15 @@ _handle_json_output = handle_json_output
 _build_minimal_config = build_minimal_config
 _validate_config = validate_config
 
+
+def _sys_stream_isatty(name: str) -> bool:
+    stream: object = getattr(sys, name, None)
+    isatty = getattr(stream, "isatty", None)
+    if not callable(isatty):
+        return False
+    return bool(isatty())
+
+
 if TYPE_CHECKING:
 
     def _option[T](default: T, *param_decls: str) -> T:
@@ -207,7 +216,9 @@ def run(
         open_report=_maybe_open_report,
         copy_to_clipboard=_copy_text_to_clipboard,
         open_url=_open_url_in_browser,
-        stdout_is_tty=sys.stdout.isatty(),
+        confirm_upload=typer.confirm,
+        stdout_is_tty=_sys_stream_isatty("stdout"),
+        stdin_is_tty=_sys_stream_isatty("stdin"),
         no_color_env_present="NO_COLOR" in os.environ,
     )
     handle_run(args, deps)

--- a/src/frame_compare/cli/output.py
+++ b/src/frame_compare/cli/output.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, Protocol
 
 from rich.console import Console
 from rich.markup import escape
@@ -30,6 +31,43 @@ STYLE_HEADER = "bold cyan"
 STYLE_SUBHEADER = "bold bright_cyan"
 STYLE_CHECK = "green"
 STYLE_METRIC_KEY = "dim"
+
+type PostUploadActionPresentationKind = Literal["clipboard", "browser", "shortcut", "webhook"]
+
+
+class PostUploadActionPresentation(Protocol):
+    @property
+    def kind(self) -> PostUploadActionPresentationKind: ...
+
+    @property
+    def success(self) -> bool: ...
+
+    @property
+    def detail(self) -> str | None: ...
+
+    @property
+    def path(self) -> Path | None: ...
+
+    @property
+    def message(self) -> str | None: ...
+
+    @property
+    def warning(self) -> str | None: ...
+
+
+@dataclass(frozen=True)
+class PostUploadActionPresentationResult:
+    """CLI-local presentation state for optional post-upload side effects."""
+
+    kind: PostUploadActionPresentationKind
+    success: bool
+    detail: str | None = None
+    path: Path | None = None
+    message: str | None = None
+    warning: str | None = None
+
+
+type PostUploadActionPresentationResults = tuple[PostUploadActionPresentation, ...]
 
 
 # ── Formatting helpers ─────────────────────────────────────────────────────────
@@ -204,7 +242,13 @@ def print_at_a_glance(
 # ── Result summary ────────────────────────────────────────────────────────────
 
 
-def print_result_summary(console: Console, *, result: RunResult, quiet: bool) -> None:
+def print_result_summary(
+    console: Console,
+    *,
+    result: RunResult,
+    quiet: bool,
+    post_upload_actions: PostUploadActionPresentationResults = (),
+) -> None:
     screenshot_dir = str(result.screenshot_dir) if result.screenshot_dir is not None else None
 
     if quiet:
@@ -213,6 +257,10 @@ def print_result_summary(console: Console, *, result: RunResult, quiet: bool) ->
         return
 
     table = _group_table()
+    all_post_upload_actions: PostUploadActionPresentationResults = (
+        *result.post_upload_actions,
+        *post_upload_actions,
+    )
 
     # Artifact rows with checkmarks
     has_artifacts = False
@@ -227,6 +275,14 @@ def print_result_summary(console: Console, *, result: RunResult, quiet: bool) ->
         table.add_row(
             f"  [{STYLE_CHECK}]\u2713[/] slow.pics",
             _styled_value(result.slowpics_url),
+        )
+    for action in all_post_upload_actions:
+        if not action.success:
+            continue
+        has_artifacts = True
+        table.add_row(
+            f"  [{STYLE_CHECK}]\u2713[/] {action.kind}",
+            _styled_value(_post_upload_action_detail(action)),
         )
     if result.report_path is not None:
         has_artifacts = True
@@ -262,10 +318,11 @@ def print_result_summary(console: Console, *, result: RunResult, quiet: bool) ->
 
     console.print(Panel(table, title=f"[{STYLE_HEADER}]Result[/]", border_style="cyan"))
 
-    if result.warnings:
+    warnings = _merged_warnings(result.warnings, all_post_upload_actions)
+    if warnings:
         max_lines = 8
-        visible = result.warnings[:max_lines]
-        remaining = len(result.warnings) - len(visible)
+        visible = warnings[:max_lines]
+        remaining = len(warnings) - len(visible)
         warning_text = "\n".join(f"[{STYLE_WARN}]\u2022[/] {escape(w)}" for w in visible)
         if remaining > 0:
             warning_text += f"\n[{STYLE_WARN}]\u2022[/] ... ({remaining} more)"
@@ -277,3 +334,23 @@ def print_result_summary(console: Console, *, result: RunResult, quiet: bool) ->
                 expand=False,
             )
         )
+
+
+def _post_upload_action_detail(action: PostUploadActionPresentation) -> str:
+    if action.path is not None:
+        return str(action.path)
+    if action.detail is not None:
+        return action.detail
+    if action.message is not None:
+        return action.message
+    return "completed"
+
+
+def _merged_warnings(
+    warnings: list[str],
+    actions: PostUploadActionPresentationResults,
+) -> list[str]:
+    action_warnings = [action.warning for action in actions if action.warning is not None]
+    if not action_warnings:
+        return warnings
+    return [*warnings, *action_warnings]

--- a/src/frame_compare/cli/output.py
+++ b/src/frame_compare/cli/output.py
@@ -276,6 +276,12 @@ def print_result_summary(
             f"  [{STYLE_CHECK}]\u2713[/] slow.pics",
             _styled_value(result.slowpics_url),
         )
+    elif result.slowpics_upload_confirmation_status == "declined":
+        has_artifacts = True
+        table.add_row(
+            f"  [{STYLE_CHECK}]\u2713[/] slow.pics",
+            _styled_value("slow.pics upload skipped by confirmation"),
+        )
     for action in all_post_upload_actions:
         if not action.success:
             continue

--- a/src/frame_compare/cli/output.py
+++ b/src/frame_compare/cli/output.py
@@ -350,7 +350,16 @@ def _merged_warnings(
     warnings: list[str],
     actions: PostUploadActionPresentationResults,
 ) -> list[str]:
-    action_warnings = [action.warning for action in actions if action.warning is not None]
-    if not action_warnings:
-        return warnings
-    return [*warnings, *action_warnings]
+    merged: list[str] = []
+    seen: set[str] = set()
+    for warning in warnings:
+        if warning in seen:
+            continue
+        seen.add(warning)
+        merged.append(warning)
+    for action in actions:
+        if action.warning is None or action.warning in seen:
+            continue
+        seen.add(action.warning)
+        merged.append(action.warning)
+    return merged

--- a/src/frame_compare/cli/run_command.py
+++ b/src/frame_compare/cli/run_command.py
@@ -13,7 +13,12 @@ import typer
 from rich.console import Console
 
 from frame_compare.cli.errors import ExitCode, format_error_json, get_exit_code
-from frame_compare.cli.output import print_at_a_glance, print_result_summary
+from frame_compare.cli.output import (
+    PostUploadActionPresentationResult,
+    PostUploadActionPresentationResults,
+    print_at_a_glance,
+    print_result_summary,
+)
 from frame_compare.config.errors import ConfigValidationError
 from frame_compare.config.overrides import apply_cli_overrides
 from frame_compare.config.schema import ConfigSchema, OverlayMode, ToneCurve, TonemapPreset
@@ -50,6 +55,8 @@ class RunCommandDeps:
     configure_logging: ConfigureLoggingFn
     console_factory: ConsoleFactory
     open_report: OpenReportFn
+    copy_to_clipboard: CopyToClipboardFn
+    open_url: OpenUrlFn
     stdout_is_tty: bool
     no_color_env_present: bool
 
@@ -79,6 +86,14 @@ class HandleErrorFn(Protocol):
 
 class OpenReportFn(Protocol):
     def __call__(self, report_path: Path) -> None: ...
+
+
+class CopyToClipboardFn(Protocol):
+    def __call__(self, text: str) -> None: ...
+
+
+class OpenUrlFn(Protocol):
+    def __call__(self, url: str) -> bool: ...
 
 
 def coerce_cli_choice[CliChoiceT: Enum](
@@ -236,12 +251,24 @@ def handle_run(args: RunCliRawArgs, deps: RunCommandDeps) -> None:
     if not result.success:
         raise typer.Exit(code=int(ExitCode.PROCESSING_ERROR))
 
-    print_result_summary(console, result=result, quiet=args.quiet)
+    post_upload_actions = collect_interactive_slowpics_actions(
+        result,
+        args=args,
+        deps=deps,
+        config=load_effective_config(),
+    )
+    print_result_summary(
+        console,
+        result=result,
+        quiet=args.quiet,
+        post_upload_actions=post_upload_actions,
+    )
     maybe_open_run_report(
         result,
         args=args,
         deps=deps,
         resolve_effective_config=resolve_effective_config,
+        suppress_report_open=slowpics_browser_open_attempted(post_upload_actions),
     )
 
 
@@ -362,8 +389,15 @@ def maybe_open_run_report(
     args: RunCliRawArgs,
     deps: RunCommandDeps,
     resolve_effective_config: EffectiveConfigLoader,
+    suppress_report_open: bool = False,
 ) -> None:
-    if result.report_path is None or args.json_output or args.quiet or not deps.stdout_is_tty:
+    if (
+        suppress_report_open
+        or result.report_path is None
+        or args.json_output
+        or args.quiet
+        or not deps.stdout_is_tty
+    ):
         return
 
     try:
@@ -375,6 +409,78 @@ def maybe_open_run_report(
 
     if cfg is None or cfg.report.auto_open:
         deps.open_report(result.report_path)
+
+
+def collect_interactive_slowpics_actions(
+    result: RunResult,
+    *,
+    args: RunCliRawArgs,
+    deps: RunCommandDeps,
+    config: ConfigSchema,
+) -> PostUploadActionPresentationResults:
+    """Run enabled interactive slow.pics URL actions and collect presentation state."""
+    url = result.slowpics_url
+    if url is None or args.json_output or args.quiet or not deps.stdout_is_tty:
+        return ()
+
+    actions: list[PostUploadActionPresentationResult] = []
+    if config.slowpics.copy_url_to_clipboard:
+        actions.append(_copy_slowpics_url(url, copy_to_clipboard=deps.copy_to_clipboard))
+    if config.slowpics.open_in_browser:
+        actions.append(_open_slowpics_url(url, open_url=deps.open_url))
+    return tuple(actions)
+
+
+def _copy_slowpics_url(
+    url: str,
+    *,
+    copy_to_clipboard: CopyToClipboardFn,
+) -> PostUploadActionPresentationResult:
+    try:
+        copy_to_clipboard(url)
+    except Exception as exc:
+        return PostUploadActionPresentationResult(
+            kind="clipboard",
+            success=False,
+            warning=f"slow.pics clipboard: failed to copy URL: {exc}",
+        )
+    return PostUploadActionPresentationResult(
+        kind="clipboard",
+        success=True,
+        detail="slow.pics URL copied to clipboard",
+    )
+
+
+def _open_slowpics_url(
+    url: str,
+    *,
+    open_url: OpenUrlFn,
+) -> PostUploadActionPresentationResult:
+    try:
+        opened = open_url(url)
+    except Exception as exc:
+        return PostUploadActionPresentationResult(
+            kind="browser",
+            success=False,
+            warning=f"slow.pics browser: failed to open URL: {exc}",
+        )
+    if not opened:
+        return PostUploadActionPresentationResult(
+            kind="browser",
+            success=False,
+            warning="slow.pics browser: failed to open URL: no browser accepted the request",
+        )
+    return PostUploadActionPresentationResult(
+        kind="browser",
+        success=True,
+        detail="slow.pics URL opened in browser",
+    )
+
+
+def slowpics_browser_open_attempted(
+    actions: PostUploadActionPresentationResults,
+) -> bool:
+    return any(action.kind == "browser" for action in actions)
 
 
 def handle_diagnose_paths(resolved_root: Path, config_path: Path, config: ConfigSchema) -> None:

--- a/src/frame_compare/cli/run_command.py
+++ b/src/frame_compare/cli/run_command.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Protocol
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 
 from frame_compare.cli.errors import ExitCode, format_error_json, get_exit_code
 from frame_compare.cli.output import (
@@ -28,6 +29,11 @@ from .cli_helpers import format_enum_expected
 
 if TYPE_CHECKING:
     from frame_compare.orchestration.coordinator import RunDependencies, RunRequest, RunResult
+    from frame_compare.orchestration.types import (
+        SlowpicsUploadConfirmationDecision,
+        SlowpicsUploadConfirmationFn,
+        SlowpicsUploadConfirmationRequest,
+    )
 
 type EffectiveConfigLoader = Callable[[], ConfigSchema]
 
@@ -57,7 +63,9 @@ class RunCommandDeps:
     open_report: OpenReportFn
     copy_to_clipboard: CopyToClipboardFn
     open_url: OpenUrlFn
+    confirm_upload: ConfirmUploadPromptFn
     stdout_is_tty: bool
+    stdin_is_tty: bool
     no_color_env_present: bool
 
 
@@ -85,7 +93,7 @@ class HandleErrorFn(Protocol):
 
 
 class OpenReportFn(Protocol):
-    def __call__(self, report_path: Path) -> None: ...
+    def __call__(self, report_path: Path) -> bool: ...
 
 
 class CopyToClipboardFn(Protocol):
@@ -94,6 +102,10 @@ class CopyToClipboardFn(Protocol):
 
 class OpenUrlFn(Protocol):
     def __call__(self, url: str) -> bool: ...
+
+
+class ConfirmUploadPromptFn(Protocol):
+    def __call__(self, text: str, *, default: bool) -> bool: ...
 
 
 def coerce_cli_choice[CliChoiceT: Enum](
@@ -228,12 +240,19 @@ def handle_run(args: RunCliRawArgs, deps: RunCommandDeps) -> None:
             handle_diagnose_paths(args.resolved_root, args.config_path, load_effective_config())
             return
 
-        validate_run_contracts(args, load_effective_config())
+        validate_run_contracts(args, deps, load_effective_config())
 
         if not args.json_output and not args.quiet:
             print_run_preview(console, args, request, load_effective_config)
 
-        result = deps.runner.run(request, dependencies=None)
+        run_dependencies = build_runner_dependencies(
+            args=args,
+            deps=deps,
+            config=load_effective_config(),
+            console=console,
+            resolve_effective_config=resolve_effective_config,
+        )
+        result = deps.runner.run(request, dependencies=run_dependencies)
     except FrameCompareError as error:
         raise run_error_exit(
             error,
@@ -241,7 +260,7 @@ def handle_run(args: RunCliRawArgs, deps: RunCommandDeps) -> None:
             deps=deps,
             no_color=effective_no_color,
         ) from error
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, typer.Abort):
         raise typer.Exit(code=int(ExitCode.INTERRUPTED)) from None
 
     if args.json_output:
@@ -268,8 +287,66 @@ def handle_run(args: RunCliRawArgs, deps: RunCommandDeps) -> None:
         args=args,
         deps=deps,
         resolve_effective_config=resolve_effective_config,
-        suppress_report_open=slowpics_browser_open_attempted(post_upload_actions),
+        suppress_report_open=(
+            slowpics_browser_open_attempted(post_upload_actions)
+            or report_confirmed_slowpics_enabled(load_effective_config())
+        ),
     )
+
+
+def build_runner_dependencies(
+    *,
+    args: RunCliRawArgs,
+    deps: RunCommandDeps,
+    config: ConfigSchema,
+    console: Console,
+    resolve_effective_config: EffectiveConfigLoader,
+) -> RunDependencies | None:
+    if not report_confirmed_slowpics_enabled(config):
+        return None
+
+    from frame_compare.orchestration.coordinator import RunDependencies
+
+    return RunDependencies(
+        confirm_slowpics_upload=build_confirm_slowpics_upload_callback(
+            args=args,
+            deps=deps,
+            console=console,
+            resolve_effective_config=resolve_effective_config,
+        )
+    )
+
+
+def report_confirmed_slowpics_enabled(config: ConfigSchema) -> bool:
+    return config.slowpics.auto_upload and config.slowpics.confirm_upload_after_report
+
+
+def build_confirm_slowpics_upload_callback(
+    *,
+    args: RunCliRawArgs,
+    deps: RunCommandDeps,
+    console: Console,
+    resolve_effective_config: EffectiveConfigLoader,
+) -> SlowpicsUploadConfirmationFn:
+    def _confirm_slowpics_upload(
+        request: SlowpicsUploadConfirmationRequest,
+    ) -> SlowpicsUploadConfirmationDecision:
+        opened = maybe_open_report_path(
+            request.report_path,
+            args=args,
+            deps=deps,
+            resolve_effective_config=resolve_effective_config,
+        )
+        if not opened:
+            console.print(f"Report: {escape(str(request.report_path))}", soft_wrap=True)
+        if deps.confirm_upload(
+            "Review the local report, then upload this comparison to slow.pics?",
+            default=False,
+        ):
+            return "confirmed"
+        return "declined"
+
+    return _confirm_slowpics_upload
 
 
 def parse_run_options(args: RunCliRawArgs, *, no_color: bool) -> RunCliOptions:
@@ -323,8 +400,16 @@ def build_effective_config_loaders(
     return _resolve_effective_config, _load_effective_config
 
 
-def validate_run_contracts(args: RunCliRawArgs, config: ConfigSchema) -> None:
+def validate_run_contracts(args: RunCliRawArgs, deps: RunCommandDeps, config: ConfigSchema) -> None:
     """Enforce public CLI mode combinations before entering the runtime pipeline."""
+    validate_json_interactive_alignment_contract(args, config)
+    validate_report_confirmed_slowpics_contract(args, deps, config)
+
+
+def validate_json_interactive_alignment_contract(
+    args: RunCliRawArgs,
+    config: ConfigSchema,
+) -> None:
     if not args.json_output:
         return
 
@@ -351,6 +436,73 @@ def validate_run_contracts(args: RunCliRawArgs, config: ConfigSchema) -> None:
         hint=(
             "Disable audio_alignment.use_vspreview and "
             "audio_alignment.force_interactive, or run without --json"
+        ),
+    )
+
+
+def validate_report_confirmed_slowpics_contract(
+    args: RunCliRawArgs,
+    deps: RunCommandDeps,
+    config: ConfigSchema,
+) -> None:
+    if not report_confirmed_slowpics_enabled(config):
+        return
+
+    validation_errors: list[dict[str, JSONValue]] = []
+    if args.json_output:
+        validation_errors.append(
+            {
+                "type": "value_error",
+                "loc": ["cli", "json"],
+                "msg": "Report-confirmed slow.pics upload is not supported with --json.",
+                "input": True,
+            }
+        )
+    if args.quiet:
+        validation_errors.append(
+            {
+                "type": "value_error",
+                "loc": ["cli", "quiet"],
+                "msg": "Report-confirmed slow.pics upload is not supported with --quiet.",
+                "input": True,
+            }
+        )
+    if not deps.stdin_is_tty:
+        validation_errors.append(
+            {
+                "type": "value_error",
+                "loc": ["stdin"],
+                "msg": "Report-confirmed slow.pics upload requires stdin to be attached to a TTY.",
+                "input": False,
+            }
+        )
+    if not deps.stdout_is_tty:
+        validation_errors.append(
+            {
+                "type": "value_error",
+                "loc": ["stdout"],
+                "msg": "Report-confirmed slow.pics upload requires stdout to be attached to a TTY.",
+                "input": False,
+            }
+        )
+    if not config.report.enable:
+        validation_errors.append(
+            {
+                "type": "value_error",
+                "loc": ["report", "enable"],
+                "msg": "Report-confirmed slow.pics upload requires report.enable = true.",
+                "input": False,
+            }
+        )
+    if not validation_errors:
+        return
+
+    raise ConfigValidationError(
+        validation_errors,
+        message="Report-confirmed slow.pics upload requires an interactive report-enabled run",
+        hint=(
+            "Disable slowpics.confirm_upload_after_report, disable slowpics.auto_upload, "
+            "enable reports, or run from an interactive terminal without --json/--quiet"
         ),
     )
 
@@ -390,15 +542,33 @@ def maybe_open_run_report(
     deps: RunCommandDeps,
     resolve_effective_config: EffectiveConfigLoader,
     suppress_report_open: bool = False,
-) -> None:
+) -> bool:
+    if result.report_path is None:
+        return False
+    return maybe_open_report_path(
+        result.report_path,
+        args=args,
+        deps=deps,
+        resolve_effective_config=resolve_effective_config,
+        suppress_report_open=suppress_report_open,
+    )
+
+
+def maybe_open_report_path(
+    report_path: Path,
+    *,
+    args: RunCliRawArgs,
+    deps: RunCommandDeps,
+    resolve_effective_config: EffectiveConfigLoader,
+    suppress_report_open: bool = False,
+) -> bool:
     if (
         suppress_report_open
-        or result.report_path is None
         or args.json_output
         or args.quiet
         or not deps.stdout_is_tty
     ):
-        return
+        return False
 
     try:
         cfg = resolve_effective_config()
@@ -408,7 +578,8 @@ def maybe_open_run_report(
         cfg = None
 
     if cfg is None or cfg.report.auto_open:
-        deps.open_report(result.report_path)
+        return deps.open_report(report_path)
+    return False
 
 
 def collect_interactive_slowpics_actions(

--- a/src/frame_compare/config/defaults.py
+++ b/src/frame_compare/config/defaults.py
@@ -60,6 +60,7 @@ contrast_recovery = 0.3
 
 [slowpics]
 auto_upload = false
+confirm_upload_after_report = false
 visibility = "unlisted"
 delete_after_upload = false
 timeout_seconds = 60.0

--- a/src/frame_compare/config/defaults.py
+++ b/src/frame_compare/config/defaults.py
@@ -64,6 +64,10 @@ visibility = "unlisted"
 delete_after_upload = false
 timeout_seconds = 60.0
 max_retries = 3
+copy_url_to_clipboard = true
+open_in_browser = true
+create_url_shortcut = true
+# webhook_url = null
 
 [tmdb]
 # api_key = "your-api-key"

--- a/src/frame_compare/config/schema_models.py
+++ b/src/frame_compare/config/schema_models.py
@@ -98,6 +98,10 @@ class SlowpicsConfig(BaseModel):
     delete_after_upload: bool = False
     timeout_seconds: float = Field(default=60.0, ge=10.0)
     max_retries: int = Field(default=3, ge=1, le=10)
+    copy_url_to_clipboard: bool = True
+    open_in_browser: bool = True
+    create_url_shortcut: bool = True
+    webhook_url: str | None = None
 
 
 class TmdbConfig(BaseModel):

--- a/src/frame_compare/config/schema_models.py
+++ b/src/frame_compare/config/schema_models.py
@@ -94,6 +94,7 @@ class SlowpicsConfig(BaseModel):
     """slow.pics upload configuration and retry policy."""
 
     auto_upload: bool = False
+    confirm_upload_after_report: bool = False
     visibility: Visibility = Visibility.UNLISTED
     delete_after_upload: bool = False
     timeout_seconds: float = Field(default=60.0, ge=10.0)

--- a/src/frame_compare/orchestration/coordinator.py
+++ b/src/frame_compare/orchestration/coordinator.py
@@ -43,6 +43,7 @@ def _assemble_run_result(
         screenshot_dir=None if artifacts.render is None else artifacts.render.screenshot_dir,
         slowpics_url=artifacts.slowpics_url,
         report_path=artifacts.report_path,
+        post_upload_actions=artifacts.post_upload_actions,
         frame_count=len(selected_frames),
         clips_processed=1 + len(context.comparisons),
         duration_seconds=duration_seconds,

--- a/src/frame_compare/orchestration/coordinator.py
+++ b/src/frame_compare/orchestration/coordinator.py
@@ -44,6 +44,7 @@ def _assemble_run_result(
         slowpics_url=artifacts.slowpics_url,
         report_path=artifacts.report_path,
         post_upload_actions=artifacts.post_upload_actions,
+        slowpics_upload_confirmation_status=artifacts.slowpics_upload_confirmation_status,
         frame_count=len(selected_frames),
         clips_processed=1 + len(context.comparisons),
         duration_seconds=duration_seconds,
@@ -67,6 +68,7 @@ async def execute_run(request: RunRequest, deps: RunDependencies | None = None) 
             ffmpeg_runner=deps.ffmpeg_runner,
             http_client=deps.http_client,
             progress=deps.progress,
+            confirm_slowpics_upload=deps.confirm_slowpics_upload,
             clock=deps.clock,
         )
 
@@ -130,6 +132,8 @@ async def execute_run(request: RunRequest, deps: RunDependencies | None = None) 
                 "post_report_cleanup": 0.0,
             }
         )
+        if prep.config.slowpics.auto_upload and prep.config.slowpics.confirm_upload_after_report:
+            state.phase_timings["confirm_slowpics_upload"] = 0.0
 
         phase_plan = build_execution_phase_plan(
             request=request,

--- a/src/frame_compare/orchestration/coordinator.py
+++ b/src/frame_compare/orchestration/coordinator.py
@@ -126,6 +126,7 @@ async def execute_run(request: RunRequest, deps: RunDependencies | None = None) 
                 "dovi": 0.0,
                 "publish": 0.0,
                 "report": 0.0,
+                "post_report_cleanup": 0.0,
             }
         )
 

--- a/src/frame_compare/orchestration/execution.py
+++ b/src/frame_compare/orchestration/execution.py
@@ -121,7 +121,9 @@ def _apply_phase_output(*, ctx: RunContext, state: ExecutionState, output: Phase
             if phase_output.selection_breakdown is not None:
                 ctx.selection_breakdown = phase_output.selection_breakdown
             if phase_output.selection_details_by_source_frame is not None:
-                ctx.selection_details_by_source_frame = phase_output.selection_details_by_source_frame
+                ctx.selection_details_by_source_frame = (
+                    phase_output.selection_details_by_source_frame
+                )
         case RenderPhaseOutput() as phase_output:
             state.artifacts.render = phase_output.render
             state.warnings.extend(phase_output.render.warnings)
@@ -321,6 +323,16 @@ def build_phases_after_align(
         warnings=state.warnings,
         warn_only=True,
     )
+    confirm_slowpics_upload_phase = _create_timed_phase(
+        "confirm_slowpics_upload",
+        "confirm_slowpics_upload",
+        None,
+        _run_confirm_slowpics_upload_with_current_artifacts,
+        state=state,
+        clock=clock,
+        phase_timings=state.phase_timings,
+        warnings=state.warnings,
+    )
     post_report_cleanup_phase = _create_timed_phase(
         "post_report_cleanup",
         "post_report_cleanup",
@@ -341,27 +353,8 @@ def build_phases_after_align(
 
     return [
         *render_metadata_dovi_phases,
-        _create_timed_phase(
-            "report",
-            "report",
-            lambda config: not config.report.enable,
-            _run_report_with_current_artifacts,
-            state=state,
-            clock=clock,
-            phase_timings=state.phase_timings,
-            warnings=state.warnings,
-            warn_only=True,
-        ),
-        _create_timed_phase(
-            "confirm_slowpics_upload",
-            "confirm_slowpics_upload",
-            None,
-            _run_confirm_slowpics_upload_with_current_artifacts,
-            state=state,
-            clock=clock,
-            phase_timings=state.phase_timings,
-            warnings=state.warnings,
-        ),
+        report_phase,
+        confirm_slowpics_upload_phase,
         publish_phase,
         post_report_cleanup_phase,
     ]

--- a/src/frame_compare/orchestration/execution.py
+++ b/src/frame_compare/orchestration/execution.py
@@ -130,6 +130,11 @@ def _apply_phase_output(*, ctx: RunContext, state: ExecutionState, output: Phase
             state.artifacts.slowpics_url = phase_output.slowpics_url
             state.artifacts.uploaded_slowpics_file_paths = phase_output.uploaded_file_paths
             state.artifacts.post_upload_actions = phase_output.post_upload_actions
+            state.warnings.extend(
+                action.warning
+                for action in phase_output.post_upload_actions
+                if action.warning is not None
+            )
         case ReportPhaseOutput() as phase_output:
             state.artifacts.report_path = phase_output.report_path
             state.artifacts.report_succeeded = phase_output.report_succeeded

--- a/src/frame_compare/orchestration/execution.py
+++ b/src/frame_compare/orchestration/execution.py
@@ -129,6 +129,7 @@ def _apply_phase_output(*, ctx: RunContext, state: ExecutionState, output: Phase
         case PublishPhaseOutput() as phase_output:
             state.artifacts.slowpics_url = phase_output.slowpics_url
             state.artifacts.uploaded_slowpics_file_paths = phase_output.uploaded_file_paths
+            state.artifacts.post_upload_actions = phase_output.post_upload_actions
         case ReportPhaseOutput() as phase_output:
             state.artifacts.report_path = phase_output.report_path
             state.artifacts.report_succeeded = phase_output.report_succeeded

--- a/src/frame_compare/orchestration/execution.py
+++ b/src/frame_compare/orchestration/execution.py
@@ -22,6 +22,7 @@ from frame_compare.orchestration.phase_tasks import (
     run_align_phase,
     run_analyze_phase,
     run_metadata_phase,
+    run_post_report_cleanup_phase,
     run_publish_phase,
     run_render_phase,
     run_report_phase,
@@ -39,6 +40,7 @@ from frame_compare.orchestration.types import (
     MetadataPhaseOutput,
     MetadataPrefetch,
     PhaseOutput,
+    PostReportCleanupPhaseOutput,
     PrepState,
     PublishPhaseOutput,
     RenderPhaseOutput,
@@ -126,8 +128,12 @@ def _apply_phase_output(*, ctx: RunContext, state: ExecutionState, output: Phase
             state.warnings.append(phase_output.warning)
         case PublishPhaseOutput() as phase_output:
             state.artifacts.slowpics_url = phase_output.slowpics_url
+            state.artifacts.uploaded_slowpics_file_paths = phase_output.uploaded_file_paths
         case ReportPhaseOutput() as phase_output:
             state.artifacts.report_path = phase_output.report_path
+            state.artifacts.report_succeeded = phase_output.report_succeeded
+        case PostReportCleanupPhaseOutput() as phase_output:
+            state.warnings.extend(phase_output.warnings)
         case _:
             raise TypeError(f"Unsupported phase output type: {output.__class__.__qualname__}")
 
@@ -198,6 +204,8 @@ def build_phases_after_align(
             ctx,
             client=http_client,
             metadata=state.artifacts.resolved_metadata,
+            render=state.artifacts.render,
+            selected_frames=state.selected_frames,
         )
 
     def _run_report_with_current_artifacts(ctx: RunContext) -> ReportPhaseOutput:
@@ -207,6 +215,15 @@ def build_phases_after_align(
             render=state.artifacts.render,
             metadata=state.artifacts.resolved_metadata,
             slowpics_url=state.artifacts.slowpics_url,
+        )
+
+    def _run_post_report_cleanup_with_current_artifacts(
+        ctx: RunContext,
+    ) -> PostReportCleanupPhaseOutput:
+        return run_post_report_cleanup_phase(
+            ctx,
+            uploaded_file_paths=state.artifacts.uploaded_slowpics_file_paths,
+            report_succeeded=state.artifacts.report_succeeded,
         )
 
     return [
@@ -271,6 +288,16 @@ def build_phases_after_align(
             phase_timings=state.phase_timings,
             warnings=state.warnings,
             warn_only=True,
+        ),
+        _create_timed_phase(
+            "post_report_cleanup",
+            "post_report_cleanup",
+            None,
+            _run_post_report_cleanup_with_current_artifacts,
+            state=state,
+            clock=clock,
+            phase_timings=state.phase_timings,
+            warnings=state.warnings,
         ),
     ]
 

--- a/src/frame_compare/orchestration/execution.py
+++ b/src/frame_compare/orchestration/execution.py
@@ -21,6 +21,7 @@ from frame_compare.orchestration.phase_tasks import (
     record_dovi_not_implemented_warning,
     run_align_phase,
     run_analyze_phase,
+    run_confirm_slowpics_upload_phase,
     run_metadata_phase,
     run_post_report_cleanup_phase,
     run_publish_phase,
@@ -33,6 +34,7 @@ from frame_compare.orchestration.phases import Phase
 from frame_compare.orchestration.types import (
     AlignPhaseOutput,
     AnalyzePhaseOutput,
+    ConfirmSlowpicsUploadPhaseOutput,
     DoviPhaseOutput,
     ExecutionPhasePlan,
     ExecutionState,
@@ -47,6 +49,7 @@ from frame_compare.orchestration.types import (
     ReportPhaseOutput,
     RunDependencies,
     RunRequest,
+    SlowpicsUploadConfirmationFn,
 )
 from frame_compare.render.backend.ffmpeg import FFmpegRunner
 from frame_compare.utils.types import WorkspacePaths
@@ -138,6 +141,9 @@ def _apply_phase_output(*, ctx: RunContext, state: ExecutionState, output: Phase
         case ReportPhaseOutput() as phase_output:
             state.artifacts.report_path = phase_output.report_path
             state.artifacts.report_succeeded = phase_output.report_succeeded
+        case ConfirmSlowpicsUploadPhaseOutput() as phase_output:
+            state.artifacts.slowpics_upload_confirmation_status = phase_output.status
+            state.warnings.extend(phase_output.warnings)
         case PostReportCleanupPhaseOutput() as phase_output:
             state.warnings.extend(phase_output.warnings)
         case _:
@@ -204,8 +210,15 @@ def build_phases_after_align(
     http_client: httpx.AsyncClient | None,
     state: ExecutionState,
     metadata_prefetch: MetadataPrefetch,
+    config: ConfigSchema,
+    confirm_slowpics_upload: SlowpicsUploadConfirmationFn | None = None,
 ) -> list[Phase]:
     async def _run_publish_with_current_artifacts(ctx: RunContext) -> PublishPhaseOutput:
+        if (
+            _requires_report_confirmed_slowpics(ctx.config)
+            and state.artifacts.slowpics_upload_confirmation_status != "confirmed"
+        ):
+            return PublishPhaseOutput(slowpics_url=None)
         return await run_publish_phase(
             ctx,
             client=http_client,
@@ -220,7 +233,19 @@ def build_phases_after_align(
             frames=state.selected_frames,
             render=state.artifacts.render,
             metadata=state.artifacts.resolved_metadata,
-            slowpics_url=state.artifacts.slowpics_url,
+            slowpics_url=None
+            if _requires_report_confirmed_slowpics(ctx.config)
+            else state.artifacts.slowpics_url,
+        )
+
+    def _run_confirm_slowpics_upload_with_current_artifacts(
+        ctx: RunContext,
+    ) -> ConfirmSlowpicsUploadPhaseOutput:
+        return run_confirm_slowpics_upload_phase(
+            ctx,
+            report_path=state.artifacts.report_path,
+            report_succeeded=state.artifacts.report_succeeded,
+            confirm_slowpics_upload=confirm_slowpics_upload,
         )
 
     def _run_post_report_cleanup_with_current_artifacts(
@@ -232,7 +257,7 @@ def build_phases_after_align(
             report_succeeded=state.artifacts.report_succeeded,
         )
 
-    return [
+    render_metadata_dovi_phases = [
         _create_timed_phase(
             "render",
             "render",
@@ -273,17 +298,49 @@ def build_phases_after_align(
             warnings=state.warnings,
             warn_only=True,
         ),
-        _create_timed_phase(
-            "publish",
-            "publish",
-            lambda config: not config.slowpics.auto_upload,
-            _run_publish_with_current_artifacts,
-            state=state,
-            clock=clock,
-            phase_timings=state.phase_timings,
-            warnings=state.warnings,
-            warn_only=True,
-        ),
+    ]
+    publish_phase = _create_timed_phase(
+        "publish",
+        "publish",
+        lambda config: not config.slowpics.auto_upload,
+        _run_publish_with_current_artifacts,
+        state=state,
+        clock=clock,
+        phase_timings=state.phase_timings,
+        warnings=state.warnings,
+        warn_only=True,
+    )
+    report_phase = _create_timed_phase(
+        "report",
+        "report",
+        lambda config: not config.report.enable,
+        _run_report_with_current_artifacts,
+        state=state,
+        clock=clock,
+        phase_timings=state.phase_timings,
+        warnings=state.warnings,
+        warn_only=True,
+    )
+    post_report_cleanup_phase = _create_timed_phase(
+        "post_report_cleanup",
+        "post_report_cleanup",
+        None,
+        _run_post_report_cleanup_with_current_artifacts,
+        state=state,
+        clock=clock,
+        phase_timings=state.phase_timings,
+        warnings=state.warnings,
+    )
+    if not _requires_report_confirmed_slowpics(config):
+        return [
+            *render_metadata_dovi_phases,
+            publish_phase,
+            report_phase,
+            post_report_cleanup_phase,
+        ]
+
+    return [
+        *render_metadata_dovi_phases,
         _create_timed_phase(
             "report",
             "report",
@@ -296,16 +353,22 @@ def build_phases_after_align(
             warn_only=True,
         ),
         _create_timed_phase(
-            "post_report_cleanup",
-            "post_report_cleanup",
+            "confirm_slowpics_upload",
+            "confirm_slowpics_upload",
             None,
-            _run_post_report_cleanup_with_current_artifacts,
+            _run_confirm_slowpics_upload_with_current_artifacts,
             state=state,
             clock=clock,
             phase_timings=state.phase_timings,
             warnings=state.warnings,
         ),
+        publish_phase,
+        post_report_cleanup_phase,
     ]
+
+
+def _requires_report_confirmed_slowpics(config: ConfigSchema) -> bool:
+    return config.slowpics.auto_upload and config.slowpics.confirm_upload_after_report
 
 
 def build_execution_phase_plan(
@@ -340,6 +403,8 @@ def build_execution_phase_plan(
         http_client=deps.http_client,
         state=state,
         metadata_prefetch=prep.metadata_prefetch,
+        config=prep.config,
+        confirm_slowpics_upload=deps.confirm_slowpics_upload,
     )
     return ExecutionPhasePlan(
         before_align=before_align,

--- a/src/frame_compare/orchestration/phase_tasks.py
+++ b/src/frame_compare/orchestration/phase_tasks.py
@@ -67,6 +67,7 @@ from frame_compare.services.slowpics_upload_plan import (
     SlowpicsUploadClip,
     build_slowpics_upload_plan,
 )
+from frame_compare.services.slowpics_webhook import deliver_slowpics_webhook
 from frame_compare.services.types import AlignmentConfig, MetadataConfig, TmdbMetadata
 from frame_compare.utils.cache_errors import CacheCorruptionError, CacheVersionMismatchError
 from frame_compare.utils.types import WorkspacePaths
@@ -785,16 +786,17 @@ async def run_publish_phase(
         progress=ctx.reporter,
         upload_plan=upload_plan,
     )
-    post_upload_actions = _slowpics_shortcut_action(
+    shortcut_actions = _slowpics_shortcut_action(
         ctx=ctx,
         slowpics_url=result.url,
         metadata=metadata,
         upload_title=screenshot_dir.name,
     )
+    webhook_actions = await _slowpics_webhook_action(ctx=ctx, slowpics_url=result.url)
     return PublishPhaseOutput(
         slowpics_url=result.url,
         uploaded_file_paths=result.uploaded_file_paths,
-        post_upload_actions=post_upload_actions,
+        post_upload_actions=(*shortcut_actions, *webhook_actions),
     )
 
 
@@ -847,6 +849,40 @@ def _slowpics_shortcut_action(
             kind="shortcut",
             success=False,
             path=result.path,
+            warning=result.warning,
+        ),
+    )
+
+
+async def _slowpics_webhook_action(
+    *,
+    ctx: RunContext,
+    slowpics_url: str,
+) -> tuple[PostUploadActionResult, ...]:
+    webhook_url = ctx.config.slowpics.webhook_url
+    if webhook_url is None:
+        return ()
+
+    result = await deliver_slowpics_webhook(
+        webhook_url=webhook_url,
+        slowpics_url=slowpics_url,
+    )
+    if result.success:
+        return (
+            PostUploadActionResult(
+                kind="webhook",
+                success=True,
+                detail=result.detail,
+                message="slow.pics webhook delivered",
+            ),
+        )
+
+    if result.warning is not None:
+        log.warning("slowpics_webhook_delivery_failed", warning=result.warning)
+    return (
+        PostUploadActionResult(
+            kind="webhook",
+            success=False,
             warning=result.warning,
         ),
     )

--- a/src/frame_compare/orchestration/phase_tasks.py
+++ b/src/frame_compare/orchestration/phase_tasks.py
@@ -41,6 +41,7 @@ from frame_compare.orchestration.types import (
     MetadataPhaseOutput,
     MetadataPrefetch,
     PostReportCleanupPhaseOutput,
+    PostUploadActionResult,
     PublishPhaseOutput,
     RenderArtifacts,
     RenderPhaseOutput,
@@ -61,6 +62,7 @@ from frame_compare.services.report.display import (
 )
 from frame_compare.services.report.entry import generate_report
 from frame_compare.services.report.payload import FrameDetail, ReportData, clip_info_from_state
+from frame_compare.services.slowpics_shortcut import create_slowpics_url_shortcut
 from frame_compare.services.slowpics_upload_plan import (
     SlowpicsUploadClip,
     build_slowpics_upload_plan,
@@ -783,9 +785,16 @@ async def run_publish_phase(
         progress=ctx.reporter,
         upload_plan=upload_plan,
     )
+    post_upload_actions = _slowpics_shortcut_action(
+        ctx=ctx,
+        slowpics_url=result.url,
+        metadata=metadata,
+        upload_title=screenshot_dir.name,
+    )
     return PublishPhaseOutput(
         slowpics_url=result.url,
         uploaded_file_paths=result.uploaded_file_paths,
+        post_upload_actions=post_upload_actions,
     )
 
 
@@ -799,6 +808,48 @@ def _slowpics_upload_clips(ctx: RunContext) -> list[SlowpicsUploadClip]:
         seen_labels.add(clip.label)
         upload_clips.append(SlowpicsUploadClip(label=clip.label, image_name=clip.path.stem))
     return upload_clips
+
+
+def _slowpics_shortcut_action(
+    *,
+    ctx: RunContext,
+    slowpics_url: str,
+    metadata: TmdbMetadata | None,
+    upload_title: str | None,
+) -> tuple[PostUploadActionResult, ...]:
+    if not ctx.config.slowpics.create_url_shortcut:
+        return ()
+
+    result = create_slowpics_url_shortcut(
+        workspace=ctx.workspace,
+        slowpics_url=slowpics_url,
+        metadata_title=metadata.title if metadata is not None else None,
+        upload_title=upload_title,
+    )
+    if result.success:
+        return (
+            PostUploadActionResult(
+                kind="shortcut",
+                success=True,
+                path=result.path,
+                message="slow.pics URL shortcut written",
+            ),
+        )
+
+    if result.warning is not None:
+        log.warning(
+            "slowpics_shortcut_create_failed",
+            path=str(result.path) if result.path is not None else None,
+            warning=result.warning,
+        )
+    return (
+        PostUploadActionResult(
+            kind="shortcut",
+            success=False,
+            path=result.path,
+            warning=result.warning,
+        ),
+    )
 
 
 def run_report_phase(

--- a/src/frame_compare/orchestration/phase_tasks.py
+++ b/src/frame_compare/orchestration/phase_tasks.py
@@ -26,7 +26,9 @@ from frame_compare.analysis.types import (
     SelectionDetail,
     SelectionDetailsByFrame,
 )
+from frame_compare.config.errors import ConfigValidationError
 from frame_compare.config.schema import AnalysisConfig, ConfigSchema, OverlayMode
+from frame_compare.errors import JSONValue
 from frame_compare.orchestration.context import (
     ClipAlignmentState,
     ClipProbeSnapshot,
@@ -36,6 +38,7 @@ from frame_compare.orchestration.context import (
 from frame_compare.orchestration.types import (
     AlignPhaseOutput,
     AnalyzePhaseOutput,
+    ConfirmSlowpicsUploadPhaseOutput,
     DoviPhaseOutput,
     FramePlanPhaseOutput,
     MetadataPhaseOutput,
@@ -46,6 +49,8 @@ from frame_compare.orchestration.types import (
     RenderArtifacts,
     RenderPhaseOutput,
     ReportPhaseOutput,
+    SlowpicsUploadConfirmationFn,
+    SlowpicsUploadConfirmationRequest,
 )
 from frame_compare.render.backend.ffmpeg import FFmpegRunner
 from frame_compare.services.alignment import (
@@ -74,6 +79,10 @@ from frame_compare.utils.types import WorkspacePaths
 from frame_compare.vs.props import range_label_from_props
 
 log = structlog.get_logger()
+
+REPORT_CONFIRMATION_UNAVAILABLE_WARNING = (
+    "slow.pics upload skipped because report confirmation was unavailable"
+)
 
 if TYPE_CHECKING:
     from frame_compare.render.types import (
@@ -798,6 +807,42 @@ async def run_publish_phase(
         uploaded_file_paths=result.uploaded_file_paths,
         post_upload_actions=(*shortcut_actions, *webhook_actions),
     )
+
+
+def run_confirm_slowpics_upload_phase(
+    _ctx: RunContext,
+    *,
+    report_path: Path | None,
+    report_succeeded: bool,
+    confirm_slowpics_upload: SlowpicsUploadConfirmationFn | None,
+) -> ConfirmSlowpicsUploadPhaseOutput:
+    if not report_succeeded or report_path is None:
+        return ConfirmSlowpicsUploadPhaseOutput(
+            status="report_unavailable",
+            warnings=[REPORT_CONFIRMATION_UNAVAILABLE_WARNING],
+        )
+    if confirm_slowpics_upload is None:
+        validation_errors: list[dict[str, JSONValue]] = [
+            {
+                "type": "value_error",
+                "loc": ["slowpics", "confirm_upload_after_report"],
+                "msg": "Report-confirmed slow.pics upload requires a confirmation callback.",
+                "input": True,
+            }
+        ]
+        raise ConfigValidationError(
+            validation_errors,
+            message="Report-confirmed slow.pics upload requires a confirmation callback",
+            hint=(
+                "Provide RunDependencies.confirm_slowpics_upload, or disable "
+                "slowpics.confirm_upload_after_report."
+            ),
+        )
+
+    decision = confirm_slowpics_upload(
+        SlowpicsUploadConfirmationRequest(report_path=report_path)
+    )
+    return ConfirmSlowpicsUploadPhaseOutput(status=decision)
 
 
 def _slowpics_upload_clips(ctx: RunContext) -> list[SlowpicsUploadClip]:

--- a/src/frame_compare/orchestration/phase_tasks.py
+++ b/src/frame_compare/orchestration/phase_tasks.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
+import structlog
 
 import frame_compare.analysis.cache_io as cache_io
 from frame_compare.analysis.errors import MetricsCalculationError, SelectionError
@@ -39,6 +40,7 @@ from frame_compare.orchestration.types import (
     FramePlanPhaseOutput,
     MetadataPhaseOutput,
     MetadataPrefetch,
+    PostReportCleanupPhaseOutput,
     PublishPhaseOutput,
     RenderArtifacts,
     RenderPhaseOutput,
@@ -50,7 +52,7 @@ from frame_compare.services.alignment import (
     calculate_alignment_trims,
     format_rejected_alignment_warning,
 )
-from frame_compare.services.errors import AudioAlignmentError
+from frame_compare.services.errors import AudioAlignmentError, SlowpicsError
 from frame_compare.services.metadata import resolve_metadata
 from frame_compare.services.publishers import publish_to_slowpics
 from frame_compare.services.report.display import (
@@ -59,10 +61,16 @@ from frame_compare.services.report.display import (
 )
 from frame_compare.services.report.entry import generate_report
 from frame_compare.services.report.payload import FrameDetail, ReportData, clip_info_from_state
+from frame_compare.services.slowpics_upload_plan import (
+    SlowpicsUploadClip,
+    build_slowpics_upload_plan,
+)
 from frame_compare.services.types import AlignmentConfig, MetadataConfig, TmdbMetadata
 from frame_compare.utils.cache_errors import CacheCorruptionError, CacheVersionMismatchError
 from frame_compare.utils.types import WorkspacePaths
 from frame_compare.vs.props import range_label_from_props
+
+log = structlog.get_logger()
 
 if TYPE_CHECKING:
     from frame_compare.render.types import (
@@ -747,17 +755,50 @@ async def run_publish_phase(
     *,
     client: httpx.AsyncClient | None,
     metadata: TmdbMetadata | None,
+    render: RenderArtifacts | None = None,
+    selected_frames: list[int] | None = None,
 ) -> PublishPhaseOutput:
     if client is None:
         return PublishPhaseOutput(slowpics_url=None)
+    if render is None:
+        raise SlowpicsError("No render artifacts available for slow.pics upload")
+    if selected_frames is None:
+        raise SlowpicsError("No selected frames available for slow.pics upload")
+
+    upload_plan = build_slowpics_upload_plan(
+        selected_frames=selected_frames,
+        clips=_slowpics_upload_clips(ctx),
+        screenshots_by_label=render.screenshots_by_label,
+    )
+    screenshot_dir = (
+        render.screenshot_dir
+        if render.screenshot_dir is not None
+        else ctx.workspace.screenshots_dir
+    )
     result = await publish_to_slowpics(
-        screenshot_dir=ctx.workspace.screenshots_dir,
+        screenshot_dir=screenshot_dir,
         config=ctx.config.slowpics,
         client=client,
         metadata=metadata,
         progress=ctx.reporter,
+        upload_plan=upload_plan,
     )
-    return PublishPhaseOutput(slowpics_url=result.url)
+    return PublishPhaseOutput(
+        slowpics_url=result.url,
+        uploaded_file_paths=result.uploaded_file_paths,
+    )
+
+
+def _slowpics_upload_clips(ctx: RunContext) -> list[SlowpicsUploadClip]:
+    clips = [ctx.reference, *ctx.comparisons]
+    seen_labels: set[str] = set()
+    upload_clips: list[SlowpicsUploadClip] = []
+    for clip in clips:
+        if clip.label in seen_labels:
+            raise SlowpicsError(f"Duplicate clip label in slow.pics upload input: {clip.label!r}")
+        seen_labels.add(clip.label)
+        upload_clips.append(SlowpicsUploadClip(label=clip.label, image_name=clip.path.stem))
+    return upload_clips
 
 
 def run_report_phase(
@@ -769,7 +810,7 @@ def run_report_phase(
     slowpics_url: str | None,
 ) -> ReportPhaseOutput:
     if render is None or not render.screenshots_by_label:
-        return ReportPhaseOutput(report_path=None)
+        return ReportPhaseOutput(report_path=None, report_succeeded=True)
 
     clips = [ctx.reference, *ctx.comparisons]
     clip_info = [
@@ -783,7 +824,58 @@ def run_report_phase(
         frame_details=_report_frame_details_for_frames(ctx, frames=frames),
     )
     report_path = generate_report(report_data, ctx.config.report)
-    return ReportPhaseOutput(report_path=report_path)
+    return ReportPhaseOutput(report_path=report_path, report_succeeded=True)
+
+
+def run_post_report_cleanup_phase(
+    ctx: RunContext,
+    *,
+    uploaded_file_paths: tuple[Path, ...],
+    report_succeeded: bool,
+) -> PostReportCleanupPhaseOutput:
+    if not _should_delete_uploaded_files_after_report(
+        ctx,
+        uploaded_file_paths=uploaded_file_paths,
+        report_succeeded=report_succeeded,
+    ):
+        return PostReportCleanupPhaseOutput()
+
+    warnings: list[str] = []
+    deleted_count = 0
+    for path in uploaded_file_paths:
+        try:
+            path.unlink()
+            deleted_count += 1
+        except OSError as exc:
+            message = f"cleanup: failed to delete uploaded screenshot {path}: {exc}"
+            warnings.append(message)
+            log.warning(
+                "slowpics_uploaded_file_delete_failed",
+                path=str(path),
+                error=str(exc),
+            )
+
+    if deleted_count:
+        log.info("slowpics_uploaded_files_deleted", count=deleted_count)
+
+    return PostReportCleanupPhaseOutput(warnings=warnings)
+
+
+def _should_delete_uploaded_files_after_report(
+    ctx: RunContext,
+    *,
+    uploaded_file_paths: tuple[Path, ...],
+    report_succeeded: bool,
+) -> bool:
+    if not ctx.config.slowpics.delete_after_upload:
+        return False
+    if not uploaded_file_paths:
+        return False
+    if not ctx.config.report.enable:
+        return True
+    if not report_succeeded:
+        return False
+    return ctx.config.report.embed_images
 
 
 @dataclass(frozen=True)

--- a/src/frame_compare/orchestration/phase_tasks.py
+++ b/src/frame_compare/orchestration/phase_tasks.py
@@ -44,7 +44,6 @@ from frame_compare.orchestration.types import (
     MetadataPhaseOutput,
     MetadataPrefetch,
     PostReportCleanupPhaseOutput,
-    PostUploadActionResult,
     PublishPhaseOutput,
     RenderArtifacts,
     RenderPhaseOutput,
@@ -66,13 +65,19 @@ from frame_compare.services.report.display import (
     frame_detail_for_source_frame,
 )
 from frame_compare.services.report.entry import generate_report
-from frame_compare.services.report.payload import FrameDetail, ReportData, clip_info_from_state
-from frame_compare.services.slowpics_shortcut import create_slowpics_url_shortcut
+from frame_compare.services.report.payload import (
+    FrameDetail,
+    ReportData,
+    clip_info_from_state,
+)
+from frame_compare.services.slowpics_post_upload import (
+    SlowpicsPostUploadRequest,
+    run_slowpics_post_upload_actions,
+)
 from frame_compare.services.slowpics_upload_plan import (
     SlowpicsUploadClip,
     build_slowpics_upload_plan,
 )
-from frame_compare.services.slowpics_webhook import deliver_slowpics_webhook
 from frame_compare.services.types import AlignmentConfig, MetadataConfig, TmdbMetadata
 from frame_compare.utils.cache_errors import CacheCorruptionError, CacheVersionMismatchError
 from frame_compare.utils.types import WorkspacePaths
@@ -795,17 +800,19 @@ async def run_publish_phase(
         progress=ctx.reporter,
         upload_plan=upload_plan,
     )
-    shortcut_actions = _slowpics_shortcut_action(
-        ctx=ctx,
-        slowpics_url=result.url,
-        metadata=metadata,
-        upload_title=screenshot_dir.name,
+    post_upload_actions = await run_slowpics_post_upload_actions(
+        SlowpicsPostUploadRequest(
+            workspace=ctx.workspace,
+            config=ctx.config.slowpics,
+            slowpics_url=result.url,
+            metadata_title=metadata.title if metadata is not None else None,
+            upload_title=screenshot_dir.name,
+        )
     )
-    webhook_actions = await _slowpics_webhook_action(ctx=ctx, slowpics_url=result.url)
     return PublishPhaseOutput(
         slowpics_url=result.url,
         uploaded_file_paths=result.uploaded_file_paths,
-        post_upload_actions=(*shortcut_actions, *webhook_actions),
+        post_upload_actions=post_upload_actions,
     )
 
 
@@ -839,9 +846,7 @@ def run_confirm_slowpics_upload_phase(
             ),
         )
 
-    decision = confirm_slowpics_upload(
-        SlowpicsUploadConfirmationRequest(report_path=report_path)
-    )
+    decision = confirm_slowpics_upload(SlowpicsUploadConfirmationRequest(report_path=report_path))
     return ConfirmSlowpicsUploadPhaseOutput(status=decision)
 
 
@@ -855,82 +860,6 @@ def _slowpics_upload_clips(ctx: RunContext) -> list[SlowpicsUploadClip]:
         seen_labels.add(clip.label)
         upload_clips.append(SlowpicsUploadClip(label=clip.label, image_name=clip.path.stem))
     return upload_clips
-
-
-def _slowpics_shortcut_action(
-    *,
-    ctx: RunContext,
-    slowpics_url: str,
-    metadata: TmdbMetadata | None,
-    upload_title: str | None,
-) -> tuple[PostUploadActionResult, ...]:
-    if not ctx.config.slowpics.create_url_shortcut:
-        return ()
-
-    result = create_slowpics_url_shortcut(
-        workspace=ctx.workspace,
-        slowpics_url=slowpics_url,
-        metadata_title=metadata.title if metadata is not None else None,
-        upload_title=upload_title,
-    )
-    if result.success:
-        return (
-            PostUploadActionResult(
-                kind="shortcut",
-                success=True,
-                path=result.path,
-                message="slow.pics URL shortcut written",
-            ),
-        )
-
-    if result.warning is not None:
-        log.warning(
-            "slowpics_shortcut_create_failed",
-            path=str(result.path) if result.path is not None else None,
-            warning=result.warning,
-        )
-    return (
-        PostUploadActionResult(
-            kind="shortcut",
-            success=False,
-            path=result.path,
-            warning=result.warning,
-        ),
-    )
-
-
-async def _slowpics_webhook_action(
-    *,
-    ctx: RunContext,
-    slowpics_url: str,
-) -> tuple[PostUploadActionResult, ...]:
-    webhook_url = ctx.config.slowpics.webhook_url
-    if webhook_url is None:
-        return ()
-
-    result = await deliver_slowpics_webhook(
-        webhook_url=webhook_url,
-        slowpics_url=slowpics_url,
-    )
-    if result.success:
-        return (
-            PostUploadActionResult(
-                kind="webhook",
-                success=True,
-                detail=result.detail,
-                message="slow.pics webhook delivered",
-            ),
-        )
-
-    if result.warning is not None:
-        log.warning("slowpics_webhook_delivery_failed", warning=result.warning)
-    return (
-        PostUploadActionResult(
-            kind="webhook",
-            success=False,
-            warning=result.warning,
-        ),
-    )
 
 
 def run_report_phase(

--- a/src/frame_compare/orchestration/types.py
+++ b/src/frame_compare/orchestration/types.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import httpx
 
@@ -99,6 +99,24 @@ def _empty_selection_details_by_source_frame() -> SelectionDetailsByFrame:
     return {}
 
 
+type PostUploadActionKind = Literal["clipboard", "browser", "shortcut", "webhook"]
+
+
+@dataclass(frozen=True)
+class PostUploadActionResult:
+    """Internal result for an optional post-upload side effect."""
+
+    kind: PostUploadActionKind
+    success: bool
+    detail: str | None = None
+    path: Path | None = None
+    message: str | None = None
+    warning: str | None = None
+
+
+type PostUploadActionResults = tuple[PostUploadActionResult, ...]
+
+
 @dataclass(frozen=True)
 class RunResult:
     """Complete result from a comparison run."""
@@ -108,6 +126,7 @@ class RunResult:
     screenshot_dir: Path | None = None
     slowpics_url: str | None = None
     report_path: Path | None = None
+    post_upload_actions: PostUploadActionResults = ()
 
     # Metrics
     frame_count: int = 0
@@ -184,6 +203,7 @@ class DoviPhaseOutput:
 class PublishPhaseOutput:
     slowpics_url: str | None
     uploaded_file_paths: tuple[Path, ...] = ()
+    post_upload_actions: PostUploadActionResults = ()
 
 
 @dataclass(frozen=True)
@@ -218,6 +238,7 @@ class RunArtifacts:
     render: RenderArtifacts | None
     slowpics_url: str | None
     uploaded_slowpics_file_paths: tuple[Path, ...]
+    post_upload_actions: PostUploadActionResults
     report_path: Path | None
     report_succeeded: bool
     resolved_metadata: TmdbMetadata | None
@@ -229,6 +250,7 @@ class RunArtifacts:
         metrics_cache_hit: bool = False,
         slowpics_url: str | None = None,
         uploaded_slowpics_file_paths: tuple[Path, ...] = (),
+        post_upload_actions: PostUploadActionResults = (),
         report_path: Path | None = None,
         report_succeeded: bool = False,
         resolved_metadata: TmdbMetadata | None = None,
@@ -239,6 +261,7 @@ class RunArtifacts:
         self.render = render
         self.slowpics_url = slowpics_url
         self.uploaded_slowpics_file_paths = uploaded_slowpics_file_paths
+        self.post_upload_actions = post_upload_actions
         self.report_path = report_path
         self.report_succeeded = report_succeeded
         self.resolved_metadata = resolved_metadata

--- a/src/frame_compare/orchestration/types.py
+++ b/src/frame_compare/orchestration/types.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Protocol
 
 import httpx
 
@@ -101,6 +101,30 @@ def _empty_selection_details_by_source_frame() -> SelectionDetailsByFrame:
 
 type PostUploadActionKind = Literal["clipboard", "browser", "shortcut", "webhook"]
 
+type SlowpicsUploadConfirmationDecision = Literal["confirmed", "declined"]
+type SlowpicsUploadConfirmationStatus = Literal[
+    "not_applicable",
+    "confirmed",
+    "declined",
+    "report_unavailable",
+]
+
+
+@dataclass(frozen=True)
+class SlowpicsUploadConfirmationRequest:
+    """Request passed to the CLI-owned slow.pics upload confirmation callback."""
+
+    report_path: Path
+
+
+class SlowpicsUploadConfirmationFn(Protocol):
+    """CLI-owned callback for report-confirmed slow.pics upload decisions."""
+
+    def __call__(
+        self,
+        request: SlowpicsUploadConfirmationRequest,
+    ) -> SlowpicsUploadConfirmationDecision: ...
+
 
 @dataclass(frozen=True)
 class PostUploadActionResult:
@@ -127,6 +151,7 @@ class RunResult:
     slowpics_url: str | None = None
     report_path: Path | None = None
     post_upload_actions: PostUploadActionResults = ()
+    slowpics_upload_confirmation_status: SlowpicsUploadConfirmationStatus = "not_applicable"
 
     # Metrics
     frame_count: int = 0
@@ -148,6 +173,7 @@ class RunDependencies:
     ffmpeg_runner: FFmpegRunner | None = None
     http_client: httpx.AsyncClient | None = None
     progress: ProgressReporter | None = None
+    confirm_slowpics_upload: SlowpicsUploadConfirmationFn | None = None
     clock: Callable[[], datetime] = field(default=datetime.now)
 
 
@@ -213,6 +239,12 @@ class ReportPhaseOutput:
 
 
 @dataclass(frozen=True)
+class ConfirmSlowpicsUploadPhaseOutput:
+    status: SlowpicsUploadConfirmationStatus
+    warnings: list[str] = field(default_factory=_empty_str_list)
+
+
+@dataclass(frozen=True)
 class PostReportCleanupPhaseOutput:
     warnings: list[str] = field(default_factory=_empty_str_list)
 
@@ -226,6 +258,7 @@ type PhaseOutput = (
     | DoviPhaseOutput
     | PublishPhaseOutput
     | ReportPhaseOutput
+    | ConfirmSlowpicsUploadPhaseOutput
     | PostReportCleanupPhaseOutput
 )
 
@@ -239,6 +272,7 @@ class RunArtifacts:
     slowpics_url: str | None
     uploaded_slowpics_file_paths: tuple[Path, ...]
     post_upload_actions: PostUploadActionResults
+    slowpics_upload_confirmation_status: SlowpicsUploadConfirmationStatus
     report_path: Path | None
     report_succeeded: bool
     resolved_metadata: TmdbMetadata | None
@@ -251,6 +285,7 @@ class RunArtifacts:
         slowpics_url: str | None = None,
         uploaded_slowpics_file_paths: tuple[Path, ...] = (),
         post_upload_actions: PostUploadActionResults = (),
+        slowpics_upload_confirmation_status: SlowpicsUploadConfirmationStatus = "not_applicable",
         report_path: Path | None = None,
         report_succeeded: bool = False,
         resolved_metadata: TmdbMetadata | None = None,
@@ -262,6 +297,7 @@ class RunArtifacts:
         self.slowpics_url = slowpics_url
         self.uploaded_slowpics_file_paths = uploaded_slowpics_file_paths
         self.post_upload_actions = post_upload_actions
+        self.slowpics_upload_confirmation_status = slowpics_upload_confirmation_status
         self.report_path = report_path
         self.report_succeeded = report_succeeded
         self.resolved_metadata = resolved_metadata

--- a/src/frame_compare/orchestration/types.py
+++ b/src/frame_compare/orchestration/types.py
@@ -20,6 +20,7 @@ from frame_compare.config.schema import ConfigSchema, OverlayMode, ToneCurve, To
 from frame_compare.orchestration.context import ClipState
 from frame_compare.render.backend.ffmpeg import FFmpegRunner
 from frame_compare.services.types import TmdbMetadata
+from frame_compare.utils.post_upload_actions import PostUploadActionResult
 from frame_compare.utils.progress_protocol import ProgressReporter
 from frame_compare.utils.types import WorkspacePaths
 from frame_compare.vs.loader import VSLoader
@@ -99,8 +100,6 @@ def _empty_selection_details_by_source_frame() -> SelectionDetailsByFrame:
     return {}
 
 
-type PostUploadActionKind = Literal["clipboard", "browser", "shortcut", "webhook"]
-
 type SlowpicsUploadConfirmationDecision = Literal["confirmed", "declined"]
 type SlowpicsUploadConfirmationStatus = Literal[
     "not_applicable",
@@ -108,6 +107,7 @@ type SlowpicsUploadConfirmationStatus = Literal[
     "declined",
     "report_unavailable",
 ]
+type PostUploadActionResults = tuple[PostUploadActionResult, ...]
 
 
 @dataclass(frozen=True)
@@ -124,21 +124,6 @@ class SlowpicsUploadConfirmationFn(Protocol):
         self,
         request: SlowpicsUploadConfirmationRequest,
     ) -> SlowpicsUploadConfirmationDecision: ...
-
-
-@dataclass(frozen=True)
-class PostUploadActionResult:
-    """Internal result for an optional post-upload side effect."""
-
-    kind: PostUploadActionKind
-    success: bool
-    detail: str | None = None
-    path: Path | None = None
-    message: str | None = None
-    warning: str | None = None
-
-
-type PostUploadActionResults = tuple[PostUploadActionResult, ...]
 
 
 @dataclass(frozen=True)

--- a/src/frame_compare/orchestration/types.py
+++ b/src/frame_compare/orchestration/types.py
@@ -183,11 +183,18 @@ class DoviPhaseOutput:
 @dataclass(frozen=True)
 class PublishPhaseOutput:
     slowpics_url: str | None
+    uploaded_file_paths: tuple[Path, ...] = ()
 
 
 @dataclass(frozen=True)
 class ReportPhaseOutput:
     report_path: Path | None
+    report_succeeded: bool = False
+
+
+@dataclass(frozen=True)
+class PostReportCleanupPhaseOutput:
+    warnings: list[str] = field(default_factory=_empty_str_list)
 
 
 type PhaseOutput = (
@@ -199,6 +206,7 @@ type PhaseOutput = (
     | DoviPhaseOutput
     | PublishPhaseOutput
     | ReportPhaseOutput
+    | PostReportCleanupPhaseOutput
 )
 
 
@@ -209,7 +217,9 @@ class RunArtifacts:
     metrics_cache_hit: bool
     render: RenderArtifacts | None
     slowpics_url: str | None
+    uploaded_slowpics_file_paths: tuple[Path, ...]
     report_path: Path | None
+    report_succeeded: bool
     resolved_metadata: TmdbMetadata | None
     warnings: list[str]
 
@@ -218,7 +228,9 @@ class RunArtifacts:
         *,
         metrics_cache_hit: bool = False,
         slowpics_url: str | None = None,
+        uploaded_slowpics_file_paths: tuple[Path, ...] = (),
         report_path: Path | None = None,
+        report_succeeded: bool = False,
         resolved_metadata: TmdbMetadata | None = None,
         warnings: list[str] | None = None,
         render: RenderArtifacts | None = None,
@@ -226,7 +238,9 @@ class RunArtifacts:
         self.metrics_cache_hit = metrics_cache_hit
         self.render = render
         self.slowpics_url = slowpics_url
+        self.uploaded_slowpics_file_paths = uploaded_slowpics_file_paths
         self.report_path = report_path
+        self.report_succeeded = report_succeeded
         self.resolved_metadata = resolved_metadata
         self.warnings = [] if warnings is None else warnings
 

--- a/src/frame_compare/services/publishers.py
+++ b/src/frame_compare/services/publishers.py
@@ -2,33 +2,50 @@
 
 import asyncio
 import random
-import warnings
+from collections.abc import Awaitable, Callable
 from contextlib import ExitStack
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from pathlib import Path
 from time import monotonic
-from typing import BinaryIO
+from typing import cast
+from urllib.parse import unquote
+from uuid import uuid4
 
 import httpx
 import structlog
 
+from frame_compare import __version__
 from frame_compare.config.schema import SlowpicsConfig, Visibility
 from frame_compare.services.errors import (
     SlowpicsError,
     SlowpicsRateLimitedError,
     SlowpicsUnavailableError,
 )
+from frame_compare.services.slowpics_upload_plan import SlowpicsUploadPlan
 from frame_compare.services.types import TmdbMetadata
 from frame_compare.utils.progress_protocol import ProgressReporter
 
 log = structlog.get_logger()
 
-SLOWPICS_UPLOAD_URL = "https://slow.pics/api/comparison"
+SLOWPICS_BASE_URL = "https://slow.pics"
+SLOWPICS_COMPARISON_URL = f"{SLOWPICS_BASE_URL}/comparison"
+SLOWPICS_METADATA_UPLOAD_URL = f"{SLOWPICS_BASE_URL}/upload/comparison"
+SLOWPICS_IMAGE_UPLOAD_URL_TEMPLATE = f"{SLOWPICS_BASE_URL}/upload/image/{{image_uuid}}"
 SLOWPICS_RETRY_BASE_DELAY_SECONDS = 1.0
 SLOWPICS_RETRY_MAX_DELAY_SECONDS = 30.0
 SLOWPICS_RETRY_JITTER_FACTOR = 0.1
+SLOWPICS_BROWSER_ID_SENTINEL = "eb80db10-97a7-11ee-8f6f-bfa69501bb51"
+SLOWPICS_USER_AGENT = f"frame-compare/{__version__} slowpics-direct"
+SLOWPICS_UPLOAD_HEADERS = {
+    "Origin": SLOWPICS_BASE_URL,
+    "Referer": SLOWPICS_COMPARISON_URL,
+    "User-Agent": SLOWPICS_USER_AGENT,
+}
+SLOWPICS_NAVIGATION_HEADERS = {"User-Agent": SLOWPICS_USER_AGENT}
+
+type _MultipartTextFields = list[tuple[str, tuple[None, str]]]
 
 
 @dataclass(frozen=True)
@@ -38,20 +55,17 @@ class PublishResult:
     url: str
     screenshot_count: int
     upload_duration_seconds: float
+    uploaded_file_paths: tuple[Path, ...]
 
 
-@dataclass(frozen=True)
-class _SlowpicsUploadRequest:
-    """Prepared slow.pics multipart payload for httpx.
+@dataclass(frozen=True, slots=True)
+class _SlowpicsMetadataResponse:
+    """Validated slow.pics metadata response needed for image uploads."""
 
-    Notes:
-        This uses `data=` + `files=` to send multipart form data. Image paths are
-        persisted here, and file handles are opened per-attempt during upload so retry
-        logic can stream fresh handles without retaining image bytes in memory.
-    """
-
-    data: dict[str, str]
-    file_paths: list[Path]
+    key: str
+    first_comparison_key: str | None
+    collection_uuid: str
+    image_uuids: tuple[tuple[str, ...], ...]
 
 
 class SlowpicsPublisher:
@@ -61,15 +75,11 @@ class SlowpicsPublisher:
         self.config = config
         self._client = client
 
-    async def upload(
-        self,
-        files: list[Path],
-        title: str | None = None,
-    ) -> str:
+    async def upload(self, upload_plan: SlowpicsUploadPlan, title: str | None = None) -> str:
         """Upload screenshots to slow.pics.
 
         Args:
-            files: List of PNG files to upload.
+            upload_plan: Planned rows/images to upload.
             title: Optional title for the comparison.
 
         Returns:
@@ -80,11 +90,12 @@ class SlowpicsPublisher:
             SlowpicsRateLimitedError: If rate limited after retries.
             SlowpicsUnavailableError: If service is down after retries.
         """
+        files = upload_plan.file_paths
         if not files:
             raise SlowpicsError("No PNG files found to upload")
+        _validate_upload_files(files)
 
         visibility = self.config.visibility
-        request = self._prepare_upload(files, title, visibility)
         log.info(
             "slowpics_upload_start",
             file_count=len(files),
@@ -93,43 +104,34 @@ class SlowpicsPublisher:
         )
 
         try:
-            response = await self._upload_with_retry(
-                self._client,
-                request,
-                self.config.max_retries,
-                self.config.timeout_seconds,
+            await self._get_comparison_page_with_retry()
+            xsrf_token = _xsrf_token_from_cookies(self._client)
+            browser_id = _browser_id_from_cookies(self._client)
+            metadata_response = await self._create_metadata_with_retry(
+                upload_plan=upload_plan,
+                title=title,
+                visibility=visibility,
+                xsrf_token=xsrf_token,
+                browser_id=browser_id,
             )
-
-            try:
-                result = response.json()
-                url = str(result["url"])
-            except (ValueError, KeyError) as e:
-                raise SlowpicsError(f"Invalid response from slow.pics: {e}") from e
-
-            log.info("slowpics_upload_complete", url=url)
+            await self._upload_planned_images_with_retry(
+                upload_plan=upload_plan,
+                metadata_response=metadata_response,
+                xsrf_token=xsrf_token,
+                browser_id=browser_id,
+            )
+            url_key = metadata_response.first_comparison_key or metadata_response.key
+            url = f"{SLOWPICS_BASE_URL}/c/{url_key}"
+            log.info("slowpics_upload_complete")
             return url
 
-        except Exception as e:
+        except Exception as exc:
             if isinstance(
-                e,
+                exc,
                 SlowpicsError | SlowpicsRateLimitedError | SlowpicsUnavailableError,
             ):
                 raise
-            raise SlowpicsError(f"Upload failed: {e}") from e
-
-    def _prepare_upload(
-        self, files: list[Path], title: str | None, visibility: Visibility
-    ) -> _SlowpicsUploadRequest:
-        """Prepare the slow.pics multipart payload for upload."""
-        form_data: dict[str, str] = {
-            "collectionName": title or "Comparison",
-            "optimize": "true",
-            "lossy": "true",
-        }
-
-        form_data["public"] = "true" if visibility is Visibility.PUBLIC else "false"
-
-        return _SlowpicsUploadRequest(file_paths=list(files), data=form_data)
+            raise SlowpicsError("Upload failed for slow.pics") from None
 
     async def _sleep_with_backoff(
         self,
@@ -177,27 +179,6 @@ class SlowpicsPublisher:
     def _has_retry_budget(self, attempt: int, max_retries: int) -> bool:
         return attempt <= max_retries
 
-    async def _post_upload_attempt(
-        self,
-        client: httpx.AsyncClient,
-        request: _SlowpicsUploadRequest,
-        timeout_seconds: float,
-    ) -> httpx.Response:
-        # Stream files per-attempt to avoid keeping all PNG bytes in memory and
-        # to ensure retries always read fresh file handles.
-        with ExitStack() as stack:
-            multipart_files: list[tuple[str, tuple[str, BinaryIO, str]]] = []
-            for file_path in request.file_paths:
-                file_handle = stack.enter_context(file_path.open("rb"))
-                multipart_files.append(("images", (file_path.name, file_handle, "image/png")))
-
-            return await client.post(
-                SLOWPICS_UPLOAD_URL,
-                timeout=timeout_seconds,
-                data=request.data,
-                files=multipart_files,
-            )
-
     async def _handle_retryable_status(
         self, response: httpx.Response, attempt: int, max_retries: int
     ) -> None:
@@ -228,13 +209,13 @@ class SlowpicsPublisher:
             )
             return
 
-        raise SlowpicsError(f"Upload failed with status {response.status_code}: {response.text}")
+        raise SlowpicsError(f"Upload failed with status {response.status_code}")
 
     async def _handle_timeout(
         self, error: httpx.TimeoutException, attempt: int, max_retries: int
     ) -> None:
         if not self._has_retry_budget(attempt, max_retries):
-            raise SlowpicsError(f"Upload timed out after {max_retries} retries") from error
+            raise SlowpicsError(f"Upload timed out after {max_retries} retries") from None
 
         sleep_time = await self._sleep_with_backoff(attempt)
         log.warning(
@@ -247,40 +228,166 @@ class SlowpicsPublisher:
         self, error: httpx.RequestError, attempt: int, max_retries: int
     ) -> None:
         if not self._has_retry_budget(attempt, max_retries):
-            raise SlowpicsUnavailableError() from error
+            raise SlowpicsUnavailableError() from None
 
         sleep_time = await self._sleep_with_backoff(attempt)
         log.warning(
             "slowpics_connection_error",
-            error=str(error),
             attempt=attempt,
             retry_in=sleep_time,
         )
 
-    async def _upload_with_retry(
+    async def _get_comparison_page_with_retry(self) -> None:
+        response = await self._request_with_retry(
+            step="comparison_page",
+            request=lambda: self._client.get(
+                SLOWPICS_COMPARISON_URL,
+                timeout=self.config.timeout_seconds,
+                headers=SLOWPICS_NAVIGATION_HEADERS,
+            ),
+            max_retries=self.config.max_retries,
+            retry_timeout=True,
+            retry_request_error=True,
+        )
+        if not response.is_success:
+            raise SlowpicsError(f"Comparison page failed with status {response.status_code}")
+
+    async def _create_metadata_with_retry(
         self,
-        client: httpx.AsyncClient,
-        request: _SlowpicsUploadRequest,
-        max_retries: int,
-        timeout_seconds: float,
+        *,
+        upload_plan: SlowpicsUploadPlan,
+        title: str | None,
+        visibility: Visibility,
+        xsrf_token: str,
+        browser_id: str,
+    ) -> _SlowpicsMetadataResponse:
+        response = await self._request_with_retry(
+            step="metadata",
+            request=lambda: self._client.post(
+                SLOWPICS_METADATA_UPLOAD_URL,
+                timeout=self.config.timeout_seconds,
+                headers=_slowpics_upload_headers(xsrf_token),
+                files=_metadata_multipart_fields(
+                    upload_plan=upload_plan,
+                    title=title,
+                    visibility=visibility,
+                    browser_id=browser_id,
+                ),
+            ),
+            max_retries=self.config.max_retries,
+            retry_timeout=False,
+            retry_request_error=False,
+        )
+        if not response.is_success:
+            raise SlowpicsError(f"Metadata upload failed with status {response.status_code}")
+        return _parse_metadata_response(response, upload_plan)
+
+    async def _upload_planned_images_with_retry(
+        self,
+        *,
+        upload_plan: SlowpicsUploadPlan,
+        metadata_response: _SlowpicsMetadataResponse,
+        xsrf_token: str,
+        browser_id: str,
+    ) -> None:
+        for row, image_uuids in zip(upload_plan.rows, metadata_response.image_uuids, strict=True):
+            for image, image_uuid in zip(row.images, image_uuids, strict=True):
+                await self._upload_image_with_retry(
+                    image_path=image.screenshot_path,
+                    image_uuid=image_uuid,
+                    collection_uuid=metadata_response.collection_uuid,
+                    xsrf_token=xsrf_token,
+                    browser_id=browser_id,
+                )
+
+    async def _upload_image_with_retry(
+        self,
+        *,
+        image_path: Path,
+        image_uuid: str,
+        collection_uuid: str,
+        xsrf_token: str,
+        browser_id: str,
+    ) -> None:
+        response = await self._request_with_retry(
+            step="image",
+            request=lambda: self._post_image_attempt(
+                image_path=image_path,
+                image_uuid=image_uuid,
+                collection_uuid=collection_uuid,
+                xsrf_token=xsrf_token,
+                browser_id=browser_id,
+            ),
+            max_retries=self.config.max_retries,
+            retry_timeout=True,
+            retry_request_error=True,
+        )
+        if response.status_code == 200:
+            return
+        if (
+            response.status_code == 400
+            and response.headers.get("X-Error-Message") == "IMAGE_IS_COMPLETE"
+        ):
+            return
+        raise SlowpicsError(f"Image upload failed with status {response.status_code}")
+
+    async def _post_image_attempt(
+        self,
+        *,
+        image_path: Path,
+        image_uuid: str,
+        collection_uuid: str,
+        xsrf_token: str,
+        browser_id: str,
     ) -> httpx.Response:
-        """Upload with exponential backoff."""
+        with ExitStack() as stack:
+            file_handle = stack.enter_context(image_path.open("rb"))
+            return await self._client.post(
+                SLOWPICS_IMAGE_UPLOAD_URL_TEMPLATE.format(image_uuid=image_uuid),
+                timeout=self.config.timeout_seconds,
+                headers=_slowpics_upload_headers(xsrf_token),
+                data={
+                    "collectionUuid": collection_uuid,
+                    "imageUuid": image_uuid,
+                    "browserId": browser_id,
+                },
+                files={"file": (image_path.name, file_handle, "image/png")},
+            )
+
+    async def _request_with_retry(
+        self,
+        *,
+        step: str,
+        request: Callable[[], Awaitable[httpx.Response]],
+        max_retries: int,
+        retry_timeout: bool,
+        retry_request_error: bool,
+    ) -> httpx.Response:
+        """Run one slow.pics HTTP step with step-specific retry policy."""
         attempt = 0
 
         while True:
             attempt += 1
             try:
-                response = await self._post_upload_attempt(client, request, timeout_seconds)
+                response = await request()
 
-                if response.is_success:
+                if response.is_success or _is_complete_image_response(step, response):
                     return response
 
                 await self._handle_retryable_status(response, attempt, max_retries)
 
             except httpx.TimeoutException as e:
+                if not retry_timeout:
+                    raise SlowpicsError(
+                        "Metadata upload failed; remote slow.pics state is unknown"
+                    ) from None
                 await self._handle_timeout(e, attempt, max_retries)
 
             except httpx.RequestError as e:
+                if not retry_request_error:
+                    raise SlowpicsError(
+                        "Metadata upload failed; remote slow.pics state is unknown"
+                    ) from None
                 await self._handle_request_error(e, attempt, max_retries)
 
 
@@ -290,24 +397,29 @@ async def publish_to_slowpics(
     client: httpx.AsyncClient,
     metadata: TmdbMetadata | None = None,
     progress: ProgressReporter | None = None,
+    upload_plan: SlowpicsUploadPlan | None = None,
 ) -> PublishResult:
-    """Convenience function to publish screenshots from a directory.
+    """Publish screenshots through the browser-compatible slow.pics upload flow.
 
     Args:
-        screenshot_dir: Directory containing PNG screenshots.
+        screenshot_dir: Screenshot directory, used for title fallback.
         config: Slowpics configuration.
         client: HTTP client to use.
         metadata: Optional metadata for title.
         progress: Optional progress reporter.
+        upload_plan: Explicit row-major upload plan.
 
     Returns:
         PublishResult containing the URL.
     """
     start_time = monotonic()
 
-    files = sorted(screenshot_dir.glob("*.png"))
+    if upload_plan is None:
+        raise SlowpicsError("No slow.pics upload plan available")
+    files = upload_plan.file_paths
     if not files:
-        raise SlowpicsError(f"No PNG files found in {screenshot_dir}")
+        raise SlowpicsError("No PNG files found to upload")
+    _validate_upload_files(files)
 
     title = metadata.title if metadata else screenshot_dir.name
 
@@ -315,21 +427,7 @@ async def publish_to_slowpics(
         progress.set_description("Uploading screenshots to slow.pics")
 
     publisher = SlowpicsPublisher(config, client)
-    url = await publisher.upload(files, title)
-
-    # Deletion semantics
-    if config.delete_after_upload:
-        try:
-            for f in files:
-                f.unlink()
-            log.info("slowpics_files_deleted", count=len(files))
-        except OSError as e:
-            warnings.warn(
-                f"Failed to delete files after upload: {e}",
-                RuntimeWarning,
-                stacklevel=2,
-            )
-            log.warning("slowpics_deletion_failed", error=str(e))
+    url = await publisher.upload(upload_plan, title)
 
     duration = monotonic() - start_time
 
@@ -337,4 +435,139 @@ async def publish_to_slowpics(
         url=url,
         screenshot_count=len(files),
         upload_duration_seconds=duration,
+        uploaded_file_paths=tuple(files),
+    )
+
+
+def _validate_upload_files(files: list[Path]) -> None:
+    for file_path in files:
+        if not file_path.is_file():
+            raise SlowpicsError(f"PNG file planned for slow.pics upload is missing: {file_path}")
+
+
+def _xsrf_token_from_cookies(client: httpx.AsyncClient) -> str:
+    raw_token = client.cookies.get("XSRF-TOKEN")
+    if raw_token is None or not raw_token:
+        raise SlowpicsError("Missing slow.pics XSRF token")
+    return unquote(raw_token)
+
+
+def _browser_id_from_cookies(client: httpx.AsyncClient) -> str:
+    browser_id = client.cookies.get("BROWSER-ID")
+    if browser_id is None or browser_id == SLOWPICS_BROWSER_ID_SENTINEL or not browser_id:
+        browser_id = str(uuid4())
+        client.cookies.set("BROWSER-ID", browser_id, domain="slow.pics", path="/")
+    return browser_id
+
+
+def _slowpics_upload_headers(xsrf_token: str) -> dict[str, str]:
+    return {**SLOWPICS_UPLOAD_HEADERS, "X-XSRF-TOKEN": xsrf_token}
+
+
+def _metadata_multipart_fields(
+    *,
+    upload_plan: SlowpicsUploadPlan,
+    title: str | None,
+    visibility: Visibility,
+    browser_id: str,
+) -> _MultipartTextFields:
+    fields: list[tuple[str, str]] = [
+        ("collectionName", title or "Comparison"),
+        ("browserId", browser_id),
+        ("optimizeImages", "true"),
+        ("desiredFileType", "image/png"),
+        ("hentai", "false"),
+        ("public", "true" if visibility is Visibility.PUBLIC else "false"),
+        ("visibility", "PUBLIC" if visibility is Visibility.PUBLIC else "UNLISTED"),
+        ("removeAfter", ""),
+    ]
+    for row in upload_plan.rows:
+        row_prefix = f"comparisons[{row.row_index}]"
+        fields.extend(
+            [
+                (f"{row_prefix}.name", row.row_name),
+                (f"{row_prefix}.hentai", "false"),
+                (f"{row_prefix}.sortOrder", str(row.sort_order)),
+            ]
+        )
+        for image in row.images:
+            image_prefix = f"{row_prefix}.images[{image.image_index}]"
+            fields.extend(
+                [
+                    (f"{image_prefix}.name", image.image_name),
+                    (f"{image_prefix}.sortOrder", str(image.sort_order)),
+                ]
+            )
+    return [(name, (None, value)) for name, value in fields]
+
+
+def _parse_metadata_response(
+    response: httpx.Response, upload_plan: SlowpicsUploadPlan
+) -> _SlowpicsMetadataResponse:
+    try:
+        payload = cast(object, response.json())
+    except ValueError:
+        raise SlowpicsError("Invalid metadata response from slow.pics") from None
+    if not isinstance(payload, dict):
+        raise SlowpicsError("Invalid metadata response from slow.pics")
+    response_payload = cast(dict[object, object], payload)
+
+    key = _required_response_string(response_payload, "key")
+    first_comparison_key = _optional_response_string(response_payload, "firstComparisonKey")
+    collection_uuid = _required_response_string(response_payload, "collectionUuid")
+    image_uuids = _response_image_matrix(response_payload.get("images"), upload_plan)
+    return _SlowpicsMetadataResponse(
+        key=key,
+        first_comparison_key=first_comparison_key,
+        collection_uuid=collection_uuid,
+        image_uuids=image_uuids,
+    )
+
+
+def _required_response_string(payload: dict[object, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise SlowpicsError("Invalid metadata response from slow.pics")
+    return value
+
+
+def _optional_response_string(payload: dict[object, object], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise SlowpicsError("Invalid metadata response from slow.pics")
+    return value
+
+
+def _response_image_matrix(
+    raw_images: object, upload_plan: SlowpicsUploadPlan
+) -> tuple[tuple[str, ...], ...]:
+    if not isinstance(raw_images, list):
+        raise SlowpicsError("Invalid metadata response from slow.pics")
+    raw_rows = cast(list[object], raw_images)
+    if len(raw_rows) != len(upload_plan.rows):
+        raise SlowpicsError("Invalid metadata response from slow.pics")
+
+    rows: list[tuple[str, ...]] = []
+    for raw_row, planned_row in zip(raw_rows, upload_plan.rows, strict=True):
+        if not isinstance(raw_row, list):
+            raise SlowpicsError("Invalid metadata response from slow.pics")
+        raw_image_uuids = cast(list[object], raw_row)
+        if len(raw_image_uuids) != len(planned_row.images):
+            raise SlowpicsError("Invalid metadata response from slow.pics")
+        image_uuids: list[str] = []
+        for raw_image_uuid in raw_image_uuids:
+            if not isinstance(raw_image_uuid, str) or not raw_image_uuid:
+                raise SlowpicsError("Invalid metadata response from slow.pics")
+            image_uuids.append(raw_image_uuid)
+        rows.append(tuple(image_uuids))
+    return tuple(rows)
+
+
+def _is_complete_image_response(step: str, response: httpx.Response) -> bool:
+    return (
+        step == "image"
+        and response.status_code == 400
+        and response.headers.get("X-Error-Message") == "IMAGE_IS_COMPLETE"
     )

--- a/src/frame_compare/services/report/assets/viewer.css
+++ b/src/frame_compare/services/report/assets/viewer.css
@@ -106,7 +106,8 @@ body {
     text-decoration: underline;
 }
 
-.rv-header-help-btn {
+.rv-header-help-btn,
+.rv-header-info-btn {
     background: var(--bg-elevated);
     border: 1px solid var(--border);
     color: var(--text-secondary);
@@ -121,10 +122,12 @@ body {
     transition: all 0.2s;
 }
 
-.rv-header-help-btn:hover {
+.rv-header-help-btn:hover,
+.rv-header-info-btn:hover {
     border-color: var(--border-active);
     color: var(--text-primary);
 }
+
 
 /* 4. Controls Toolbar */
 .rv-controls {
@@ -827,3 +830,81 @@ select {
         border-bottom: none;
     }
 }
+
+/* 13. Info Modal Content Styling */
+.rv-info-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    max-height: 450px;
+    overflow-y: auto;
+    padding-right: 0.5rem;
+}
+
+.rv-info-section h3 {
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--accent);
+    margin-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.25rem;
+}
+
+.rv-metadata-list {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    gap: 0.35rem 1rem;
+    font-size: var(--text-xs);
+}
+
+.rv-metadata-list div {
+    display: contents;
+}
+
+.rv-metadata-list dt {
+    color: var(--text-muted);
+}
+
+.rv-metadata-list dd {
+    color: var(--text-primary);
+    overflow-wrap: anywhere;
+}
+
+.rv-clip-meta-list {
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.rv-clip-meta-item {
+    display: grid;
+    gap: 0.25rem;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.5rem;
+}
+
+.rv-clip-meta-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    color: var(--text-primary);
+    font-size: var(--text-xs);
+    font-weight: 600;
+}
+
+.rv-clip-meta-heading span:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.rv-clip-meta-heading span:last-child {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--accent-hover);
+}
+

--- a/src/frame_compare/services/report/assets/viewer.css
+++ b/src/frame_compare/services/report/assets/viewer.css
@@ -1,4 +1,6 @@
 :root {
+    color-scheme: dark;
+
     /* 1. Design Tokens - Theme Colors */
     --bg-primary: #0f1115;
     --bg-surface: #1a1d24;
@@ -17,7 +19,7 @@
     --divider: #5ba4e6;
 
     /* Spacing & Sizes */
-    --font-sans: -apple-system, "BlinkMacSystemFont", "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+    --font-sans: "Inter", "SF Pro Text", "Segoe UI Variable Text", "Segoe UI", system-ui, -apple-system, "BlinkMacSystemFont", sans-serif;
     --font-mono: "SF Mono", Monaco, "Cascadia Code", Consolas, monospace;
     --text-xs: 0.75rem;
     --text-sm: 0.875rem;
@@ -37,6 +39,7 @@ body {
     background: var(--bg-primary);
     color: var(--text-primary);
     font-family: var(--font-sans);
+    font-optical-sizing: auto;
     height: 100vh;
     display: flex;
     flex-direction: column;
@@ -193,13 +196,38 @@ button:disabled {
 }
 
 select {
-    padding-right: 1.25rem;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    padding-right: 1.9rem;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6' fill='none'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%2392b9df' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.55rem center;
+    background-size: 0.7rem auto;
+}
+
+select::-ms-expand {
+    display: none;
+}
+
+select option,
+select optgroup {
+    background: var(--bg-elevated);
+    color: var(--text-primary);
 }
 
 .rv-number-input {
     width: 4rem;
     cursor: text;
     text-align: center;
+    -moz-appearance: textfield;
+    appearance: textfield;
+}
+
+.rv-number-input::-webkit-outer-spin-button,
+.rv-number-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
 }
 
 .rv-clip-prefix {
@@ -215,6 +243,13 @@ select {
     font-weight: 500;
     user-select: none;
     margin: 0 0.1rem;
+}
+
+.rv-swap-button {
+    min-width: 2rem;
+    padding: 0.25rem 0.5rem;
+    font-size: var(--text-sm);
+    line-height: 1;
 }
 
 /* Custom Zoom Slider Styling */
@@ -242,6 +277,25 @@ select {
 }
 
 #zoom-range::-webkit-slider-thumb:hover {
+    background: var(--accent-hover);
+}
+
+#zoom-range::-moz-range-track {
+    background: transparent;
+    border: none;
+}
+
+#zoom-range::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--accent);
+    border: 1px solid rgba(255,255,255,0.1);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.5);
+    transition: background-color 0.15s;
+}
+
+#zoom-range:hover::-moz-range-thumb {
     background: var(--accent-hover);
 }
 
@@ -338,6 +392,11 @@ select {
     pointer-events: none;
 }
 
+.rv-canvas--pixelated .rv-image {
+    image-rendering: crisp-edges;
+    image-rendering: pixelated;
+}
+
 .rv-layer {
     position: absolute;
     inset: 0;
@@ -426,8 +485,8 @@ select {
 /* Labels overlay on image */
 .rv-overlay-label {
     position: absolute;
-    top: 12px;
-    left: 12px;
+    bottom: 16px;
+    left: 16px;
     background: rgba(11, 13, 16, 0.75);
     padding: 4px 10px;
     border-radius: 4px;
@@ -438,11 +497,15 @@ select {
     border: 1px solid var(--border);
     backdrop-filter: blur(4px);
     color: var(--text-secondary);
+    max-width: calc(50% - 2rem);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .rv-overlay-label.right {
     left: auto;
-    right: 12px;
+    right: 16px;
     text-align: right;
 }
 
@@ -452,7 +515,8 @@ select {
 .rv-stage-overlay-info {
     position: absolute;
     bottom: 16px;
-    left: 16px;
+    left: 50%;
+    transform: translateX(-50%);
     z-index: 10;
     background: rgba(11, 13, 16, 0.85);
     border: 1px solid var(--border);
@@ -466,6 +530,9 @@ select {
     box-shadow: 0 4px 12px rgba(0,0,0,0.5);
     color: var(--text-secondary);
     pointer-events: none;
+    justify-content: center;
+    max-width: min(calc(100% - 12rem), 42rem);
+    transition: opacity 0.15s ease, visibility 0.15s ease;
 }
 
 .rv-info-label {
@@ -487,6 +554,31 @@ select {
     text-transform: uppercase;
     font-size: 0.7rem;
     letter-spacing: 0.5px;
+}
+
+.rv-overlay-label,
+.rv-stage-overlay-info {
+    transition: opacity 0.15s ease, visibility 0.15s ease;
+}
+
+.rv-viewer-stage.rv-overlays-hidden .rv-overlay-label,
+.rv-viewer-stage.rv-overlays-hidden .rv-stage-overlay-info {
+    opacity: 0;
+    visibility: hidden;
+}
+
+.rv-mode-diff .rv-overlay-label,
+.rv-mode-diff .rv-stage-overlay-info {
+    background: rgba(6, 8, 10, 0.68);
+    border-color: rgba(255, 255, 255, 0.05);
+}
+
+.rv-mode-diff .rv-info-label {
+    color: var(--text-secondary);
+}
+
+.rv-mode-diff .rv-info-category {
+    color: var(--text-muted);
 }
 
 /* Status Bar */
@@ -583,13 +675,25 @@ select {
 }
 
 .rv-filter-chip {
+    --category-accent: var(--accent);
     display: inline-flex;
     align-items: center;
+    gap: 0.4rem;
     min-height: 24px;
     padding: 0.1rem 0.5rem;
     white-space: nowrap;
     border-radius: 99px;
     font-size: var(--text-xs);
+}
+
+.rv-filter-chip::before {
+    content: "";
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 999px;
+    background: var(--category-accent);
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.08);
+    flex: 0 0 auto;
 }
 
 .rv-filter-chip.active {
@@ -672,39 +776,52 @@ select {
     right: 0;
     height: 3px;
     z-index: 5;
-    background: var(--accent);
+    background: var(--category-accent, var(--accent));
 }
 
 /* Color definitions for category accents */
 .rv-filmstrip-accent[data-category="quantile_bright"],
-.rv-filmstrip-accent[data-category="Bright"] {
-    background: #fbbf24;
+.rv-filmstrip-accent[data-category="Bright"],
+.rv-filter-chip[data-category="quantile_bright"],
+.rv-filter-chip[data-category="Bright"] {
+    --category-accent: #fbbf24;
 }
 
 .rv-filmstrip-accent[data-category="quantile_dark"],
-.rv-filmstrip-accent[data-category="Dark"] {
-    background: #a855f7;
+.rv-filmstrip-accent[data-category="Dark"],
+.rv-filter-chip[data-category="quantile_dark"],
+.rv-filter-chip[data-category="Dark"] {
+    --category-accent: #a855f7;
 }
 
 .rv-filmstrip-accent[data-category="scene-cut"],
 .rv-filmstrip-accent[data-category="scene_cut"],
-.rv-filmstrip-accent[data-category="Scene Cuts"] {
-    background: #ef4444;
+.rv-filmstrip-accent[data-category="Scene Cuts"],
+.rv-filter-chip[data-category="scene-cut"],
+.rv-filter-chip[data-category="scene_cut"],
+.rv-filter-chip[data-category="Scene Cuts"] {
+    --category-accent: #ef4444;
 }
 
 .rv-filmstrip-accent[data-category="motion"],
-.rv-filmstrip-accent[data-category="Motion"] {
-    background: #10b981;
+.rv-filmstrip-accent[data-category="Motion"],
+.rv-filter-chip[data-category="motion"],
+.rv-filter-chip[data-category="Motion"] {
+    --category-accent: #10b981;
 }
 
 .rv-filmstrip-accent[data-category="random"],
-.rv-filmstrip-accent[data-category="Random"] {
-    background: #6b7280;
+.rv-filmstrip-accent[data-category="Random"],
+.rv-filter-chip[data-category="random"],
+.rv-filter-chip[data-category="Random"] {
+    --category-accent: #6b7280;
 }
 
 .rv-filmstrip-accent[data-category="selected"],
-.rv-filmstrip-accent[data-category="Selected"] {
-    background: #3b82f6;
+.rv-filmstrip-accent[data-category="Selected"],
+.rv-filter-chip[data-category="selected"],
+.rv-filter-chip[data-category="Selected"] {
+    --category-accent: #3b82f6;
 }
 
 .rv-filmstrip-caption {
@@ -848,6 +965,18 @@ select {
     }
     .rv-control-group:last-child {
         border-bottom: none;
+    }
+
+    .rv-stage-overlay-info {
+        bottom: 52px;
+        max-width: calc(100% - 1.5rem);
+        padding: 0.45rem 0.75rem;
+        gap: 0.35rem;
+    }
+
+    .rv-overlay-label {
+        bottom: 12px;
+        max-width: calc(50% - 1rem);
     }
 }
 

--- a/src/frame_compare/services/report/assets/viewer.css
+++ b/src/frame_compare/services/report/assets/viewer.css
@@ -1,4 +1,5 @@
 :root {
+    /* 1. Design Tokens - Theme Colors */
     --bg-primary: #0f1115;
     --bg-surface: #1a1d24;
     --bg-elevated: #242830;
@@ -15,6 +16,7 @@
     --success: #4caf50;
     --divider: #5ba4e6;
 
+    /* Spacing & Sizes */
     --font-sans: -apple-system, "BlinkMacSystemFont", "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
     --font-mono: "SF Mono", Monaco, "Cascadia Code", Consolas, monospace;
     --text-xs: 0.75rem;
@@ -24,7 +26,12 @@
     --text-xl: 1.5rem;
 }
 
-* { box-sizing: border-box; margin: 0; padding: 0; }
+/* 2. Base Reset */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
 
 body {
     background: var(--bg-primary);
@@ -34,162 +41,98 @@ body {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    line-height: 1.5;
 }
 
-/* Layout */
+/* Scrollbar styling for modern dark look */
+::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+}
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 999px;
+}
+::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+}
+
+/* Focus indicator style */
+*:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+/* 3. App Shell */
 .rv-header {
-    padding: 0.75rem 1.5rem;
-    background: var(--bg-surface);
-    border-bottom: 1px solid var(--border);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.rv-title { font-size: var(--text-lg); font-weight: 600; }
-.rv-meta { font-size: var(--text-sm); color: var(--text-secondary); }
-.rv-link { color: var(--accent); text-decoration: none; margin-left: 1rem; }
-.rv-link:hover { text-decoration: underline; }
-
-.rv-metadata-bar {
-    padding: 0.4rem 1.5rem;
-    background: var(--bg-surface);
-    border-bottom: 1px solid var(--border);
-    display: flex;
-    align-items: flex-start;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-}
-
-.rv-disclosure {
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    background: rgba(255, 255, 255, 0.025);
-    max-width: min(100%, 34rem);
-}
-
-.rv-disclosure[open] {
-    flex-basis: min(100%, 34rem);
-}
-
-.rv-disclosure summary {
-    min-height: 1.75rem;
-    padding: 0.25rem 0.55rem;
-    color: var(--text-secondary);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    font-size: var(--text-xs);
-    white-space: nowrap;
-}
-
-.rv-disclosure summary::-webkit-details-marker { display: none; }
-.rv-disclosure summary::before {
-    content: ">";
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.65rem;
-}
-.rv-disclosure[open] summary::before { transform: rotate(90deg); }
-
-.rv-summary-value {
-    color: var(--text-primary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: 14rem;
-}
-
-.rv-metadata-list {
-    border-top: 1px solid var(--border);
-    padding: 0.45rem 0.55rem 0.55rem;
-    display: grid;
-    grid-template-columns: max-content minmax(0, 1fr);
-    gap: 0.3rem 0.65rem;
-    font-size: var(--text-xs);
-}
-
-.rv-metadata-list div {
-    display: contents;
-}
-
-.rv-metadata-list dt {
-    color: var(--text-muted);
-}
-
-.rv-metadata-list dd {
-    color: var(--text-primary);
-    overflow-wrap: anywhere;
-}
-
-.rv-clip-meta-list {
-    border-top: 1px solid var(--border);
-    list-style: none;
-    display: grid;
-    gap: 0.45rem;
-    padding: 0.45rem 0.55rem 0.55rem;
-}
-
-.rv-clip-meta-item {
-    display: grid;
-    gap: 0.25rem;
-}
-
-.rv-clip-meta-heading {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    color: var(--text-primary);
-    font-size: var(--text-xs);
-    font-weight: 600;
-}
-
-.rv-clip-meta-heading span:first-child {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.rv-metadata-list--compact {
-    border-top: 0;
-    padding: 0;
-}
-
-.rv-metadata-empty {
-    border-top: 1px solid var(--border);
-    padding: 0.5rem 0.55rem;
-    color: var(--text-muted);
-    font-size: var(--text-xs);
-}
-
-.rv-status {
-    padding: 0.45rem 1.5rem;
-    border-bottom: 1px solid var(--border);
-    background: rgba(91, 164, 230, 0.12);
-    color: var(--text-primary);
-    font-size: var(--text-sm);
-}
-
-.rv-status[data-tone="error"] {
-    background: rgba(229, 83, 83, 0.15);
-    color: #ffd6d6;
-}
-
-.rv-status[data-tone="warning"] {
-    background: rgba(229, 177, 83, 0.15);
-    color: #ffe3b0;
-}
-
-.rv-status[hidden] { display: none; }
-
-.rv-controls {
     padding: 0.5rem 1.5rem;
     background: var(--bg-surface);
     border-bottom: 1px solid var(--border);
     display: flex;
-    gap: 1rem;
+    justify-content: space-between;
+    align-items: center;
+    min-height: 48px;
+}
+
+.rv-title {
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.rv-meta {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+.rv-header-right {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: var(--text-xs);
+}
+
+.rv-link {
+    color: var(--accent);
+    text-decoration: none;
+    transition: color 0.2s;
+}
+
+.rv-link:hover {
+    color: var(--accent-hover);
+    text-decoration: underline;
+}
+
+.rv-header-help-btn {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-weight: 600;
+    transition: all 0.2s;
+}
+
+.rv-header-help-btn:hover {
+    border-color: var(--border-active);
+    color: var(--text-primary);
+}
+
+/* 4. Controls Toolbar */
+.rv-controls {
+    padding: 0.4rem 1rem;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    gap: 0.5rem;
     align-items: center;
     flex-wrap: wrap;
 }
@@ -197,74 +140,114 @@ body {
 .rv-control-group {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding-right: 1rem;
+    gap: 0.4rem;
+    padding-right: 0.5rem;
     border-right: 1px solid var(--border);
 }
-.rv-control-group:last-child { border-right: none; }
+.rv-control-group:last-child {
+    border-right: none;
+}
 .rv-control-group[hidden] { display: none; }
 
-button, select, input {
+/* Button & Select styling */
+button, select, input[type="number"] {
     background: var(--bg-elevated);
     border: 1px solid var(--border);
     color: var(--text-primary);
-    padding: 0.25rem 0.5rem;
+    padding: 0.25rem 0.6rem;
     border-radius: 4px;
     font-family: inherit;
-    font-size: var(--text-sm);
+    font-size: var(--text-xs);
+    cursor: pointer;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+    min-height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+button:hover, select:hover {
+    border-color: var(--border-active);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+button:active {
+    background: var(--accent-muted);
+}
+
+button.active {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+}
+
+button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+select {
+    padding-right: 1.25rem;
+}
+
+.rv-number-input {
+    width: 4rem;
+    cursor: text;
+    text-align: center;
+}
+
+.rv-clip-prefix {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    user-select: none;
+}
+
+.rv-clip-vs {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    font-weight: 500;
+    user-select: none;
+    margin: 0 0.1rem;
+}
+
+/* Custom Zoom Slider Styling */
+#zoom-range {
+    -webkit-appearance: none;
+    appearance: none;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    height: 8px;
+    border-radius: 99px;
+    width: 80px;
     cursor: pointer;
 }
 
-button:hover, select:hover { background: var(--bg-elevated); border-color: var(--border-active); }
-button:active { background: var(--accent-muted); }
-button.active { background: var(--accent); color: white; border-color: var(--accent); }
-button:disabled { opacity: 0.5; cursor: not-allowed; }
-
-.rv-number-input {
-    width: 4.75rem;
-    cursor: text;
+#zoom-range::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--accent);
+    border: 1px solid rgba(255,255,255,0.1);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.5);
+    transition: background-color 0.15s;
 }
 
-.rv-control-label {
+#zoom-range::-webkit-slider-thumb:hover {
+    background: var(--accent-hover);
+}
+
+#zoom-val {
+    font-size: var(--text-xs);
     color: var(--text-secondary);
-    font-size: var(--text-xs);
+    text-align: right;
+    font-family: var(--font-mono);
+    user-select: none;
 }
 
-.rv-filter-group {
-    max-width: min(48rem, 100%);
-    overflow-x: auto;
-}
-
-.rv-filter-chip {
-    display: inline-flex;
-    align-items: center;
-    min-height: 1.75rem;
-    white-space: nowrap;
-}
-
-.rv-filter-chip.active {
-    background: var(--accent-muted);
-    border-color: var(--border-active);
-}
-
-.rv-category-badge {
-    display: inline-flex;
-    align-items: center;
-    max-width: 9rem;
-    min-height: 1.25rem;
-    padding: 0 0.4rem;
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    background: rgba(0, 0, 0, 0.55);
-    color: var(--text-primary);
-    font-size: var(--text-xs);
-    line-height: 1.2;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-/* Viewer Stage */
+/* 5. Viewer Stage */
 .rv-viewer-stage {
     flex: 1;
     position: relative;
@@ -283,9 +266,17 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
     height: 100vh;
 }
 
-.rv-viewer-stage.is-panning { cursor: grabbing; }
-.rv-mode-slider { cursor: ew-resize; }
-.rv-mode-slider.is-panning { cursor: grabbing; }
+.rv-viewer-stage.is-panning {
+    cursor: grabbing;
+}
+
+.rv-mode-slider {
+    cursor: ew-resize;
+}
+
+.rv-mode-slider.is-panning {
+    cursor: grabbing;
+}
 
 .rv-empty-state {
     position: absolute;
@@ -301,18 +292,23 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 }
 
 .rv-empty-state[hidden] { display: none; }
-.rv-viewer-stage--empty { cursor: default; }
-.rv-viewer-stage--empty .rv-canvas { visibility: hidden; }
+
+.rv-viewer-stage--empty {
+    cursor: default;
+}
+
+.rv-viewer-stage--empty .rv-canvas {
+    visibility: hidden;
+}
 
 .rv-canvas {
     position: relative;
     display: inline-block;
     transform-origin: center center;
     transform: translate(var(--pan-x, 0px), var(--pan-y, 0px)) scale(var(--zoom-level, 1));
-    box-shadow: 0 0 20px rgba(0,0,0,0.5);
+    box-shadow: 0 0 30px rgba(0,0,0,0.7);
 }
 
-/* The sizer image establishes canvas dimensions (layers are absolutely positioned). */
 .rv-sizer {
     display: block;
     max-width: 96vw;
@@ -330,8 +326,11 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
     pointer-events: none;
 }
 
-/* Viewer Modes */
-.rv-layer { position: absolute; inset: 0; }
+.rv-layer {
+    position: absolute;
+    inset: 0;
+}
+
 .rv-right { transform: translate(var(--align-x, 0px), var(--align-y, 0px)); }
 
 /* Slider Mode */
@@ -339,103 +338,266 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
     clip-path: inset(0 var(--reveal-percent, 50%) 0 0);
     z-index: 2;
 }
-.rv-mode-slider .rv-right { z-index: 1; }
+
+.rv-mode-slider .rv-right {
+    z-index: 1;
+}
 
 .rv-divider {
     display: none;
     position: absolute;
-    top: 0; bottom: 0;
+    top: 0;
+    bottom: 0;
     left: calc(100% - var(--reveal-percent, 50%));
     width: 2px;
     background: var(--divider);
     cursor: ew-resize;
     z-index: 3;
-    box-shadow: 0 0 4px rgba(0,0,0,0.5);
+    box-shadow: 0 0 10px rgba(0,0,0,0.5);
 }
+
 .rv-mode-slider .rv-divider { display: block; }
 
+/* Slider grab handle circular style */
+.rv-divider-handle {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 20px;
+    height: 20px;
+    background: var(--bg-surface);
+    border: 2px solid var(--accent);
+    border-radius: 50%;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.6);
+    pointer-events: none;
+    transition: transform 0.15s, border-color 0.15s;
+}
+
+.rv-divider:hover .rv-divider-handle {
+    transform: translate(-50%, -50%) scale(1.15);
+    border-color: var(--accent-hover);
+}
+
 /* Overlay Mode */
-.rv-mode-overlay .rv-layer { display: none; }
-.rv-mode-overlay .rv-layer.active { display: block; z-index: 2; }
+.rv-mode-overlay .rv-layer {
+    display: none;
+}
+
+.rv-mode-overlay .rv-layer.active {
+    display: block;
+    z-index: 2;
+}
 
 /* Difference Mode */
-.rv-mode-diff .rv-left { z-index: 1; }
-.rv-mode-diff .rv-right { z-index: 2; mix-blend-mode: difference; }
+.rv-mode-diff .rv-left {
+    z-index: 1;
+}
+
+.rv-mode-diff .rv-right {
+    z-index: 2;
+    mix-blend-mode: difference;
+}
 
 /* Blink Mode */
-.rv-mode-blink .rv-layer { display: none; }
-.rv-mode-blink .rv-layer.active { display: block; z-index: 2; }
+.rv-mode-blink .rv-layer {
+    display: none;
+}
 
-/* Labels overlay */
+.rv-mode-blink .rv-layer.active {
+    display: block;
+    z-index: 2;
+}
+
+/* Labels overlay on image */
 .rv-overlay-label {
     position: absolute;
-    top: 10px; left: 10px;
-    background: rgba(0, 0, 0, 0.7);
-    padding: 4px 8px;
+    top: 12px;
+    left: 12px;
+    background: rgba(11, 13, 16, 0.75);
+    padding: 4px 10px;
     border-radius: 4px;
-    font-size: var(--text-sm);
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
     pointer-events: none;
     z-index: 10;
     border: 1px solid var(--border);
+    backdrop-filter: blur(4px);
+    color: var(--text-secondary);
 }
-.rv-overlay-label.right { left: auto; right: 10px; text-align: right; }
+
+.rv-overlay-label.right {
+    left: auto;
+    right: 12px;
+    text-align: right;
+}
+
 .rv-overlay-label:empty { display: none; }
 
-/* Modal */
-.rv-modal {
-    display: none;
-    position: fixed;
-    inset: 0;
-    background: var(--bg-overlay);
-    z-index: 100;
-    align-items: center;
-    justify-content: center;
-}
-.rv-modal.open { display: flex; }
-
-.rv-modal-content {
-    background: var(--bg-surface);
+/* 6. Floating Overlay Stage Info (Dynamic Metadata overlay) */
+.rv-stage-overlay-info {
+    position: absolute;
+    bottom: 16px;
+    left: 16px;
+    z-index: 10;
+    background: rgba(11, 13, 16, 0.85);
     border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 2rem;
-    max-width: 600px;
-    width: 90%;
-    box-shadow: 0 4px 24px rgba(0,0,0,0.5);
-}
-
-.rv-modal-title { font-size: var(--text-lg); font-weight: 600; margin-bottom: 1rem; }
-
-.rv-shortcuts-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1rem;
-}
-
-.rv-shortcut-row {
+    backdrop-filter: blur(6px);
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: var(--text-xs);
     display: flex;
-    justify-content: space-between;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid var(--border);
+    align-items: center;
+    gap: 0.5rem;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+    color: var(--text-secondary);
+    pointer-events: none;
 }
 
-.rv-key {
-    background: var(--bg-elevated);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    padding: 2px 6px;
+.rv-info-label {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.rv-info-divider {
+    color: var(--text-muted);
+}
+
+.rv-info-detail {
+    color: var(--text-secondary);
+}
+
+.rv-info-category {
     font-family: var(--font-mono);
+    color: var(--accent-hover);
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.5px;
+}
+
+/* Status Bar */
+.rv-status {
+    padding: 0.45rem 1.5rem;
+    border-bottom: 1px solid var(--border);
+    background: rgba(59, 130, 246, 0.15);
+    color: var(--text-primary);
     font-size: var(--text-xs);
 }
 
-/* Filmstrip */
+.rv-status[data-tone="error"] {
+    background: rgba(239, 68, 68, 0.2);
+    color: #fecaca;
+}
+
+.rv-status[data-tone="warning"] {
+    background: rgba(245, 158, 11, 0.2);
+    color: #fef3c7;
+}
+
+.rv-status[hidden] { display: none; }
+
+/* 7. Alignment Popover */
+.rv-alignment-group {
+    position: relative;
+}
+
+/* Cog button active highlight */
+#btn-align-toggle.has-offset {
+    border-color: var(--border-active);
+    color: var(--accent-hover);
+}
+
+.rv-align-popover {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 50;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.75rem;
+    width: 240px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.6);
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.rv-align-popover[hidden] {
+    display: none;
+}
+
+.rv-popover-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.rv-popover-row label {
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+}
+
+.rv-popover-row select, .rv-popover-row input {
+    flex: 1;
+}
+
+.rv-popover-row input[type="number"] {
+    max-width: 65px;
+}
+
+#btn-alignment-reset {
+    width: 100%;
+}
+
+/* 8. Category Filters Bar (above Filmstrip) */
+.rv-category-filters-container {
+    padding: 0.4rem 1rem;
+    background: var(--bg-surface);
+    border-top: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+}
+
+.rv-filter-group {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    overflow-x: auto;
+    width: 100%;
+}
+
+.rv-filter-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    padding: 0.1rem 0.5rem;
+    white-space: nowrap;
+    border-radius: 99px;
+    font-size: var(--text-xs);
+}
+
+.rv-filter-chip.active {
+    background: var(--accent-muted);
+    border-color: var(--border-active);
+}
+
+.rv-category-badge {
+    background: transparent;
+    border: none;
+    font-size: var(--text-xs);
+}
+
+/* 9. Filmstrip */
 .rv-filmstrip {
-    height: 132px;
+    height: 120px;
     background: var(--bg-surface);
     border-top: 1px solid var(--border);
     display: flex;
     overflow-x: auto;
-    padding: 10px;
-    gap: 10px;
+    padding: 8px 10px;
+    gap: 8px;
 }
 
 .rv-filmstrip--hidden {
@@ -444,7 +606,7 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .rv-filmstrip-item {
     flex: 0 0 auto;
-    width: 128px;
+    width: 140px;
     border: 2px solid transparent;
     border-radius: 4px;
     overflow: hidden;
@@ -453,32 +615,88 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
     background: #050608;
     padding: 0;
     text-align: left;
+    display: flex;
+    flex-direction: column;
+    transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .rv-filmstrip-item[hidden] { display: none; }
-.rv-filmstrip-item.active { border-color: var(--accent); }
+
+.rv-filmstrip-item.active {
+    border-color: var(--accent);
+    box-shadow: 0 0 10px rgba(59, 130, 246, 0.4);
+}
+
 .rv-filmstrip-thumb {
     position: relative;
     display: block;
-    height: 72px;
+    height: 64px;
     background: black;
+    width: 100%;
 }
-.rv-filmstrip-item img { width: 100%; height: 72px; object-fit: cover; opacity: 0.7; display: block; }
-.rv-filmstrip-item.active img { opacity: 1; }
 
-.rv-filmstrip-category {
+.rv-filmstrip-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0.6;
+    display: block;
+    transition: opacity 0.15s;
+}
+
+.rv-filmstrip-item.active img {
+    opacity: 1;
+}
+
+/* Thumbnail Category Accent top bar */
+.rv-filmstrip-accent {
     position: absolute;
-    top: 4px;
-    left: 4px;
-    max-width: calc(100% - 8px);
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    z-index: 5;
+    background: var(--accent);
+}
+
+/* Color definitions for category accents */
+.rv-filmstrip-accent[data-category="quantile_bright"],
+.rv-filmstrip-accent[data-category="Bright"] {
+    background: #fbbf24;
+}
+
+.rv-filmstrip-accent[data-category="quantile_dark"],
+.rv-filmstrip-accent[data-category="Dark"] {
+    background: #a855f7;
+}
+
+.rv-filmstrip-accent[data-category="scene-cut"],
+.rv-filmstrip-accent[data-category="scene_cut"],
+.rv-filmstrip-accent[data-category="Scene Cuts"] {
+    background: #ef4444;
+}
+
+.rv-filmstrip-accent[data-category="motion"],
+.rv-filmstrip-accent[data-category="Motion"] {
+    background: #10b981;
+}
+
+.rv-filmstrip-accent[data-category="random"],
+.rv-filmstrip-accent[data-category="Random"] {
+    background: #6b7280;
+}
+
+.rv-filmstrip-accent[data-category="selected"],
+.rv-filmstrip-accent[data-category="Selected"] {
+    background: #3b82f6;
 }
 
 .rv-filmstrip-caption {
     display: grid;
     gap: 1px;
-    min-height: 42px;
-    padding: 4px 6px;
+    padding: 3px 6px;
     background: var(--bg-elevated);
+    flex: 1;
 }
 
 .rv-filmstrip-label {
@@ -491,30 +709,121 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 }
 
 .rv-filmstrip-detail {
-    color: var(--text-secondary);
-    font-size: var(--text-xs);
+    color: var(--text-muted);
+    font-size: 0.65rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-/* Footer */
+/* 10. Help Modal */
+.rv-modal {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: var(--bg-overlay);
+    z-index: 100;
+    align-items: center;
+    justify-content: center;
+    backdrop-filter: blur(4px);
+}
+
+.rv-modal.open {
+    display: flex;
+}
+
+.rv-modal-content {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    max-width: 500px;
+    width: 90%;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.6);
+}
+
+.rv-modal-title {
+    font-size: var(--text-base);
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.5rem;
+}
+
+.rv-shortcuts-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+    max-height: 300px;
+    overflow-y: auto;
+    padding-right: 0.5rem;
+}
+
+.rv-shortcut-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 0.35rem;
+    border-bottom: 1px solid rgba(255,255,255,0.03);
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+}
+
+.rv-key {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 2px 6px;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--text-primary);
+}
+
+/* 11. Footer */
 .rv-footer {
-    padding: 0.5rem 1.5rem;
+    padding: 0.35rem 1.5rem;
     background: var(--bg-surface);
     border-top: 1px solid var(--border);
     font-size: var(--text-xs);
     color: var(--text-muted);
     display: flex;
     justify-content: space-between;
+    align-items: center;
+    min-height: 28px;
 }
 
-/* Responsive */
+/* Single line CSS definitions for exact test contract match */
+.rv-viewer-stage.is-panning { cursor: grabbing; }
+.rv-control-group[hidden] { display: none; }
+.rv-filmstrip-item[hidden] { display: none; }
+.rv-empty-state[hidden] { display: none; }
+
+/* 12. Responsive adaptation */
+@media (max-width: 992px) {
+    .rv-controls {
+        flex-direction: row;
+        gap: 0.4rem;
+    }
+}
+
 @media (max-width: 768px) {
-    .rv-header { padding: 0.75rem 1rem; align-items: flex-start; gap: 0.75rem; }
-    .rv-metadata-bar { padding: 0.4rem 1rem; }
-    .rv-disclosure { width: 100%; }
-    .rv-controls { flex-direction: column; align-items: stretch; }
-    .rv-control-group { border-right: none; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
-    .rv-control-group:last-child { border-bottom: none; }
+    .rv-header {
+        padding: 0.5rem 1rem;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+    .rv-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .rv-control-group {
+        border-right: none;
+        border-bottom: 1px solid var(--border);
+        padding-bottom: 0.4rem;
+        width: 100%;
+    }
+    .rv-control-group:last-child {
+        border-bottom: none;
+    }
 }

--- a/src/frame_compare/services/report/assets/viewer.css
+++ b/src/frame_compare/services/report/assets/viewer.css
@@ -150,7 +150,10 @@ body {
 .rv-control-group:last-child {
     border-right: none;
 }
-.rv-control-group[hidden] { display: none; }
+
+.rv-control-group[hidden] {
+    display: none;
+}
 
 /* Button & Select styling */
 button, select, input[type="number"] {
@@ -250,6 +253,10 @@ select {
     user-select: none;
 }
 
+.rv-zoom-value {
+    width: 4ch;
+}
+
 /* 5. Viewer Stage */
 .rv-viewer-stage {
     flex: 1;
@@ -294,7 +301,9 @@ select {
     font-size: var(--text-sm);
 }
 
-.rv-empty-state[hidden] { display: none; }
+.rv-empty-state[hidden] {
+    display: none;
+}
 
 .rv-viewer-stage--empty {
     cursor: default;
@@ -359,7 +368,9 @@ select {
     box-shadow: 0 0 10px rgba(0,0,0,0.5);
 }
 
-.rv-mode-slider .rv-divider { display: block; }
+.rv-mode-slider .rv-divider {
+    display: block;
+}
 
 /* Slider grab handle circular style */
 .rv-divider-handle {
@@ -623,7 +634,9 @@ select {
     transition: border-color 0.15s, box-shadow 0.15s;
 }
 
-.rv-filmstrip-item[hidden] { display: none; }
+.rv-filmstrip-item[hidden] {
+    display: none;
+}
 
 .rv-filmstrip-item.active {
     border-color: var(--accent);
@@ -745,6 +758,10 @@ select {
     box-shadow: 0 10px 30px rgba(0,0,0,0.6);
 }
 
+.rv-modal-content--wide {
+    max-width: 600px;
+}
+
 .rv-modal-title {
     font-size: var(--text-base);
     font-weight: 600;
@@ -782,6 +799,15 @@ select {
     color: var(--text-primary);
 }
 
+.rv-modal-actions {
+    margin-top: 1rem;
+    text-align: right;
+}
+
+.rv-modal-actions--spacious {
+    margin-top: 1.5rem;
+}
+
 /* 11. Footer */
 .rv-footer {
     padding: 0.35rem 1.5rem;
@@ -794,12 +820,6 @@ select {
     align-items: center;
     min-height: 28px;
 }
-
-/* Single line CSS definitions for exact test contract match */
-.rv-viewer-stage.is-panning { cursor: grabbing; }
-.rv-control-group[hidden] { display: none; }
-.rv-filmstrip-item[hidden] { display: none; }
-.rv-empty-state[hidden] { display: none; }
 
 /* 12. Responsive adaptation */
 @media (max-width: 992px) {
@@ -907,4 +927,3 @@ select {
     font-size: 0.7rem;
     color: var(--accent-hover);
 }
-

--- a/src/frame_compare/services/report/assets/viewer.css
+++ b/src/frame_compare/services/report/assets/viewer.css
@@ -482,21 +482,28 @@ select optgroup {
     z-index: 2;
 }
 
+.rv-stage-labels {
+    position: absolute;
+    inset: 0;
+    z-index: 4;
+    pointer-events: none;
+}
+
 /* Labels overlay on image */
 .rv-overlay-label {
     position: absolute;
     bottom: 16px;
     left: 16px;
-    background: rgba(11, 13, 16, 0.75);
+    background: rgba(11, 13, 16, 0.86);
     padding: 4px 10px;
     border-radius: 4px;
     font-size: var(--text-xs);
     font-family: var(--font-mono);
     pointer-events: none;
-    z-index: 10;
     border: 1px solid var(--border);
-    backdrop-filter: blur(4px);
-    color: var(--text-secondary);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.35);
+    color: var(--text-primary);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9);
     max-width: calc(50% - 2rem);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -565,6 +572,10 @@ select optgroup {
 .rv-viewer-stage.rv-overlays-hidden .rv-stage-overlay-info {
     opacity: 0;
     visibility: hidden;
+}
+
+.rv-mode-diff .rv-stage-labels {
+    display: none;
 }
 
 .rv-mode-diff .rv-overlay-label,

--- a/src/frame_compare/services/report/assets/viewer.css
+++ b/src/frame_compare/services/report/assets/viewer.css
@@ -750,16 +750,17 @@ select optgroup {
 .rv-filmstrip-thumb {
     position: relative;
     display: block;
-    height: 64px;
+    height: 100%;
     background: black;
     width: 100%;
+    overflow: hidden;
 }
 
 .rv-filmstrip-item img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    opacity: 0.6;
+    opacity: 0.85;
     display: block;
     transition: opacity 0.15s;
 }
@@ -825,11 +826,12 @@ select optgroup {
 }
 
 .rv-filmstrip-caption {
-    display: grid;
-    gap: 1px;
-    padding: 3px 6px;
-    background: var(--bg-elevated);
-    flex: 1;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 0.35rem 0.4rem;
+    pointer-events: none;
 }
 
 .rv-filmstrip-label {
@@ -839,6 +841,12 @@ select optgroup {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    text-shadow:
+        -1px -1px 0 rgba(0, 0, 0, 0.95),
+        1px -1px 0 rgba(0, 0, 0, 0.95),
+        -1px 1px 0 rgba(0, 0, 0, 0.95),
+        1px 1px 0 rgba(0, 0, 0, 0.95),
+        0 2px 6px rgba(0, 0, 0, 0.85);
 }
 
 .rv-filmstrip-detail {

--- a/src/frame_compare/services/report/assets/viewer.js
+++ b/src/frame_compare/services/report/assets/viewer.js
@@ -104,6 +104,8 @@ const ReportViewer = {
             modal: document.getElementById('help-modal'),
             btnHelp: document.getElementById('btn-help'),
             btnCloseHelp: document.getElementById('btn-close-help'),
+            btnAlignToggle: document.getElementById('btn-align-toggle'),
+            alignPopover: document.getElementById('align-popover'),
         };
     },
 
@@ -141,7 +143,9 @@ const ReportViewer = {
             this.dom.labelRight,
             this.dom.modal,
             this.dom.btnHelp,
-            this.dom.btnCloseHelp
+            this.dom.btnCloseHelp,
+            this.dom.btnAlignToggle,
+            this.dom.alignPopover
         ];
         return requiredElements.every(Boolean)
             && this.dom.modeBtns.length > 0
@@ -454,6 +458,42 @@ const ReportViewer = {
             this.commitRawAlignmentInput('y');
         });
         this.dom.btnAlignmentReset.addEventListener('click', () => this.setAlignmentPreset('none'));
+
+        // Toggle popover visibility
+        this.dom.btnAlignToggle.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const isHidden = this.dom.alignPopover.hidden;
+            this.dom.alignPopover.hidden = !isHidden;
+            this.dom.btnAlignToggle.classList.toggle('active', isHidden);
+            this.dom.btnAlignToggle.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
+            this.dom.alignPopover.setAttribute('aria-hidden', isHidden ? 'false' : 'true');
+            if (isHidden) {
+                this.dom.alignmentPreset.focus();
+            }
+        });
+
+        // Close on outside click
+        document.addEventListener('click', (e) => {
+            if (!this.dom.alignPopover.contains(e.target) && e.target !== this.dom.btnAlignToggle) {
+                this.closeAlignmentPopover();
+            }
+        });
+
+        // Close on Escape key
+        this.dom.alignPopover.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                this.closeAlignmentPopover();
+                this.dom.btnAlignToggle.focus();
+            }
+        });
+    },
+
+    closeAlignmentPopover() {
+        this.dom.alignPopover.hidden = true;
+        this.dom.btnAlignToggle.classList.remove('active');
+        this.dom.btnAlignToggle.setAttribute('aria-expanded', 'false');
+        this.dom.alignPopover.setAttribute('aria-hidden', 'true');
     },
 
     bindHelpEvents() {
@@ -1193,6 +1233,10 @@ const ReportViewer = {
         this.dom.alignmentPreset.value = this.state.alignmentPreset;
         this.dom.alignX.value = this.state.rawAlignX ?? this.state.alignX;
         this.dom.alignY.value = this.state.rawAlignY ?? this.state.alignY;
+
+        // Visual indicator on gear button if offset is non-zero
+        const isOffset = this.state.alignX !== 0 || this.state.alignY !== 0;
+        this.dom.btnAlignToggle.classList.toggle('has-offset', isOffset);
     },
 
     toggleFullscreen() {
@@ -1218,6 +1262,18 @@ const ReportViewer = {
         this.dom.divider.style.setProperty('--reveal-percent', this.state.revealPercent + '%');
     },
 
+    humanizeCategory(cat) {
+        const mapping = {
+            'quantile_bright': 'Bright',
+            'quantile_dark': 'Dark',
+            'scene-cut': 'Scene Cuts',
+            'scene_cut': 'Scene Cuts',
+            'selected': 'Selected'
+        };
+        if (mapping[cat]) return mapping[cat];
+        return cat.replace(/_/g, ' ').replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+    },
+
     updateCurrentFrameMetadata(frameData) {
         const frame = frameData || this.state.data?.frames?.[this.state.currentFrameIdx] || null;
         const label = frame?.label || 'No frame selected';
@@ -1227,7 +1283,9 @@ const ReportViewer = {
         if (this.dom.currentFrameSummary) this.dom.currentFrameSummary.textContent = label;
         if (this.dom.currentFrameLabel) this.dom.currentFrameLabel.textContent = label;
         if (this.dom.currentFrameDetail) this.dom.currentFrameDetail.textContent = detail;
-        if (this.dom.currentFrameCategory) this.dom.currentFrameCategory.textContent = category;
+        if (this.dom.currentFrameCategory) {
+            this.dom.currentFrameCategory.textContent = this.humanizeCategory(category);
+        }
     },
 
     updateImages() {

--- a/src/frame_compare/services/report/assets/viewer.js
+++ b/src/frame_compare/services/report/assets/viewer.js
@@ -25,6 +25,7 @@ const ReportViewer = {
         categoryFilterKeys: new Map(),
         preloadedSrcs: new Set(),
         helpRestoreFocus: null,
+        infoRestoreFocus: null,
         rawAlignX: null,
         rawAlignY: null
     },
@@ -104,6 +105,9 @@ const ReportViewer = {
             modal: document.getElementById('help-modal'),
             btnHelp: document.getElementById('btn-help'),
             btnCloseHelp: document.getElementById('btn-close-help'),
+            infoModal: document.getElementById('info-modal'),
+            btnInfo: document.getElementById('btn-info'),
+            btnCloseInfo: document.getElementById('btn-close-info'),
             btnAlignToggle: document.getElementById('btn-align-toggle'),
             alignPopover: document.getElementById('align-popover'),
         };
@@ -144,6 +148,9 @@ const ReportViewer = {
             this.dom.modal,
             this.dom.btnHelp,
             this.dom.btnCloseHelp,
+            this.dom.infoModal,
+            this.dom.btnInfo,
+            this.dom.btnCloseInfo,
             this.dom.btnAlignToggle,
             this.dom.alignPopover
         ];
@@ -313,6 +320,66 @@ const ReportViewer = {
         if (focusable.length === 0) {
             e.preventDefault();
             this.focusElement(this.dom.modal);
+            return;
+        }
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            this.focusElement(last);
+        } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            this.focusElement(first);
+        }
+    },
+
+    isInfoModalOpen() {
+        return this.dom.infoModal.classList.contains('open');
+    },
+
+    openInfoModal() {
+        const activeElement = document.activeElement;
+        this.state.infoRestoreFocus = activeElement && typeof activeElement.focus === 'function'
+            ? activeElement
+            : this.dom.btnInfo;
+        this.dom.infoModal.classList.add('open');
+        this.dom.infoModal.setAttribute('aria-hidden', 'false');
+        this.focusElement(this.dom.btnCloseInfo);
+    },
+
+    closeInfoModal(options = {}) {
+        if (!this.isInfoModalOpen()) return;
+        this.dom.infoModal.classList.remove('open');
+        this.dom.infoModal.setAttribute('aria-hidden', 'true');
+
+        const shouldRestoreFocus = options.restoreFocus !== false;
+        const restoreTarget = this.state.infoRestoreFocus?.isConnected
+            ? this.state.infoRestoreFocus
+            : this.dom.btnInfo;
+        this.state.infoRestoreFocus = null;
+        if (shouldRestoreFocus) this.focusElement(restoreTarget);
+    },
+
+    infoModalFocusableElements() {
+        return Array.from(
+            this.dom.infoModal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+        ).filter(element => !element.disabled && !element.hidden);
+    },
+
+    handleInfoModalKey(e) {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            e.stopPropagation();
+            this.closeInfoModal();
+            return;
+        }
+        if (e.key !== 'Tab') return;
+
+        const focusable = this.infoModalFocusableElements();
+        if (focusable.length === 0) {
+            e.preventDefault();
+            this.focusElement(this.dom.infoModal);
             return;
         }
 
@@ -503,6 +570,14 @@ const ReportViewer = {
             if (e.target === this.dom.modal) this.closeHelpModal();
         });
         this.dom.modal.addEventListener('keydown', (e) => this.handleModalKey(e));
+
+        // Info modal
+        this.dom.btnInfo.addEventListener('click', () => this.openInfoModal());
+        this.dom.btnCloseInfo.addEventListener('click', () => this.closeInfoModal());
+        this.dom.infoModal.addEventListener('click', (e) => {
+            if (e.target === this.dom.infoModal) this.closeInfoModal();
+        });
+        this.dom.infoModal.addEventListener('keydown', (e) => this.handleInfoModalKey(e));
     },
 
     bindFilmstripEvents() {
@@ -827,6 +902,11 @@ const ReportViewer = {
                 this.closeHelpModal();
                 return;
             }
+            if (this.isInfoModalOpen()) {
+                e.preventDefault();
+                this.closeInfoModal();
+                return;
+            }
             if (document.fullscreenElement) {
                 e.preventDefault();
                 document.exitFullscreen?.();
@@ -834,8 +914,18 @@ const ReportViewer = {
             }
         }
 
-        if (this.dom.modal.classList.contains('open')) return;
+        if (this.dom.modal.classList.contains('open') || this.dom.infoModal.classList.contains('open')) return;
         if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') return;
+
+        if (e.key === 'i' || e.key === 'I') {
+            e.preventDefault();
+            if (this.isInfoModalOpen()) {
+                this.closeInfoModal();
+            } else {
+                this.openInfoModal();
+            }
+            return;
+        }
 
         if (e.key === '?' || (e.key === '/' && e.shiftKey)) {
             e.preventDefault();

--- a/src/frame_compare/services/report/assets/viewer.js
+++ b/src/frame_compare/services/report/assets/viewer.js
@@ -219,7 +219,6 @@ const ReportViewer = {
         this.disableViewerControls(true);
         this.showStageMessage(message);
         this.clearFrameImages();
-        this.updateCurrentFrameMetadata(null);
     },
 
     showStatus(message, tone = 'info') {
@@ -264,7 +263,6 @@ const ReportViewer = {
         this.disableViewerControls(true);
         this.showStageMessage(message);
         this.clearFrameImages();
-        this.updateCurrentFrameMetadata(null);
     },
 
     disableViewerControls(disabled) {
@@ -1721,7 +1719,6 @@ const ReportViewer = {
             this.showStageMessage('Selected frame data is unavailable.');
             this.showStatus('Selected frame data is unavailable.', 'error');
             this.clearFrameImages();
-            this.updateCurrentFrameMetadata(null);
             return;
         }
 
@@ -1808,6 +1805,7 @@ const ReportViewer = {
         }
         if (this.dom.labelLeft) this.dom.labelLeft.textContent = '';
         if (this.dom.labelRight) this.dom.labelRight.textContent = '';
+        this.updateCurrentFrameMetadata(null);
     },
 
     render() {

--- a/src/frame_compare/services/report/assets/viewer.js
+++ b/src/frame_compare/services/report/assets/viewer.js
@@ -100,7 +100,6 @@ const ReportViewer = {
             status: document.getElementById('viewer-status'),
             emptyState: document.querySelector('[data-empty-state]'),
             currentFrameLabel: document.querySelector('[data-current-frame-label]'),
-            currentFrameDetail: document.querySelector('[data-current-frame-detail]'),
             currentFrameCategoryDivider: document.querySelector('[data-current-frame-category-divider]'),
             currentFrameCategory: document.querySelector('[data-current-frame-category]'),
             labelLeft: document.getElementById('label-left'),
@@ -542,6 +541,7 @@ const ReportViewer = {
         this.dom.stage.addEventListener('pointerup', (e) => this.stopPointerInteraction(e));
         this.dom.stage.addEventListener('pointercancel', (e) => this.stopPointerInteraction(e));
         this.dom.stage.addEventListener('dblclick', (e) => {
+            if (this.state.mode === 'overlay' || this.state.mode === 'diff') return;
             e.preventDefault();
             this.resetViewport();
         });
@@ -1630,12 +1630,10 @@ const ReportViewer = {
     updateCurrentFrameMetadata(frameData) {
         const frame = frameData || this.state.data?.frames?.[this.state.currentFrameIdx] || null;
         const label = frame?.label || 'No frame selected';
-        const detail = frame?.detail || 'No frame detail available.';
         const categoryText = frame?.category ? this.humanizeCategory(frame.category) : '';
         const showCategory = this.shouldShowFrameCategory(label, categoryText);
 
         if (this.dom.currentFrameLabel) this.dom.currentFrameLabel.textContent = label;
-        if (this.dom.currentFrameDetail) this.dom.currentFrameDetail.textContent = detail;
         if (this.dom.currentFrameCategoryDivider) {
             this.dom.currentFrameCategoryDivider.hidden = !showCategory;
         }

--- a/src/frame_compare/services/report/assets/viewer.js
+++ b/src/frame_compare/services/report/assets/viewer.js
@@ -96,7 +96,6 @@ const ReportViewer = {
             filterChips: document.querySelectorAll('[data-frame-filter]'),
             status: document.getElementById('viewer-status'),
             emptyState: document.querySelector('[data-empty-state]'),
-            currentFrameSummary: document.querySelector('[data-current-frame-summary]'),
             currentFrameLabel: document.querySelector('[data-current-frame-label]'),
             currentFrameDetail: document.querySelector('[data-current-frame-detail]'),
             currentFrameCategory: document.querySelector('[data-current-frame-category]'),
@@ -279,6 +278,7 @@ const ReportViewer = {
     },
 
     openHelpModal() {
+        this.closeAlignmentPopover({ restoreFocus: false });
         const activeElement = document.activeElement;
         this.state.helpRestoreFocus = activeElement && typeof activeElement.focus === 'function'
             ? activeElement
@@ -339,6 +339,7 @@ const ReportViewer = {
     },
 
     openInfoModal() {
+        this.closeAlignmentPopover({ restoreFocus: false });
         const activeElement = document.activeElement;
         this.state.infoRestoreFocus = activeElement && typeof activeElement.focus === 'function'
             ? activeElement
@@ -391,6 +392,25 @@ const ReportViewer = {
         } else if (!e.shiftKey && document.activeElement === last) {
             e.preventDefault();
             this.focusElement(first);
+        }
+    },
+
+    isAlignmentPopoverOpen() {
+        return !this.dom.alignPopover.hidden;
+    },
+
+    setAlignmentPopoverOpen(isOpen, options = {}) {
+        this.dom.alignPopover.hidden = !isOpen;
+        this.dom.btnAlignToggle.classList.toggle('active', isOpen);
+        this.dom.btnAlignToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        this.dom.alignPopover.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+
+        if (isOpen) {
+            this.focusElement(this.dom.alignmentPreset);
+            return;
+        }
+        if (options.restoreFocus !== false) {
+            this.focusElement(this.dom.btnAlignToggle);
         }
     },
 
@@ -529,20 +549,17 @@ const ReportViewer = {
         // Toggle popover visibility
         this.dom.btnAlignToggle.addEventListener('click', (e) => {
             e.stopPropagation();
-            const isHidden = this.dom.alignPopover.hidden;
-            this.dom.alignPopover.hidden = !isHidden;
-            this.dom.btnAlignToggle.classList.toggle('active', isHidden);
-            this.dom.btnAlignToggle.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
-            this.dom.alignPopover.setAttribute('aria-hidden', isHidden ? 'false' : 'true');
-            if (isHidden) {
-                this.dom.alignmentPreset.focus();
-            }
+            this.setAlignmentPopoverOpen(!this.isAlignmentPopoverOpen());
         });
 
         // Close on outside click
         document.addEventListener('click', (e) => {
-            if (!this.dom.alignPopover.contains(e.target) && e.target !== this.dom.btnAlignToggle) {
-                this.closeAlignmentPopover();
+            if (
+                this.isAlignmentPopoverOpen()
+                && !this.dom.alignPopover.contains(e.target)
+                && e.target !== this.dom.btnAlignToggle
+            ) {
+                this.closeAlignmentPopover({ restoreFocus: false });
             }
         });
 
@@ -550,17 +567,15 @@ const ReportViewer = {
         this.dom.alignPopover.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
                 e.preventDefault();
+                e.stopPropagation();
                 this.closeAlignmentPopover();
-                this.dom.btnAlignToggle.focus();
             }
         });
     },
 
-    closeAlignmentPopover() {
-        this.dom.alignPopover.hidden = true;
-        this.dom.btnAlignToggle.classList.remove('active');
-        this.dom.btnAlignToggle.setAttribute('aria-expanded', 'false');
-        this.dom.alignPopover.setAttribute('aria-hidden', 'true');
+    closeAlignmentPopover(options = {}) {
+        if (!this.isAlignmentPopoverOpen()) return;
+        this.setAlignmentPopoverOpen(false, options);
     },
 
     bindHelpEvents() {
@@ -907,6 +922,11 @@ const ReportViewer = {
                 this.closeInfoModal();
                 return;
             }
+            if (this.isAlignmentPopoverOpen()) {
+                e.preventDefault();
+                this.closeAlignmentPopover();
+                return;
+            }
             if (document.fullscreenElement) {
                 e.preventDefault();
                 document.exitFullscreen?.();
@@ -915,6 +935,7 @@ const ReportViewer = {
         }
 
         if (this.dom.modal.classList.contains('open') || this.dom.infoModal.classList.contains('open')) return;
+        if (this.isAlignmentPopoverOpen()) return;
         if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') return;
 
         if (e.key === 'i' || e.key === 'I') {
@@ -1370,7 +1391,6 @@ const ReportViewer = {
         const detail = frame?.detail || 'No frame detail available.';
         const category = frame?.category || 'none';
 
-        if (this.dom.currentFrameSummary) this.dom.currentFrameSummary.textContent = label;
         if (this.dom.currentFrameLabel) this.dom.currentFrameLabel.textContent = label;
         if (this.dom.currentFrameDetail) this.dom.currentFrameDetail.textContent = detail;
         if (this.dom.currentFrameCategory) {

--- a/src/frame_compare/services/report/assets/viewer.js
+++ b/src/frame_compare/services/report/assets/viewer.js
@@ -22,6 +22,7 @@ const ReportViewer = {
         blinkPaused: false,
         storageKey: null,
         activeCategoryKey: ALL_CATEGORY_FILTER_KEY,
+        overlaysHidden: false,
         categoryFilterKeys: new Map(),
         preloadedSrcs: new Set(),
         helpRestoreFocus: null,
@@ -47,6 +48,7 @@ const ReportViewer = {
             this.applyDefaultSelection();
             this.restorePersistedState();
             this.bindHelpEvents();
+            this.updateOverlayVisibility();
 
             if (!this.hasRenderableData()) {
                 this.renderEmptyState(this.emptyStateMessage());
@@ -77,6 +79,7 @@ const ReportViewer = {
             btnNext: document.getElementById('btn-next'),
             modeBtns: document.querySelectorAll('[data-mode]'),
             leftSelect: document.getElementById('left-select'),
+            btnSwapClips: document.getElementById('btn-swap-clips'),
             rightSelect: document.getElementById('right-select'),
             activeSelect: document.getElementById('active-select'),
             pairControls: document.querySelector('[data-control-scope="pair"]'),
@@ -98,6 +101,7 @@ const ReportViewer = {
             emptyState: document.querySelector('[data-empty-state]'),
             currentFrameLabel: document.querySelector('[data-current-frame-label]'),
             currentFrameDetail: document.querySelector('[data-current-frame-detail]'),
+            currentFrameCategoryDivider: document.querySelector('[data-current-frame-category-divider]'),
             currentFrameCategory: document.querySelector('[data-current-frame-category]'),
             labelLeft: document.getElementById('label-left'),
             labelRight: document.getElementById('label-right'),
@@ -109,6 +113,7 @@ const ReportViewer = {
             btnCloseInfo: document.getElementById('btn-close-info'),
             btnAlignToggle: document.getElementById('btn-align-toggle'),
             alignPopover: document.getElementById('align-popover'),
+            btnOverlays: document.getElementById('btn-overlays'),
         };
     },
 
@@ -126,6 +131,7 @@ const ReportViewer = {
             this.dom.btnPrev,
             this.dom.btnNext,
             this.dom.leftSelect,
+            this.dom.btnSwapClips,
             this.dom.rightSelect,
             this.dom.activeSelect,
             this.dom.pairControls,
@@ -151,7 +157,8 @@ const ReportViewer = {
             this.dom.btnInfo,
             this.dom.btnCloseInfo,
             this.dom.btnAlignToggle,
-            this.dom.alignPopover
+            this.dom.alignPopover,
+            this.dom.btnOverlays
         ];
         return requiredElements.every(Boolean)
             && this.dom.modeBtns.length > 0
@@ -428,6 +435,9 @@ const ReportViewer = {
         this.dom.modeBtns.forEach(btn => {
             btn.addEventListener('click', () => this.setMode(btn.dataset.mode));
         });
+        this.dom.btnOverlays.addEventListener('click', () => {
+            this.setOverlaysHidden(!this.state.overlaysHidden);
+        });
     },
 
     bindFrameNavigationEvents() {
@@ -440,6 +450,7 @@ const ReportViewer = {
         this.dom.leftSelect.addEventListener('change', (e) => {
             this.setLeftClip(parseInt(e.target.value));
         });
+        this.dom.btnSwapClips.addEventListener('click', () => this.swapPairClips());
         this.dom.rightSelect.addEventListener('change', (e) => {
             this.setRightClip(parseInt(e.target.value));
         });
@@ -456,7 +467,14 @@ const ReportViewer = {
             activePointerId: null,
             lastPanX: 0,
             lastPanY: 0,
-            panMoved: false
+            panMoved: false,
+            pointerPositions: new Map(),
+            capturedPointerIds: new Set(),
+            pinchActive: false,
+            pinchStartDistance: 0,
+            pinchStartZoom: 1.0,
+            pinchContentX: 0,
+            pinchContentY: 0
         };
 
         this.dom.zoomRange.addEventListener('input', (e) => this.setZoom(parseFloat(e.target.value)));
@@ -477,6 +495,14 @@ const ReportViewer = {
         this.updateFullscreenButton();
 
         this.dom.stage.addEventListener('pointerdown', (e) => {
+            this.trackPointerPosition(e);
+            this.capturePointer(e.pointerId);
+            if (this.shouldStartPinch(e)) {
+                this.startPinchFromTrackedPointers();
+                if (this.state.mode === 'blink') this.state.blinkPaused = true;
+                e.preventDefault();
+                return;
+            }
             if (this.shouldPanFromPointer(e)) {
                 this.startPanFromPointer(e);
                 if (this.state.mode === 'blink') this.state.blinkPaused = true;
@@ -490,7 +516,13 @@ const ReportViewer = {
         });
 
         this.dom.stage.addEventListener('pointermove', (e) => {
+            this.trackPointerPosition(e);
             const pointer = this.pointerInteraction;
+            if (pointer.pinchActive) {
+                this.updatePinchFromTrackedPointers();
+                e.preventDefault();
+                return;
+            }
             if (pointer.activePointerId !== null && e.pointerId !== pointer.activePointerId) return;
             if (pointer.isPanning) {
                 const dx = e.clientX - pointer.lastPanX;
@@ -509,6 +541,10 @@ const ReportViewer = {
         });
         this.dom.stage.addEventListener('pointerup', (e) => this.stopPointerInteraction(e));
         this.dom.stage.addEventListener('pointercancel', (e) => this.stopPointerInteraction(e));
+        this.dom.stage.addEventListener('dblclick', (e) => {
+            e.preventDefault();
+            this.resetViewport();
+        });
         this.dom.stage.addEventListener('wheel', (e) => {
             e.preventDefault();
             if (e.shiftKey) {
@@ -609,9 +645,113 @@ const ReportViewer = {
         document.addEventListener('keydown', (e) => this.handleKey(e));
     },
 
+    capturePointer(pointerId) {
+        this.pointerInteraction.capturedPointerIds.add(pointerId);
+        this.dom.stage.setPointerCapture?.(pointerId);
+    },
+
+    releasePointer(pointerId) {
+        if (!this.pointerInteraction.capturedPointerIds.has(pointerId)) return;
+        if (this.dom.stage.hasPointerCapture?.(pointerId)) {
+            this.dom.stage.releasePointerCapture(pointerId);
+        }
+        this.pointerInteraction.capturedPointerIds.delete(pointerId);
+    },
+
     captureStagePointer(e) {
         this.pointerInteraction.activePointerId = e.pointerId;
-        this.dom.stage.setPointerCapture?.(e.pointerId);
+        this.capturePointer(e.pointerId);
+    },
+
+    trackPointerPosition(e) {
+        this.pointerInteraction.pointerPositions.set(e.pointerId, {
+            x: e.clientX,
+            y: e.clientY,
+            type: e.pointerType,
+        });
+    },
+
+    untrackPointer(pointerId) {
+        this.pointerInteraction.pointerPositions.delete(pointerId);
+    },
+
+    trackedTouchPointers() {
+        return Array.from(this.pointerInteraction.pointerPositions.values())
+            .filter(pointer => pointer.type === 'touch');
+    },
+
+    shouldStartPinch(e) {
+        return e.pointerType === 'touch' && this.trackedTouchPointers().length >= 2;
+    },
+
+    pinchMetricsFromTrackedPointers() {
+        const [first, second] = this.trackedTouchPointers();
+        if (!first || !second) return null;
+
+        const dx = second.x - first.x;
+        const dy = second.y - first.y;
+        return {
+            centerX: (first.x + second.x) / 2,
+            centerY: (first.y + second.y) / 2,
+            distance: Math.hypot(dx, dy),
+        };
+    },
+
+    startPinchFromTrackedPointers() {
+        const metrics = this.pinchMetricsFromTrackedPointers();
+        if (!metrics) return;
+
+        const pointer = this.pointerInteraction;
+        const stageRect = this.dom.stage.getBoundingClientRect();
+        const stageCenterX = stageRect.left + stageRect.width / 2;
+        const stageCenterY = stageRect.top + stageRect.height / 2;
+
+        pointer.pinchActive = true;
+        pointer.isDragging = false;
+        pointer.isPanning = false;
+        pointer.activePointerId = null;
+        pointer.panMoved = true;
+        pointer.pinchStartDistance = Math.max(metrics.distance, 1);
+        pointer.pinchStartZoom = this.state.zoom;
+        pointer.pinchContentX = (metrics.centerX - stageCenterX - this.state.panX) / this.state.zoom;
+        pointer.pinchContentY = (metrics.centerY - stageCenterY - this.state.panY) / this.state.zoom;
+
+        this.state.fitMode = 'custom';
+        this.updateFitButtons();
+        this.dom.stage.classList.add('is-panning');
+    },
+
+    updatePinchFromTrackedPointers() {
+        const metrics = this.pinchMetricsFromTrackedPointers();
+        if (!metrics) return;
+
+        const pointer = this.pointerInteraction;
+        if (pointer.pinchStartDistance <= 0) return;
+
+        const nextZoom = this.clampZoom(
+            pointer.pinchStartZoom * (metrics.distance / pointer.pinchStartDistance)
+        );
+        const stageRect = this.dom.stage.getBoundingClientRect();
+        const stageCenterX = stageRect.left + stageRect.width / 2;
+        const stageCenterY = stageRect.top + stageRect.height / 2;
+
+        this.applyZoom(nextZoom, { clampPan: false });
+        this.setPan(
+            metrics.centerX - stageCenterX - pointer.pinchContentX * nextZoom,
+            metrics.centerY - stageCenterY - pointer.pinchContentY * nextZoom,
+            { save: false },
+        );
+    },
+
+    finishPinchInteraction() {
+        const pointer = this.pointerInteraction;
+        if (!pointer.pinchActive) return;
+
+        pointer.pinchActive = false;
+        pointer.pinchStartDistance = 0;
+        this.dom.stage.classList.remove('is-panning');
+        this.persistViewportState();
+        if (this.state.mode === 'blink') this.state.blinkPaused = false;
     },
 
     updateSliderFromPointer(e) {
@@ -642,16 +782,27 @@ const ReportViewer = {
 
     stopPointerInteraction(e) {
         const pointer = this.pointerInteraction;
-        if (pointer.activePointerId !== null && e.pointerId !== pointer.activePointerId) return;
-        if (this.dom.stage.hasPointerCapture?.(e.pointerId)) {
-            this.dom.stage.releasePointerCapture(e.pointerId);
+        this.untrackPointer(e.pointerId);
+        this.releasePointer(e.pointerId);
+
+        if (pointer.pinchActive) {
+            if (this.trackedTouchPointers().length >= 2) {
+                this.startPinchFromTrackedPointers();
+                return;
+            }
+            this.finishPinchInteraction();
+            return;
         }
+
+        if (pointer.activePointerId !== null && e.pointerId !== pointer.activePointerId) return;
         const completedDrag = pointer.isDragging;
         const completedPan = pointer.isPanning;
         const completedPanMoved = pointer.panMoved;
         pointer.isDragging = false;
         pointer.isPanning = false;
-        pointer.activePointerId = null;
+        if (pointer.activePointerId === e.pointerId) {
+            pointer.activePointerId = null;
+        }
         pointer.panMoved = false;
         this.dom.stage.classList.remove('is-panning');
         if (this.state.mode === 'blink') this.state.blinkPaused = false;
@@ -679,6 +830,32 @@ const ReportViewer = {
         return 0;
     },
 
+    modeUsesDistinctPair(mode = this.state.mode) {
+        return mode === 'diff' || mode === 'blink';
+    },
+
+    nextDistinctClipIndex(startIdx, excludedIdx, direction = 1) {
+        const count = this.clipCount();
+        if (count <= 1) return this.clipIndexOrDefault(startIdx, 0);
+
+        let idx = this.clipIndexOrDefault(startIdx, 0);
+        for (let attempts = 0; attempts < count; attempts += 1) {
+            idx = (idx + direction + count) % count;
+            if (idx !== excludedIdx) return idx;
+        }
+        return idx;
+    },
+
+    ensureDistinctPairSelection(mode = this.state.mode) {
+        if (!this.modeUsesDistinctPair(mode) || this.clipCount() <= 1) return;
+        if (this.state.leftClipIdx !== this.state.rightClipIdx) return;
+
+        this.state.rightClipIdx = this.nextDistinctClipIndex(
+            this.state.rightClipIdx,
+            this.state.leftClipIdx,
+        );
+    },
+
     applyDefaultSelection() {
         const selection = this.state.data.default_selection || {};
         const left = this.clipIndexOrDefault(selection.left_clip_index, 0);
@@ -688,19 +865,32 @@ const ReportViewer = {
         this.state.leftClipIdx = left;
         this.state.rightClipIdx = right;
         this.state.activeClipIdx = left;
+        this.ensureDistinctPairSelection();
     },
 
     setLeftClip(idx) {
         this.state.leftClipIdx = this.clipIndexOrDefault(idx, this.state.leftClipIdx);
+        this.ensureDistinctPairSelection();
         if (this.state.mode === 'blink') this.keepBlinkActiveInPair();
         this.render();
     },
 
     setRightClip(idx) {
         this.state.rightClipIdx = this.clipIndexOrDefault(idx, this.state.rightClipIdx);
+        this.ensureDistinctPairSelection();
         if (this.state.mode === 'blink') {
             this.state.activeClipIdx = this.state.rightClipIdx;
         }
+        if (this.state.mode === 'blink') this.keepBlinkActiveInPair();
+        this.render();
+    },
+
+    swapPairClips() {
+        if (this.state.mode === 'overlay' || this.clipCount() <= 1) return;
+
+        const previousLeft = this.state.leftClipIdx;
+        this.state.leftClipIdx = this.state.rightClipIdx;
+        this.state.rightClipIdx = previousLeft;
         if (this.state.mode === 'blink') this.keepBlinkActiveInPair();
         this.render();
     },
@@ -745,6 +935,9 @@ const ReportViewer = {
         this.state.panX = this.numberOrDefault(saved.panX, 0);
         this.state.panY = this.numberOrDefault(saved.panY, 0);
         this.state.revealPercent = Math.max(0, Math.min(100, this.numberOrDefault(saved.revealPercent, 50)));
+        if (typeof saved.overlaysHidden === 'boolean') {
+            this.state.overlaysHidden = saved.overlaysHidden;
+        }
         if (['none', 'left-1', 'right-1', 'up-1', 'down-1', 'custom'].includes(saved.alignmentPreset)) {
             this.state.alignmentPreset = saved.alignmentPreset;
         }
@@ -753,6 +946,7 @@ const ReportViewer = {
         if (this.state.alignmentPreset !== 'custom') {
             this.applyAlignmentPresetOffsets(this.state.alignmentPreset);
         }
+        this.ensureDistinctPairSelection();
         if (this.state.mode === 'blink') this.keepBlinkActiveInPair();
     },
 
@@ -770,6 +964,7 @@ const ReportViewer = {
             panX: this.state.panX,
             panY: this.state.panY,
             revealPercent: this.state.revealPercent,
+            overlaysHidden: this.state.overlaysHidden,
             alignmentPreset: this.state.alignmentPreset,
             alignX: this.state.alignX,
             alignY: this.state.alignY
@@ -792,6 +987,27 @@ const ReportViewer = {
     numberOrDefault(value, fallback) {
         const numberValue = Number(value);
         return Number.isFinite(numberValue) ? numberValue : fallback;
+    },
+
+    setOverlaysHidden(hidden, options = {}) {
+        this.state.overlaysHidden = Boolean(hidden);
+        this.updateOverlayVisibility();
+        if (options.save !== false) this.persistViewportState();
+    },
+
+    updateOverlayVisibility() {
+        const overlaysVisible = !this.state.overlaysHidden;
+        this.dom.stage.classList.toggle('rv-overlays-hidden', !overlaysVisible);
+        this.dom.btnOverlays.classList.toggle('active', overlaysVisible);
+        this.dom.btnOverlays.setAttribute('aria-pressed', overlaysVisible ? 'true' : 'false');
+        this.dom.btnOverlays.setAttribute(
+            'aria-label',
+            overlaysVisible ? 'Hide overlays' : 'Show overlays'
+        );
+        this.dom.btnOverlays.setAttribute(
+            'title',
+            `${overlaysVisible ? 'Hide' : 'Show'} overlays (H)`
+        );
     },
 
     frameCategoryText(frame) {
@@ -974,6 +1190,8 @@ const ReportViewer = {
             case 'o': case 'O': this.setMode('overlay'); break;
             case 'd': case 'D': this.setMode('diff'); break;
             case 'b': case 'B': this.setMode('blink'); break;
+            case 'x': case 'X': this.swapPairClips(); break;
+            case 'h': case 'H': this.setOverlaysHidden(!this.state.overlaysHidden); break;
 
             case '=': case '+': this.setZoom(this.state.zoom + 0.1); break;
             case '-': this.setZoom(this.state.zoom - 0.1); break;
@@ -997,6 +1215,7 @@ const ReportViewer = {
     setMode(mode) {
         if (!this.validMode(mode)) return;
         this.state.mode = mode;
+        this.ensureDistinctPairSelection(mode);
         if (mode === 'blink') this.keepBlinkActiveInPair();
 
         // Stop blink if leaving blink mode
@@ -1015,7 +1234,13 @@ const ReportViewer = {
             btn.setAttribute('aria-checked', isActive);
         });
 
-        this.dom.stage.className = `rv-viewer-stage rv-mode-${mode}`;
+        this.dom.stage.classList.remove(
+            'rv-mode-slider',
+            'rv-mode-overlay',
+            'rv-mode-diff',
+            'rv-mode-blink',
+        );
+        this.dom.stage.classList.add(`rv-mode-${mode}`);
         this.updateModeControls();
         this.render();
     },
@@ -1039,6 +1264,7 @@ const ReportViewer = {
         this.dom.activeControls.hidden = !isOverlay;
         this.dom.leftSelect.disabled = isOverlay;
         this.dom.rightSelect.disabled = isOverlay;
+        this.dom.btnSwapClips.disabled = isOverlay || this.clipCount() <= 1;
         this.dom.activeSelect.disabled = !isOverlay;
 
         if (mode === 'diff') {
@@ -1105,7 +1331,9 @@ const ReportViewer = {
             this.setLeftClip((this.state.leftClipIdx + direction + count) % count);
         } else if (this.state.mode === 'diff' || this.state.mode === 'blink') {
             // Cycle the comparison side of the explicit pair.
-            this.setRightClip((this.state.rightClipIdx + direction + count) % count);
+            this.setRightClip(
+                this.nextDistinctClipIndex(this.state.rightClipIdx, this.state.leftClipIdx, direction)
+            );
         } else {
             this.state.activeClipIdx = (this.state.activeClipIdx + direction + count) % count;
             this.dom.activeSelect.value = this.state.activeClipIdx;
@@ -1129,6 +1357,7 @@ const ReportViewer = {
         this.dom.zoomRange.value = this.state.zoom;
         this.dom.zoomRange.setAttribute('aria-valuenow', this.state.zoom);
         this.dom.zoomVal.textContent = Math.round(this.state.zoom * 100) + '%';
+        this.dom.canvas.classList.toggle('rv-canvas--pixelated', this.state.zoom > 1);
         this.dom.canvas.style.setProperty('--zoom-level', this.state.zoom);
         if (options.clampPan !== false) this.clampPan();
     },
@@ -1385,16 +1614,34 @@ const ReportViewer = {
         return cat.replace(/_/g, ' ').replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
     },
 
+    normalizedDisplayToken(value) {
+        return String(value || '')
+            .trim()
+            .toLowerCase()
+            .replace(/[_-]+/g, ' ')
+            .replace(/\s+/g, ' ');
+    },
+
+    shouldShowFrameCategory(label, categoryText) {
+        return Boolean(categoryText)
+            && this.normalizedDisplayToken(label) !== this.normalizedDisplayToken(categoryText);
+    },
+
     updateCurrentFrameMetadata(frameData) {
         const frame = frameData || this.state.data?.frames?.[this.state.currentFrameIdx] || null;
         const label = frame?.label || 'No frame selected';
         const detail = frame?.detail || 'No frame detail available.';
-        const category = frame?.category || 'none';
+        const categoryText = frame?.category ? this.humanizeCategory(frame.category) : '';
+        const showCategory = this.shouldShowFrameCategory(label, categoryText);
 
         if (this.dom.currentFrameLabel) this.dom.currentFrameLabel.textContent = label;
         if (this.dom.currentFrameDetail) this.dom.currentFrameDetail.textContent = detail;
+        if (this.dom.currentFrameCategoryDivider) {
+            this.dom.currentFrameCategoryDivider.hidden = !showCategory;
+        }
         if (this.dom.currentFrameCategory) {
-            this.dom.currentFrameCategory.textContent = this.humanizeCategory(category);
+            this.dom.currentFrameCategory.hidden = !showCategory;
+            this.dom.currentFrameCategory.textContent = showCategory ? categoryText : '';
         }
     },
 
@@ -1412,7 +1659,7 @@ const ReportViewer = {
         let leftLabelTxt, rightLabelTxt;
         this.updateCurrentFrameMetadata(frameData);
 
-        if (this.state.mode === 'slider' || this.state.mode === 'diff') {
+        if (this.state.mode === 'slider' || this.state.mode === 'diff' || this.state.mode === 'blink') {
             const leftImage = frameData.images?.[this.state.leftClipIdx];
             const rightImage = frameData.images?.[this.state.rightClipIdx];
             const leftClip = this.state.data.clips[this.state.leftClipIdx];
@@ -1426,15 +1673,19 @@ const ReportViewer = {
             leftSrc = leftImage.src;
             rightSrc = rightImage.src;
 
-            leftLabelTxt = `${leftClip.label} (Left)`;
-            rightLabelTxt = `${rightClip.label} (Right)`;
+            if (this.state.mode === 'blink') {
+                leftLabelTxt = leftClip.label;
+                rightLabelTxt = rightClip.label;
+            } else {
+                leftLabelTxt = `${leftClip.label} (Left)`;
+                rightLabelTxt = `${rightClip.label} (Right)`;
+            }
 
             // For Diff mode, right layer is the "compare" one which gets difference blend
             // Left layer is base.
 
         } else {
-            // Overlay or Blink - show activeClip
-            // We use left layer as the main visible one for these modes
+            // Overlay uses the left layer as the single visible layer.
             const activeImage = frameData.images?.[this.state.activeClipIdx];
             const rightImage = frameData.images?.[this.state.rightClipIdx];
             const activeClip = this.state.data.clips[this.state.activeClipIdx];
@@ -1462,7 +1713,7 @@ const ReportViewer = {
             }
             this.dom.leftImg.src = leftSrc;
             // Alt text update
-            const clip = (this.state.mode === 'overlay' || this.state.mode === 'blink')
+            const clip = this.state.mode === 'overlay'
                 ? this.state.data.clips[this.state.activeClipIdx]
                 : this.state.data.clips[this.state.leftClipIdx];
             const clipName = clip?.label || 'Clip';
@@ -1479,9 +1730,16 @@ const ReportViewer = {
         this.dom.labelRight.textContent = rightLabelTxt;
 
         // Toggle visibility classes based on mode logic in CSS
-        const singleClipMode = this.state.mode === 'overlay' || this.state.mode === 'blink';
-        this.dom.leftLayer.classList.toggle('active', singleClipMode);
-        this.dom.rightLayer.classList.toggle('active', false);
+        const isOverlay = this.state.mode === 'overlay';
+        const isBlink = this.state.mode === 'blink';
+        this.dom.leftLayer.classList.toggle(
+            'active',
+            isOverlay || (isBlink && this.state.activeClipIdx === this.state.leftClipIdx)
+        );
+        this.dom.rightLayer.classList.toggle(
+            'active',
+            isBlink && this.state.activeClipIdx === this.state.rightClipIdx
+        );
     },
 
     clearFrameImages() {
@@ -1514,6 +1772,7 @@ const ReportViewer = {
         this.dom.leftSelect.value = this.state.leftClipIdx;
         this.dom.rightSelect.value = this.state.rightClipIdx;
         this.dom.activeSelect.value = this.state.activeClipIdx;
+        this.updateOverlayVisibility();
 
         // Update images and labels
         this.updateImages();

--- a/src/frame_compare/services/report/assets/viewer.js
+++ b/src/frame_compare/services/report/assets/viewer.js
@@ -24,7 +24,8 @@ const ReportViewer = {
         activeCategoryKey: ALL_CATEGORY_FILTER_KEY,
         overlaysHidden: false,
         categoryFilterKeys: new Map(),
-        preloadedSrcs: new Set(),
+        imageLoadPromises: new Map(),
+        imageRequestToken: 0,
         helpRestoreFocus: null,
         infoRestoreFocus: null,
         rawAlignX: null,
@@ -1643,6 +1644,77 @@ const ReportViewer = {
         }
     },
 
+    commitImageState(imageState) {
+        const requestToken = ++this.state.imageRequestToken;
+        const commit = () => {
+            if (requestToken !== this.state.imageRequestToken) return;
+            this.applyImageState(imageState);
+        };
+
+        if (!this.shouldAwaitAtomicDiffSwap(imageState)) {
+            commit();
+            return;
+        }
+
+        Promise.all([
+            this.ensureImageReady(imageState.leftSrc),
+            this.ensureImageReady(imageState.rightSrc),
+        ]).then(() => {
+            if (typeof window.requestAnimationFrame === 'function') {
+                window.requestAnimationFrame(() => commit());
+                return;
+            }
+            commit();
+        });
+    },
+
+    shouldAwaitAtomicDiffSwap(imageState) {
+        return this.state.mode === 'diff'
+            && (
+                this.dom.leftImg.getAttribute('src') !== imageState.leftSrc
+                || this.dom.rightImg.getAttribute('src') !== imageState.rightSrc
+            );
+    },
+
+    applyImageState(imageState) {
+        const {
+            frameData,
+            leftSrc,
+            rightSrc,
+            leftAlt,
+            rightAlt,
+            leftLabelTxt,
+            rightLabelTxt,
+            isOverlay,
+            isBlink,
+        } = imageState;
+
+        if (this.dom.leftImg.getAttribute('src') !== leftSrc) {
+            if (this.dom.sizerImg && this.dom.sizerImg.getAttribute('src') !== leftSrc) {
+                this.dom.sizerImg.src = leftSrc;
+            }
+            this.dom.leftImg.src = leftSrc;
+        }
+        if (this.dom.rightImg.getAttribute('src') !== rightSrc) {
+            this.dom.rightImg.src = rightSrc;
+        }
+
+        this.dom.leftImg.alt = leftAlt;
+        this.dom.rightImg.alt = rightAlt;
+        this.dom.labelLeft.textContent = leftLabelTxt;
+        this.dom.labelRight.textContent = rightLabelTxt;
+        this.updateCurrentFrameMetadata(frameData);
+
+        this.dom.leftLayer.classList.toggle(
+            'active',
+            isOverlay || (isBlink && this.state.activeClipIdx === this.state.leftClipIdx)
+        );
+        this.dom.rightLayer.classList.toggle(
+            'active',
+            isBlink && this.state.activeClipIdx === this.state.rightClipIdx
+        );
+    },
+
     updateImages() {
         const frameData = this.state.data.frames[this.state.currentFrameIdx];
         if (!frameData) {
@@ -1655,7 +1727,9 @@ const ReportViewer = {
 
         let leftSrc, rightSrc;
         let leftLabelTxt, rightLabelTxt;
-        this.updateCurrentFrameMetadata(frameData);
+        let leftAlt, rightAlt;
+        const isOverlay = this.state.mode === 'overlay';
+        const isBlink = this.state.mode === 'blink';
 
         if (this.state.mode === 'slider' || this.state.mode === 'diff' || this.state.mode === 'blink') {
             const leftImage = frameData.images?.[this.state.leftClipIdx];
@@ -1678,6 +1752,8 @@ const ReportViewer = {
                 leftLabelTxt = `${leftClip.label} (Left)`;
                 rightLabelTxt = `${rightClip.label} (Right)`;
             }
+            leftAlt = `${leftClip.label} - Frame ${frameData.number}`;
+            rightAlt = `${rightClip.label} - Frame ${frameData.number}`;
 
             // For Diff mode, right layer is the "compare" one which gets difference blend
             // Left layer is base.
@@ -1700,47 +1776,27 @@ const ReportViewer = {
 
             leftLabelTxt = activeClip.label;
             rightLabelTxt = "";
+            leftAlt = `${activeClip.label} - Frame ${frameData.number}`;
+            rightAlt = `${rightClip.label} - Frame ${frameData.number}`;
         }
 
         this.hideStageMessage();
         this.clearStatus();
-
-        if (this.dom.leftImg.getAttribute('src') !== leftSrc) {
-            if (this.dom.sizerImg && this.dom.sizerImg.getAttribute('src') !== leftSrc) {
-                this.dom.sizerImg.src = leftSrc;
-            }
-            this.dom.leftImg.src = leftSrc;
-            // Alt text update
-            const clip = this.state.mode === 'overlay'
-                ? this.state.data.clips[this.state.activeClipIdx]
-                : this.state.data.clips[this.state.leftClipIdx];
-            const clipName = clip?.label || 'Clip';
-            this.dom.leftImg.alt = `${clipName} - Frame ${frameData.number}`;
-        }
-        if (this.dom.rightImg.getAttribute('src') !== rightSrc) {
-            this.dom.rightImg.src = rightSrc;
-            // Alt text update for right image (only relevant in split modes)
-            const clipName = this.state.data.clips[this.state.rightClipIdx]?.label || 'Clip';
-            this.dom.rightImg.alt = `${clipName} - Frame ${frameData.number}`;
-        }
-
-        this.dom.labelLeft.textContent = leftLabelTxt;
-        this.dom.labelRight.textContent = rightLabelTxt;
-
-        // Toggle visibility classes based on mode logic in CSS
-        const isOverlay = this.state.mode === 'overlay';
-        const isBlink = this.state.mode === 'blink';
-        this.dom.leftLayer.classList.toggle(
-            'active',
-            isOverlay || (isBlink && this.state.activeClipIdx === this.state.leftClipIdx)
-        );
-        this.dom.rightLayer.classList.toggle(
-            'active',
-            isBlink && this.state.activeClipIdx === this.state.rightClipIdx
-        );
+        this.commitImageState({
+            frameData,
+            leftSrc,
+            rightSrc,
+            leftAlt,
+            rightAlt,
+            leftLabelTxt,
+            rightLabelTxt,
+            isOverlay,
+            isBlink,
+        });
     },
 
     clearFrameImages() {
+        this.state.imageRequestToken += 1;
         if (this.dom.sizerImg) this.dom.sizerImg.src = EMPTY_IMAGE_SRC;
         if (this.dom.leftImg) {
             this.dom.leftImg.src = EMPTY_IMAGE_SRC;
@@ -1836,11 +1892,46 @@ const ReportViewer = {
     },
 
     preloadImage(src) {
-        if (!src || src.startsWith('data:') || this.state.preloadedSrcs.has(src)) return;
+        void this.ensureImageReady(src);
+    },
 
-        this.state.preloadedSrcs.add(src);
-        const image = new Image();
-        image.src = src;
+    ensureImageReady(src) {
+        if (!src || src.startsWith('data:')) return Promise.resolve();
+
+        const existingPromise = this.state.imageLoadPromises.get(src);
+        if (existingPromise) return existingPromise;
+
+        const promise = new Promise(resolve => {
+            const image = new Image();
+            let settled = false;
+            const finish = () => {
+                if (settled) return;
+                settled = true;
+                resolve();
+            };
+            const decodeAndFinish = () => {
+                if (typeof image.decode === 'function') {
+                    image.decode().catch(() => undefined).finally(finish);
+                    return;
+                }
+                finish();
+            };
+
+            image.addEventListener('load', decodeAndFinish, { once: true });
+            image.addEventListener('error', finish, { once: true });
+            image.decoding = 'async';
+            image.src = src;
+            if (image.complete) {
+                if (image.naturalWidth > 0 || image.naturalHeight > 0) {
+                    decodeAndFinish();
+                } else {
+                    finish();
+                }
+            }
+        });
+
+        this.state.imageLoadPromises.set(src, promise);
+        return promise;
     }
 };
 

--- a/src/frame_compare/services/report/category_display.py
+++ b/src/frame_compare/services/report/category_display.py
@@ -1,0 +1,36 @@
+"""Shared category display helpers for report labels and filters."""
+
+from __future__ import annotations
+
+_CATEGORY_LABELS = {
+    "quantile_bright": "Bright",
+    "quantile_dark": "Dark",
+    "scene-cut": "Scene Cuts",
+    "scene_cut": "Scene Cuts",
+    "selected": "Selected",
+}
+
+
+def humanize_category(category: str | None) -> str | None:
+    """Map technical report categories into readable display labels."""
+    if category is None:
+        return None
+    if category in _CATEGORY_LABELS:
+        return _CATEGORY_LABELS[category]
+    return category.replace("_", " ").replace("-", " ").title()
+
+
+def normalized_display_token(value: str | None) -> str | None:
+    """Normalize category and label text for display-equivalence checks."""
+    if value is None:
+        return None
+    normalized = " ".join(value.replace("_", " ").replace("-", " ").split()).casefold()
+    return normalized or None
+
+
+def label_repeats_category(label: str | None, category: str | None) -> bool:
+    """Return whether a label repeats the human-readable category text."""
+    label_token = normalized_display_token(label)
+    return label_token is not None and label_token == normalized_display_token(
+        humanize_category(category)
+    )

--- a/src/frame_compare/services/report/display.py
+++ b/src/frame_compare/services/report/display.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from frame_compare.services.report.category_display import label_repeats_category
 from frame_compare.services.report.payload import FrameDetail
 
 
@@ -18,35 +19,6 @@ class SourceFrameSelectionDetail:
 
 def _default_frame_label(source_frame: int) -> str:
     return f"Frame {source_frame}"
-
-
-def _humanize_category(category: str | None) -> str | None:
-    if category is None:
-        return None
-    mapping = {
-        "quantile_bright": "Bright",
-        "quantile_dark": "Dark",
-        "scene-cut": "Scene Cuts",
-        "scene_cut": "Scene Cuts",
-        "selected": "Selected",
-    }
-    if category in mapping:
-        return mapping[category]
-    return category.replace("_", " ").replace("-", " ").title()
-
-
-def _normalized_display_token(value: str | None) -> str | None:
-    if value is None:
-        return None
-    normalized = " ".join(value.replace("_", " ").replace("-", " ").split()).casefold()
-    return normalized or None
-
-
-def _label_repeats_category(label: str | None, category: str | None) -> bool:
-    humanized_category = _humanize_category(category)
-    return _normalized_display_token(label) is not None and _normalized_display_token(
-        label
-    ) == _normalized_display_token(humanized_category)
 
 
 def category_from_selection_label(label: str | None) -> str | None:
@@ -82,7 +54,7 @@ def frame_detail_for_source_frame(
     if (
         selection_detail is not None
         and selection_detail.label is not None
-        and not _label_repeats_category(selection_detail.label, category)
+        and not label_repeats_category(selection_detail.label, category)
     ):
         label = selection_detail.label
 

--- a/src/frame_compare/services/report/display.py
+++ b/src/frame_compare/services/report/display.py
@@ -16,6 +16,39 @@ class SourceFrameSelectionDetail:
     notes: str | None = None
 
 
+def _default_frame_label(source_frame: int) -> str:
+    return f"Frame {source_frame}"
+
+
+def _humanize_category(category: str | None) -> str | None:
+    if category is None:
+        return None
+    mapping = {
+        "quantile_bright": "Bright",
+        "quantile_dark": "Dark",
+        "scene-cut": "Scene Cuts",
+        "scene_cut": "Scene Cuts",
+        "selected": "Selected",
+    }
+    if category in mapping:
+        return mapping[category]
+    return category.replace("_", " ").replace("-", " ").title()
+
+
+def _normalized_display_token(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = " ".join(value.replace("_", " ").replace("-", " ").split()).casefold()
+    return normalized or None
+
+
+def _label_repeats_category(label: str | None, category: str | None) -> bool:
+    humanized_category = _humanize_category(category)
+    return _normalized_display_token(label) is not None and _normalized_display_token(
+        label
+    ) == _normalized_display_token(humanized_category)
+
+
 def category_from_selection_label(label: str | None) -> str | None:
     if label is None:
         return None
@@ -39,20 +72,21 @@ def frame_detail_for_source_frame(
     selection_label: str | None,
 ) -> FrameDetail:
     """Build report display metadata for a selected source-domain frame."""
-    label = (
-        selection_detail.label
-        if selection_detail is not None and selection_detail.label is not None
-        else selection_label
-    )
-    detail_text = f"Source frame {source_frame}"
-    if selection_detail is not None and selection_detail.timecode is not None:
-        detail_text = f"{detail_text} ({selection_detail.timecode})"
-
     category = None
     if selection_detail is not None:
         category = selection_detail.notes or category_from_selection_label(selection_detail.label)
     if category is None:
         category = category_from_selection_label(selection_label)
+
+    label = _default_frame_label(source_frame)
+    if (
+        selection_detail is not None
+        and selection_detail.label is not None
+        and not _label_repeats_category(selection_detail.label, category)
+    ):
+        label = selection_detail.label
+
+    detail_text = f"Source frame {source_frame}"
 
     return FrameDetail(
         label=label,

--- a/src/frame_compare/services/report/renderer.py
+++ b/src/frame_compare/services/report/renderer.py
@@ -427,13 +427,15 @@ def _render_stage() -> str:
             <img src="data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=" alt="" class="rv-sizer" aria-hidden="true">
             <div class="rv-layer rv-left">
                 <img src="" alt="" class="rv-image">
-                <div id="label-left" class="rv-overlay-label"></div>
             </div>
             <div class="rv-layer rv-right">
                 <img src="" alt="" class="rv-image">
-                <div id="label-right" class="rv-overlay-label right"></div>
             </div>
             <div class="rv-divider"><div class="rv-divider-handle"></div></div>
+            <div class="rv-stage-labels" aria-hidden="true">
+                <div id="label-left" class="rv-overlay-label"></div>
+                <div id="label-right" class="rv-overlay-label right"></div>
+            </div>
         </div>
         <div class="rv-stage-overlay-info">
             <span class="rv-info-label" data-current-frame-label></span>

--- a/src/frame_compare/services/report/renderer.py
+++ b/src/frame_compare/services/report/renderer.py
@@ -111,6 +111,27 @@ def _humanize_category(cat: str) -> str:
     return cat.replace("_", " ").replace("-", " ").title()
 
 
+def _normalized_display_token(value: str) -> str:
+    return " ".join(value.replace("_", " ").replace("-", " ").split()).casefold()
+
+
+def _frame_category_text(frame: ReportFramePayload) -> str:
+    return _humanize_category(frame["category"])
+
+
+def _frame_label_repeats_category(frame: ReportFramePayload) -> bool:
+    return _normalized_display_token(frame["label"]) == _normalized_display_token(
+        _frame_category_text(frame)
+    )
+
+
+def _frame_filmstrip_label(frame: ReportFramePayload) -> str:
+    category_text = _frame_category_text(frame)
+    if _frame_label_repeats_category(frame):
+        return frame["label"]
+    return f"{frame['label']} • {category_text}"
+
+
 def _frame_categories(frames: list[ReportFramePayload]) -> list[str]:
     categories: list[str] = []
     seen: set[str] = set()
@@ -172,7 +193,7 @@ def _render_filmstrip(
                         <span class="rv-filmstrip-accent" data-category-key="{_esc_attr(category_filter_keys[frame["category"]])}" data-category="{_esc_attr(frame["category"])}"></span>
                     </span>
                     <span class="rv-filmstrip-caption">
-                        <span class="rv-filmstrip-label">{_esc_text(frame["label"])} • {_esc_text(_humanize_category(frame["category"]))}</span>
+                        <span class="rv-filmstrip-label">{_esc_text(_frame_filmstrip_label(frame))}</span>
                         <span class="rv-filmstrip-detail">{_esc_text(frame["detail"])}</span>
                     </span>
                 </button>
@@ -230,9 +251,9 @@ def _render_info_modal(
     if safe_slowpics_href:
         slowpics_row = f'<div><dt>slow.pics</dt><dd><a href="{safe_slowpics_href}" target="_blank" rel="noopener noreferrer" class="rv-link">{_esc_text(slowpics_url)}</a></dd></div>'
     elif slowpics_url:
-        slowpics_row = f'<div><dt>slow.pics</dt><dd>{_esc_text(slowpics_url)}</dd></div>'
+        slowpics_row = f"<div><dt>slow.pics</dt><dd>{_esc_text(slowpics_url)}</dd></div>"
     else:
-        slowpics_row = '<div><dt>slow.pics</dt><dd>Not uploaded</dd></div>'
+        slowpics_row = "<div><dt>slow.pics</dt><dd>Not uploaded</dd></div>"
 
     clip_items: list[str] = []
     for i, clip in enumerate(clips):
@@ -240,16 +261,16 @@ def _render_info_modal(
         clip_items.append(
             f'<li class="rv-clip-meta-item" data-clip-index="{_esc_attr(i)}">'
             f'<div class="rv-clip-meta-heading">'
-            f'<span>{_esc_text(clip["label"])}</span>'
-            f'<span>{hdr_tag}</span>'
-            f'</div>'
+            f"<span>{_esc_text(clip['label'])}</span>"
+            f"<span>{hdr_tag}</span>"
+            f"</div>"
             f'<dl class="rv-metadata-list">'
-            f'<div><dt>Name</dt><dd>{_esc_text(clip["name"])}</dd></div>'
-            f'<div><dt>Resolution</dt><dd>{_render_resolution(clip["resolution"])}</dd></div>'
-            f'<div><dt>FPS</dt><dd>{_render_fps(clip["fps"])}</dd></div>'
-            f'<div><dt>Frames</dt><dd>{clip["frame_count"]}</dd></div>'
-            f'</dl>'
-            f'</li>'
+            f"<div><dt>Name</dt><dd>{_esc_text(clip['name'])}</dd></div>"
+            f"<div><dt>Resolution</dt><dd>{_render_resolution(clip['resolution'])}</dd></div>"
+            f"<div><dt>FPS</dt><dd>{_render_fps(clip['fps'])}</dd></div>"
+            f"<div><dt>Frames</dt><dd>{clip['frame_count']}</dd></div>"
+            f"</dl>"
+            f"</li>"
         )
     clip_list_html = (
         f'<ol class="rv-clip-meta-list">{"".join(clip_items)}</ol>'
@@ -334,6 +355,7 @@ def _render_controls(
             <select id="left-select" aria-label="Left clip">
                 {left_clip_options}
             </select>
+            <button id="btn-swap-clips" class="rv-swap-button" aria-label="Swap comparison clips" title="Swap clips (X)">⇄</button>
             <span class="rv-clip-vs">vs</span>
             <span class="rv-clip-prefix right">R:</span>
             <select id="right-select" aria-label="Right clip">
@@ -392,6 +414,10 @@ def _render_controls(
         <div class="rv-control-group">
             <button id="btn-fullscreen" aria-label="Enter fullscreen" aria-pressed="false" title="Fullscreen">Fullscreen</button>
         </div>
+
+        <div class="rv-control-group">
+            <button id="btn-overlays" class="active" aria-label="Hide overlays" aria-pressed="true" title="Hide overlays (H)">Overlays</button>
+        </div>
     </div>"""
 
 
@@ -414,7 +440,7 @@ def _render_stage() -> str:
             <span class="rv-info-label" data-current-frame-label></span>
             <span class="rv-info-divider">•</span>
             <span class="rv-info-detail" data-current-frame-detail></span>
-            <span class="rv-info-divider">•</span>
+            <span class="rv-info-divider" data-current-frame-category-divider>•</span>
             <span class="rv-info-category" data-current-frame-category></span>
         </div>
     </div>"""
@@ -423,16 +449,18 @@ def _render_stage() -> str:
 def _render_help_modal() -> str:
     return """    <div id="help-modal" class="rv-modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="help-modal-title" tabindex="-1">
         <div class="rv-modal-content">
-            <div id="help-modal-title" class="rv-modal-title">Keyboard Shortcuts</div>
+            <div id="help-modal-title" class="rv-modal-title">Viewer Shortcuts</div>
             <div class="rv-shortcuts-grid">
                 <div class="rv-shortcut-row"><span>Previous Frame</span><span class="rv-key">←</span></div>
                 <div class="rv-shortcut-row"><span>Next Frame</span><span class="rv-key">→</span></div>
                 <div class="rv-shortcut-row"><span>First / Last Frame</span><span class="rv-key">Home / End</span></div>
                 <div class="rv-shortcut-row"><span>Cycle Clip</span><span class="rv-key">↑ / ↓</span></div>
                 <div class="rv-shortcut-row"><span>Direct Clip Select</span><span class="rv-key">1 - 9</span></div>
+                <div class="rv-shortcut-row"><span>Swap Clips</span><span class="rv-key">X</span></div>
                 <div class="rv-shortcut-row"><span>Modes (Slider/Overlay/Diff/Blink)</span><span class="rv-key">S / O / D / B</span></div>
+                <div class="rv-shortcut-row"><span>Toggle Overlays</span><span class="rv-key">H</span></div>
                 <div class="rv-shortcut-row"><span>Zoom In / Out</span><span class="rv-key">+ / -</span></div>
-                <div class="rv-shortcut-row"><span>Reset Viewport</span><span class="rv-key">R</span></div>
+                <div class="rv-shortcut-row"><span>Reset Viewport</span><span class="rv-key">R / Double-click</span></div>
                 <div class="rv-shortcut-row"><span>Open Help</span><span class="rv-key">?</span></div>
                 <div class="rv-shortcut-row"><span>Close Help / Exit Fullscreen</span><span class="rv-key">Esc</span></div>
             </div>

--- a/src/frame_compare/services/report/renderer.py
+++ b/src/frame_compare/services/report/renderer.py
@@ -111,7 +111,6 @@ def _humanize_category(cat: str) -> str:
     return cat.replace("_", " ").replace("-", " ").title()
 
 
-
 def _frame_categories(frames: list[ReportFramePayload]) -> list[str]:
     categories: list[str] = []
     seen: set[str] = set()
@@ -214,6 +213,7 @@ def _render_info_modal(
     right_clip_index: int,
 ) -> str:
     clips = data["clips"]
+    stats = data["stats"]
     title = data["title"]
     report_id = data["report_id"]
     generated_at = data["generated_at"]
@@ -251,10 +251,14 @@ def _render_info_modal(
             f'</dl>'
             f'</li>'
         )
-    clip_list_html = "".join(clip_items) if clip_items else '<div class="rv-metadata-empty">No clips in payload.</div>'
+    clip_list_html = (
+        f'<ol class="rv-clip-meta-list">{"".join(clip_items)}</ol>'
+        if clip_items
+        else '<div class="rv-metadata-empty">No clips in payload.</div>'
+    )
 
     return f"""    <div id="info-modal" class="rv-modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="info-modal-title" tabindex="-1">
-        <div class="rv-modal-content" style="max-width: 600px;">
+        <div class="rv-modal-content rv-modal-content--wide">
             <div id="info-modal-title" class="rv-modal-title">Report Information</div>
             <div class="rv-info-grid">
                 <div class="rv-info-section">
@@ -263,6 +267,8 @@ def _render_info_modal(
                         <div><dt>Title</dt><dd>{_esc_text(title)}</dd></div>
                         <div><dt>Report ID</dt><dd>{_esc_text(report_id)}</dd></div>
                         <div><dt>Generated</dt><dd>{_esc_text(generated_at)}</dd></div>
+                        <div><dt>Frames</dt><dd>{stats["frame_count"]}</dd></div>
+                        <div><dt>Clips</dt><dd>{stats["clip_count"]}</dd></div>
                         <div><dt>Default Mode</dt><dd>{_esc_text(default_mode)}</dd></div>
                         <div><dt>Default Pair</dt><dd>{default_pair}</dd></div>
                         {slowpics_row}
@@ -270,12 +276,10 @@ def _render_info_modal(
                 </div>
                 <div class="rv-info-section">
                     <h3>Clips</h3>
-                    <ol class="rv-clip-meta-list">
-                        {clip_list_html}
-                    </ol>
+                    {clip_list_html}
                 </div>
             </div>
-            <div style="margin-top: 1.5rem; text-align: right;">
+            <div class="rv-modal-actions rv-modal-actions--spacious">
                 <button id="btn-close-info">Close</button>
             </div>
         </div>
@@ -305,7 +309,6 @@ def _render_header(
 
 def _render_controls(
     frame_options: str,
-    category_filter_controls: str,
     left_clip_options: str,
     right_clip_options: str,
     active_clip_options: str,
@@ -350,7 +353,7 @@ def _render_controls(
             <input type="range" id="zoom-range" min="0.25" max="4.0" step="0.1" value="1.0" aria-label="Zoom level" aria-valuemin="0.25" aria-valuemax="4.0" aria-valuenow="1.0">
             <button id="btn-zoom-in" aria-label="Zoom in">+</button>
             <button id="btn-zoom-reset" aria-label="Reset zoom">R</button>
-            <span id="zoom-val" style="width: 4ch">100%</span>
+            <span id="zoom-val" class="rv-zoom-value">100%</span>
         </div>
 
         <div class="rv-control-group" role="radiogroup" aria-label="Fit mode">
@@ -433,7 +436,7 @@ def _render_help_modal() -> str:
                 <div class="rv-shortcut-row"><span>Open Help</span><span class="rv-key">?</span></div>
                 <div class="rv-shortcut-row"><span>Close Help / Exit Fullscreen</span><span class="rv-key">Esc</span></div>
             </div>
-            <div style="margin-top: 1rem; text-align: right;">
+            <div class="rv-modal-actions">
                 <button id="btn-close-help">Close</button>
             </div>
         </div>
@@ -496,7 +499,6 @@ def build_html(data: ReportPayload, include_filmstrip: bool = True) -> str:
     )
     controls_html = _render_controls(
         frame_options,
-        category_filter_controls,
         left_clip_options,
         right_clip_options,
         active_clip_options,

--- a/src/frame_compare/services/report/renderer.py
+++ b/src/frame_compare/services/report/renderer.py
@@ -193,6 +193,95 @@ def _render_filmstrip(
         """
 
 
+def _render_resolution(resolution: tuple[int, int]) -> str:
+    return f"{resolution[0]}x{resolution[1]}"
+
+
+def _render_fps(fps: float) -> str:
+    return f"{fps:g} fps"
+
+
+def _clip_label_for_index(clips: list[ReportClipPayload], index: int) -> str:
+    if 0 <= index < len(clips):
+        return clips[index]["label"]
+    return f"Clip {index + 1}"
+
+
+def _render_info_modal(
+    data: ReportPayload,
+    *,
+    left_clip_index: int,
+    right_clip_index: int,
+) -> str:
+    clips = data["clips"]
+    title = data["title"]
+    report_id = data["report_id"]
+    generated_at = data["generated_at"]
+    default_mode = data["default_mode"]
+
+    default_pair = (
+        f"{_esc_text(_clip_label_for_index(clips, left_clip_index))} "
+        f"vs {_esc_text(_clip_label_for_index(clips, right_clip_index))}"
+    )
+
+    slowpics_url = data["slowpics_url"]
+    safe_slowpics_href = _safe_http_href(slowpics_url)
+    slowpics_row = ""
+    if safe_slowpics_href:
+        slowpics_row = f'<div><dt>slow.pics</dt><dd><a href="{safe_slowpics_href}" target="_blank" rel="noopener noreferrer" class="rv-link">{_esc_text(slowpics_url)}</a></dd></div>'
+    elif slowpics_url:
+        slowpics_row = f'<div><dt>slow.pics</dt><dd>{_esc_text(slowpics_url)}</dd></div>'
+    else:
+        slowpics_row = '<div><dt>slow.pics</dt><dd>Not uploaded</dd></div>'
+
+    clip_items: list[str] = []
+    for i, clip in enumerate(clips):
+        hdr_tag = "HDR" if clip["hdr"] else "SDR"
+        clip_items.append(
+            f'<li class="rv-clip-meta-item" data-clip-index="{_esc_attr(i)}">'
+            f'<div class="rv-clip-meta-heading">'
+            f'<span>{_esc_text(clip["label"])}</span>'
+            f'<span>{hdr_tag}</span>'
+            f'</div>'
+            f'<dl class="rv-metadata-list">'
+            f'<div><dt>Name</dt><dd>{_esc_text(clip["name"])}</dd></div>'
+            f'<div><dt>Resolution</dt><dd>{_render_resolution(clip["resolution"])}</dd></div>'
+            f'<div><dt>FPS</dt><dd>{_render_fps(clip["fps"])}</dd></div>'
+            f'<div><dt>Frames</dt><dd>{clip["frame_count"]}</dd></div>'
+            f'</dl>'
+            f'</li>'
+        )
+    clip_list_html = "".join(clip_items) if clip_items else '<div class="rv-metadata-empty">No clips in payload.</div>'
+
+    return f"""    <div id="info-modal" class="rv-modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="info-modal-title" tabindex="-1">
+        <div class="rv-modal-content" style="max-width: 600px;">
+            <div id="info-modal-title" class="rv-modal-title">Report Information</div>
+            <div class="rv-info-grid">
+                <div class="rv-info-section">
+                    <h3>General</h3>
+                    <dl class="rv-metadata-list">
+                        <div><dt>Title</dt><dd>{_esc_text(title)}</dd></div>
+                        <div><dt>Report ID</dt><dd>{_esc_text(report_id)}</dd></div>
+                        <div><dt>Generated</dt><dd>{_esc_text(generated_at)}</dd></div>
+                        <div><dt>Default Mode</dt><dd>{_esc_text(default_mode)}</dd></div>
+                        <div><dt>Default Pair</dt><dd>{default_pair}</dd></div>
+                        {slowpics_row}
+                    </dl>
+                </div>
+                <div class="rv-info-section">
+                    <h3>Clips</h3>
+                    <ol class="rv-clip-meta-list">
+                        {clip_list_html}
+                    </ol>
+                </div>
+            </div>
+            <div style="margin-top: 1.5rem; text-align: right;">
+                <button id="btn-close-info">Close</button>
+            </div>
+        </div>
+    </div>"""
+
+
 def _render_header(
     title: str,
     generated_at: str,
@@ -200,6 +289,7 @@ def _render_header(
     clip_count: int,
     slowpics_link: str,
 ) -> str:
+    info_button = '<button id="btn-info" class="rv-header-info-btn" aria-label="Report information" title="Report Info (I)">ℹ</button>'
     help_button = '<button id="btn-help" class="rv-header-help-btn" aria-label="Keyboard shortcuts" title="Help (?)">?</button>'
     slowpics_block = f"{slowpics_link} • " if slowpics_link else ""
     return f"""        <header class="rv-header">
@@ -208,7 +298,7 @@ def _render_header(
                 <div class="rv-meta">Generated {_esc_text(generated_at)} • {frame_count} frames • {clip_count} clips</div>
             </div>
             <div class="rv-header-right">
-                {slowpics_block}{help_button}
+                {slowpics_block}{info_button} {help_button}
             </div>
         </header>"""
 
@@ -413,6 +503,11 @@ def build_html(data: ReportPayload, include_filmstrip: bool = True) -> str:
     )
     stage_html = _render_stage()
     modal_html = _render_help_modal()
+    info_modal_html = _render_info_modal(
+        data,
+        left_clip_index=left_clip_index,
+        right_clip_index=right_clip_index,
+    )
     footer_html = _render_footer(json_str)
 
     return f"""<!DOCTYPE html>
@@ -429,6 +524,7 @@ def build_html(data: ReportPayload, include_filmstrip: bool = True) -> str:
 {controls_html}
 {stage_html}
 {modal_html}
+{info_modal_html}
 <div class="rv-category-filters-container">
     <div class="rv-filter-group" data-control-scope="frame-filters" aria-label="Frame category filters">
         {category_filter_controls}

--- a/src/frame_compare/services/report/renderer.py
+++ b/src/frame_compare/services/report/renderer.py
@@ -97,98 +97,19 @@ def _render_slowpics_link(slowpics_url: str | None) -> str:
     )
 
 
-def _render_resolution(resolution: tuple[int, int]) -> str:
-    return f"{resolution[0]}x{resolution[1]}"
+def _humanize_category(cat: str) -> str:
+    """Map dynamic technical categories into readable names."""
+    mapping = {
+        "quantile_bright": "Bright",
+        "quantile_dark": "Dark",
+        "scene-cut": "Scene Cuts",
+        "scene_cut": "Scene Cuts",
+        "selected": "Selected",
+    }
+    if cat in mapping:
+        return mapping[cat]
+    return cat.replace("_", " ").replace("-", " ").title()
 
-
-def _render_fps(fps: float) -> str:
-    return f"{fps:g} fps"
-
-
-def _clip_label_for_index(clips: list[ReportClipPayload], index: int) -> str:
-    if 0 <= index < len(clips):
-        return clips[index]["label"]
-    return f"Clip {index + 1}"
-
-
-def _render_report_metadata(
-    data: ReportPayload,
-    *,
-    left_clip_index: int,
-    right_clip_index: int,
-) -> str:
-    stats = data["stats"]
-    default_pair = (
-        f"{_esc_text(_clip_label_for_index(data['clips'], left_clip_index))} "
-        f"vs {_esc_text(_clip_label_for_index(data['clips'], right_clip_index))}"
-    )
-    slowpics_value = data["slowpics_url"] or "Not uploaded"
-    return f"""            <details class="rv-disclosure" data-report-metadata>
-                <summary>Report <span class="rv-summary-value">{_esc_text(data["default_mode"])}</span></summary>
-                <dl class="rv-metadata-list">
-                    <div><dt>Title</dt><dd>{_esc_text(data["title"])}</dd></div>
-                    <div><dt>Report ID</dt><dd>{_esc_text(data["report_id"])}</dd></div>
-                    <div><dt>Generated</dt><dd>{_esc_text(data["generated_at"])}</dd></div>
-                    <div><dt>Frames</dt><dd>{stats["frame_count"]}</dd></div>
-                    <div><dt>Clips</dt><dd>{stats["clip_count"]}</dd></div>
-                    <div><dt>Default pair</dt><dd>{default_pair}</dd></div>
-                    <div><dt>slow.pics</dt><dd>{_esc_text(slowpics_value)}</dd></div>
-                </dl>
-            </details>"""
-
-
-def _render_clip_metadata(clips: list[ReportClipPayload]) -> str:
-    if not clips:
-        clip_items = '<div class="rv-metadata-empty">No clips in payload.</div>'
-    else:
-        clip_items = "".join(
-            f"""                    <li class="rv-clip-meta-item" data-clip-index="{_esc_attr(i)}">
-                        <div class="rv-clip-meta-heading">
-                            <span>{_esc_text(clip["label"])}</span>
-                            <span>{"HDR" if clip["hdr"] else "SDR"}</span>
-                        </div>
-                        <dl class="rv-metadata-list rv-metadata-list--compact">
-                            <div><dt>Name</dt><dd>{_esc_text(clip["name"])}</dd></div>
-                            <div><dt>Resolution</dt><dd>{_render_resolution(clip["resolution"])}</dd></div>
-                            <div><dt>FPS</dt><dd>{_render_fps(clip["fps"])}</dd></div>
-                            <div><dt>Frames</dt><dd>{clip["frame_count"]}</dd></div>
-                        </dl>
-                    </li>"""
-            for i, clip in enumerate(clips)
-        )
-        clip_items = f'<ol class="rv-clip-meta-list">{clip_items}</ol>'
-    return f"""            <details class="rv-disclosure" data-clip-metadata>
-                <summary>Clips <span class="rv-summary-value">{len(clips)}</span></summary>
-                {clip_items}
-            </details>"""
-
-
-def _render_frame_metadata(frames: list[ReportFramePayload]) -> str:
-    frame = frames[0] if frames else None
-    label = frame["label"] if frame else "No frame selected"
-    detail = frame["detail"] if frame else "No frame detail available."
-    category = frame["category"] if frame else "none"
-    return f"""            <details class="rv-disclosure" data-frame-metadata>
-                <summary>Frame <span class="rv-summary-value" data-current-frame-summary>{_esc_text(label)}</span></summary>
-                <dl class="rv-metadata-list">
-                    <div><dt>Label</dt><dd data-current-frame-label>{_esc_text(label)}</dd></div>
-                    <div><dt>Detail</dt><dd data-current-frame-detail>{_esc_text(detail)}</dd></div>
-                    <div><dt>Category</dt><dd data-current-frame-category>{_esc_text(category)}</dd></div>
-                </dl>
-            </details>"""
-
-
-def _render_metadata_bar(
-    data: ReportPayload,
-    *,
-    left_clip_index: int,
-    right_clip_index: int,
-) -> str:
-    return f"""        <section class="rv-metadata-bar" aria-label="Report metadata">
-{_render_report_metadata(data, left_clip_index=left_clip_index, right_clip_index=right_clip_index)}
-{_render_clip_metadata(data["clips"])}
-{_render_frame_metadata(data["frames"])}
-        </section>"""
 
 
 def _frame_categories(frames: list[ReportFramePayload]) -> list[str]:
@@ -212,6 +133,11 @@ def _render_category_filters(
     category_filter_keys: dict[str, str],
 ) -> str:
     categories = _frame_categories(frames)
+    counts: dict[str, int] = {}
+    for frame in frames:
+        cat = frame["category"]
+        counts[cat] = counts.get(cat, 0) + 1
+
     category_buttons = "".join(
         f'<button class="rv-filter-chip" type="button" data-frame-filter '
         f'data-category-key="{_esc_attr(category_filter_keys[category])}" '
@@ -219,13 +145,13 @@ def _render_category_filters(
         f'<span class="rv-category-badge" '
         f'data-category-key="{_esc_attr(category_filter_keys[category])}" '
         f'data-category="{_esc_attr(category)}">'
-        f"{_esc_text(category)}</span></button>"
+        f"{_esc_text(_humanize_category(category))} ({counts[category]})</span></button>"
         for category in categories
     )
     return (
         '<button class="rv-filter-chip active" type="button" data-frame-filter '
         f'data-category-key="{_esc_attr(ALL_CATEGORY_FILTER_KEY)}" '
-        'aria-pressed="true">All</button>'
+        f'aria-pressed="true">All ({len(frames)})</button>'
         f"{category_buttons}"
     )
 
@@ -244,10 +170,10 @@ def _render_filmstrip(
                 <button class="rv-filmstrip-item" data-idx="{_esc_attr(i)}" data-category-key="{_esc_attr(category_filter_keys[frame["category"]])}" data-category="{_esc_attr(frame["category"])}" aria-label="{_esc_attr(frame["label"])}: {_esc_attr(frame["detail"])}">
                     <span class="rv-filmstrip-thumb">
                         <img src="{_esc_attr(frame["images"][0]["src"] if frame["images"] else "")}" loading="lazy" alt="{_esc_attr(first_clip_label)} - Frame {_esc_attr(frame["number"])}">
-                        <span class="rv-category-badge rv-filmstrip-category" data-category-key="{_esc_attr(category_filter_keys[frame["category"]])}" data-category="{_esc_attr(frame["category"])}">{_esc_text(frame["category"])}</span>
+                        <span class="rv-filmstrip-accent" data-category-key="{_esc_attr(category_filter_keys[frame["category"]])}" data-category="{_esc_attr(frame["category"])}"></span>
                     </span>
                     <span class="rv-filmstrip-caption">
-                        <span class="rv-filmstrip-label">{_esc_text(frame["label"])}</span>
+                        <span class="rv-filmstrip-label">{_esc_text(frame["label"])} • {_esc_text(_humanize_category(frame["category"]))}</span>
                         <span class="rv-filmstrip-detail">{_esc_text(frame["detail"])}</span>
                     </span>
                 </button>
@@ -274,13 +200,15 @@ def _render_header(
     clip_count: int,
     slowpics_link: str,
 ) -> str:
+    help_button = '<button id="btn-help" class="rv-header-help-btn" aria-label="Keyboard shortcuts" title="Help (?)">?</button>'
+    slowpics_block = f"{slowpics_link} • " if slowpics_link else ""
     return f"""        <header class="rv-header">
             <div>
                 <div class="rv-title">{_esc_text(title)}</div>
                 <div class="rv-meta">Generated {_esc_text(generated_at)} • {frame_count} frames • {clip_count} clips</div>
             </div>
-            <div>
-                {slowpics_link}
+            <div class="rv-header-right">
+                {slowpics_block}{help_button}
             </div>
         </header>"""
 
@@ -294,37 +222,37 @@ def _render_controls(
 ) -> str:
     return f"""    <div class="rv-controls" role="toolbar" aria-label="Viewer controls">
         <div class="rv-control-group">
-                <button id="btn-prev" aria-label="Previous frame">←</button>
-                <select id="frame-select" aria-label="Select frame">
-                    {frame_options}
-                </select>
-                <button id="btn-next" aria-label="Next frame">→</button>
-            </div>
-
-            <div class="rv-control-group rv-filter-group" data-control-scope="frame-filters" aria-label="Frame category filters">
-                {category_filter_controls}
-            </div>
-
-            <div class="rv-control-group" data-control-scope="pair" aria-label="Comparison pair">
-                <select id="left-select" aria-label="Left clip">
-                    {left_clip_options}
-                </select>
-                <select id="right-select" aria-label="Right clip">
-                    {right_clip_options}
-                </select>
-            </div>
-
-            <div class="rv-control-group" data-control-scope="active" aria-label="Overlay clip" hidden>
-                <select id="active-select" aria-label="Overlay clip">
-                    {active_clip_options}
-                </select>
-            </div>
+            <button id="btn-prev" aria-label="Previous frame">←</button>
+            <select id="frame-select" aria-label="Select frame">
+                {frame_options}
+            </select>
+            <button id="btn-next" aria-label="Next frame">→</button>
+        </div>
 
         <div class="rv-control-group" role="radiogroup" aria-label="View mode">
-            <button data-mode="slider" class="active" role="radio" aria-checked="true" aria-label="Slider mode" title="Slider (S)">⊟</button>
-            <button data-mode="overlay" role="radio" aria-checked="false" aria-label="Overlay mode" title="Overlay (O)">◐</button>
-            <button data-mode="diff" role="radio" aria-checked="false" aria-label="Difference mode" title="Difference (D)">◑</button>
-            <button data-mode="blink" role="radio" aria-checked="false" aria-label="Blink mode" title="Blink (B)">◫</button>
+            <button data-mode="slider" class="active" role="radio" aria-checked="true" aria-label="Slider mode" title="Slider (S)">Slider</button>
+            <button data-mode="overlay" role="radio" aria-checked="false" aria-label="Overlay mode" title="Overlay (O)">Overlay</button>
+            <button data-mode="diff" role="radio" aria-checked="false" aria-label="Difference mode" title="Difference (D)">Diff</button>
+            <button data-mode="blink" role="radio" aria-checked="false" aria-label="Blink mode" title="Blink (B)">Blink</button>
+        </div>
+
+        <div class="rv-control-group" data-control-scope="pair" aria-label="Comparison pair">
+            <span class="rv-clip-prefix left">L:</span>
+            <select id="left-select" aria-label="Left clip">
+                {left_clip_options}
+            </select>
+            <span class="rv-clip-vs">vs</span>
+            <span class="rv-clip-prefix right">R:</span>
+            <select id="right-select" aria-label="Right clip">
+                {right_clip_options}
+            </select>
+        </div>
+
+        <div class="rv-control-group" data-control-scope="active" aria-label="Overlay clip" hidden>
+            <span class="rv-clip-prefix active">Clip:</span>
+            <select id="active-select" aria-label="Overlay clip">
+                {active_clip_options}
+            </select>
         </div>
 
         <div class="rv-control-group">
@@ -332,7 +260,7 @@ def _render_controls(
             <input type="range" id="zoom-range" min="0.25" max="4.0" step="0.1" value="1.0" aria-label="Zoom level" aria-valuemin="0.25" aria-valuemax="4.0" aria-valuenow="1.0">
             <button id="btn-zoom-in" aria-label="Zoom in">+</button>
             <button id="btn-zoom-reset" aria-label="Reset zoom">R</button>
-            <span id="zoom-val" style="font-size: var(--text-xs); width: 3ch">100%</span>
+            <span id="zoom-val" style="width: 4ch">100%</span>
         </div>
 
         <div class="rv-control-group" role="radiogroup" aria-label="Fit mode">
@@ -342,28 +270,34 @@ def _render_controls(
             <button data-fit="fill" role="radio" aria-checked="false" aria-label="Fill stage" title="Fill stage">Fill</button>
         </div>
 
-        <div class="rv-control-group" aria-label="Right layer alignment">
-            <select id="alignment-preset" aria-label="Alignment preset">
-                <option value="none">No offset</option>
-                <option value="left-1">Left 1px</option>
-                <option value="right-1">Right 1px</option>
-                <option value="up-1">Up 1px</option>
-                <option value="down-1">Down 1px</option>
-                <option value="custom">Custom</option>
-            </select>
-            <label class="rv-control-label" for="align-x">X</label>
-            <input id="align-x" class="rv-number-input" type="number" value="0" step="1" aria-label="Manual horizontal alignment offset">
-            <label class="rv-control-label" for="align-y">Y</label>
-            <input id="align-y" class="rv-number-input" type="number" value="0" step="1" aria-label="Manual vertical alignment offset">
-            <button id="btn-alignment-reset" aria-label="Reset alignment" title="Reset alignment">Reset</button>
+        <div class="rv-control-group rv-alignment-group">
+            <button id="btn-align-toggle" aria-label="Alignment settings" title="Alignment Settings (⚙)" aria-expanded="false" aria-haspopup="true">⚙</button>
+            <div id="align-popover" class="rv-align-popover" aria-hidden="true" hidden>
+                <div class="rv-popover-row">
+                    <label for="alignment-preset">Preset</label>
+                    <select id="alignment-preset" aria-label="Alignment preset">
+                        <option value="none">No offset</option>
+                        <option value="left-1">Left 1px</option>
+                        <option value="right-1">Right 1px</option>
+                        <option value="up-1">Up 1px</option>
+                        <option value="down-1">Down 1px</option>
+                        <option value="custom">Custom</option>
+                    </select>
+                </div>
+                <div class="rv-popover-row">
+                    <label for="align-x">X</label>
+                    <input id="align-x" class="rv-number-input" type="number" value="0" step="1" aria-label="Manual horizontal alignment offset">
+                    <label for="align-y">Y</label>
+                    <input id="align-y" class="rv-number-input" type="number" value="0" step="1" aria-label="Manual vertical alignment offset">
+                </div>
+                <div class="rv-popover-row">
+                    <button id="btn-alignment-reset" aria-label="Reset alignment" title="Reset alignment">Reset</button>
+                </div>
+            </div>
         </div>
 
         <div class="rv-control-group">
             <button id="btn-fullscreen" aria-label="Enter fullscreen" aria-pressed="false" title="Fullscreen">Fullscreen</button>
-        </div>
-
-        <div class="rv-control-group">
-             <button id="btn-help" aria-label="Keyboard shortcuts" title="Help (?)">?</button>
         </div>
     </div>"""
 
@@ -381,7 +315,14 @@ def _render_stage() -> str:
                 <img src="" alt="" class="rv-image">
                 <div id="label-right" class="rv-overlay-label right"></div>
             </div>
-            <div class="rv-divider"></div>
+            <div class="rv-divider"><div class="rv-divider-handle"></div></div>
+        </div>
+        <div class="rv-stage-overlay-info">
+            <span class="rv-info-label" data-current-frame-label></span>
+            <span class="rv-info-divider">•</span>
+            <span class="rv-info-detail" data-current-frame-detail></span>
+            <span class="rv-info-divider">•</span>
+            <span class="rv-info-category" data-current-frame-category></span>
         </div>
     </div>"""
 
@@ -470,11 +411,6 @@ def build_html(data: ReportPayload, include_filmstrip: bool = True) -> str:
         right_clip_options,
         active_clip_options,
     )
-    metadata_html = _render_metadata_bar(
-        data,
-        left_clip_index=left_clip_index,
-        right_clip_index=right_clip_index,
-    )
     stage_html = _render_stage()
     modal_html = _render_help_modal()
     footer_html = _render_footer(json_str)
@@ -489,11 +425,15 @@ def build_html(data: ReportPayload, include_filmstrip: bool = True) -> str:
 </head>
 <body>
 {header_html}
-{metadata_html}
 <div id="viewer-status" class="rv-status" role="status" aria-live="polite" hidden></div>
 {controls_html}
 {stage_html}
 {modal_html}
+<div class="rv-category-filters-container">
+    <div class="rv-filter-group" data-control-scope="frame-filters" aria-label="Frame category filters">
+        {category_filter_controls}
+    </div>
+</div>
 {filmstrip}
 {footer_html}
 </body>

--- a/src/frame_compare/services/report/renderer.py
+++ b/src/frame_compare/services/report/renderer.py
@@ -7,6 +7,10 @@ import json
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from frame_compare.services.report.category_display import (
+    humanize_category,
+    label_repeats_category,
+)
 from frame_compare.services.report.payload import REPORT_VERSION
 from frame_compare.services.report.viewer import get_css, get_js
 
@@ -97,32 +101,12 @@ def _render_slowpics_link(slowpics_url: str | None) -> str:
     )
 
 
-def _humanize_category(cat: str) -> str:
-    """Map dynamic technical categories into readable names."""
-    mapping = {
-        "quantile_bright": "Bright",
-        "quantile_dark": "Dark",
-        "scene-cut": "Scene Cuts",
-        "scene_cut": "Scene Cuts",
-        "selected": "Selected",
-    }
-    if cat in mapping:
-        return mapping[cat]
-    return cat.replace("_", " ").replace("-", " ").title()
-
-
-def _normalized_display_token(value: str) -> str:
-    return " ".join(value.replace("_", " ").replace("-", " ").split()).casefold()
-
-
 def _frame_category_text(frame: ReportFramePayload) -> str:
-    return _humanize_category(frame["category"])
+    return humanize_category(frame["category"]) or frame["category"]
 
 
 def _frame_label_repeats_category(frame: ReportFramePayload) -> bool:
-    return _normalized_display_token(frame["label"]) == _normalized_display_token(
-        _frame_category_text(frame)
-    )
+    return label_repeats_category(frame["label"], frame["category"])
 
 
 def _frame_filmstrip_label(frame: ReportFramePayload) -> str:
@@ -165,7 +149,8 @@ def _render_category_filters(
         f'<span class="rv-category-badge" '
         f'data-category-key="{_esc_attr(category_filter_keys[category])}" '
         f'data-category="{_esc_attr(category)}">'
-        f"{_esc_text(_humanize_category(category))} ({counts[category]})</span></button>"
+        f"{_esc_text(humanize_category(category) or category)} ({counts[category]})"
+        "</span></button>"
         for category in categories
     )
     return (

--- a/src/frame_compare/services/report/renderer.py
+++ b/src/frame_compare/services/report/renderer.py
@@ -187,14 +187,13 @@ def _render_filmstrip(
     items = (
         "".join(
             f"""
-                <button class="rv-filmstrip-item" data-idx="{_esc_attr(i)}" data-category-key="{_esc_attr(category_filter_keys[frame["category"]])}" data-category="{_esc_attr(frame["category"])}" aria-label="{_esc_attr(frame["label"])}: {_esc_attr(frame["detail"])}">
+                <button class="rv-filmstrip-item" data-idx="{_esc_attr(i)}" data-category-key="{_esc_attr(category_filter_keys[frame["category"]])}" data-category="{_esc_attr(frame["category"])}" aria-label="{_esc_attr(_frame_filmstrip_label(frame))}">
                     <span class="rv-filmstrip-thumb">
                         <img src="{_esc_attr(frame["images"][0]["src"] if frame["images"] else "")}" loading="lazy" alt="{_esc_attr(first_clip_label)} - Frame {_esc_attr(frame["number"])}">
                         <span class="rv-filmstrip-accent" data-category-key="{_esc_attr(category_filter_keys[frame["category"]])}" data-category="{_esc_attr(frame["category"])}"></span>
                     </span>
                     <span class="rv-filmstrip-caption">
                         <span class="rv-filmstrip-label">{_esc_text(_frame_filmstrip_label(frame))}</span>
-                        <span class="rv-filmstrip-detail">{_esc_text(frame["detail"])}</span>
                     </span>
                 </button>
                 """
@@ -438,8 +437,6 @@ def _render_stage() -> str:
         </div>
         <div class="rv-stage-overlay-info">
             <span class="rv-info-label" data-current-frame-label></span>
-            <span class="rv-info-divider">•</span>
-            <span class="rv-info-detail" data-current-frame-detail></span>
             <span class="rv-info-divider" data-current-frame-category-divider>•</span>
             <span class="rv-info-category" data-current-frame-category></span>
         </div>

--- a/src/frame_compare/services/slowpics_post_upload.py
+++ b/src/frame_compare/services/slowpics_post_upload.py
@@ -1,0 +1,106 @@
+"""Service-owned slow.pics post-upload policy and side effects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import structlog
+
+from frame_compare.config.schema import SlowpicsConfig
+from frame_compare.services.slowpics_shortcut import create_slowpics_url_shortcut
+from frame_compare.services.slowpics_webhook import deliver_slowpics_webhook
+from frame_compare.utils.post_upload_actions import PostUploadActionResult, PostUploadActionResults
+from frame_compare.utils.types import WorkspacePaths
+
+log = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class SlowpicsPostUploadRequest:
+    """Service inputs for optional post-upload slow.pics side effects."""
+
+    workspace: WorkspacePaths
+    config: SlowpicsConfig
+    slowpics_url: str
+    metadata_title: str | None
+    upload_title: str | None
+
+
+async def run_slowpics_post_upload_actions(
+    request: SlowpicsPostUploadRequest,
+) -> PostUploadActionResults:
+    actions: list[PostUploadActionResult] = []
+
+    if request.config.create_url_shortcut:
+        actions.extend(_create_shortcut_actions(request))
+    if request.config.webhook_url is not None:
+        actions.extend(await _deliver_webhook_actions(request))
+
+    return tuple(actions)
+
+
+def _create_shortcut_actions(
+    request: SlowpicsPostUploadRequest,
+) -> PostUploadActionResults:
+    result = create_slowpics_url_shortcut(
+        workspace=request.workspace,
+        slowpics_url=request.slowpics_url,
+        metadata_title=request.metadata_title,
+        upload_title=request.upload_title,
+    )
+    if result.success:
+        return (
+            PostUploadActionResult(
+                kind="shortcut",
+                success=True,
+                path=result.path,
+                message="slow.pics URL shortcut written",
+            ),
+        )
+
+    if result.warning is not None:
+        log.warning(
+            "slowpics_shortcut_create_failed",
+            path=str(result.path) if result.path is not None else None,
+            warning=result.warning,
+        )
+    return (
+        PostUploadActionResult(
+            kind="shortcut",
+            success=False,
+            path=result.path,
+            warning=result.warning,
+        ),
+    )
+
+
+async def _deliver_webhook_actions(
+    request: SlowpicsPostUploadRequest,
+) -> PostUploadActionResults:
+    webhook_url = request.config.webhook_url
+    if webhook_url is None:
+        return ()
+
+    result = await deliver_slowpics_webhook(
+        webhook_url=webhook_url,
+        slowpics_url=request.slowpics_url,
+    )
+    if result.success:
+        return (
+            PostUploadActionResult(
+                kind="webhook",
+                success=True,
+                detail=result.detail,
+                message="slow.pics webhook delivered",
+            ),
+        )
+
+    if result.warning is not None:
+        log.warning("slowpics_webhook_delivery_failed", warning=result.warning)
+    return (
+        PostUploadActionResult(
+            kind="webhook",
+            success=False,
+            warning=result.warning,
+        ),
+    )

--- a/src/frame_compare/services/slowpics_shortcut.py
+++ b/src/frame_compare/services/slowpics_shortcut.py
@@ -1,0 +1,160 @@
+"""Filesystem shortcut creation for slow.pics comparison URLs."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+from frame_compare.utils.atomic_write import write_text_atomic
+from frame_compare.utils.types import WorkspacePaths
+
+_WINDOWS_RESERVED_FILENAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{index}" for index in range(1, 10)),
+    *(f"LPT{index}" for index in range(1, 10)),
+}
+_UNSAFE_FILENAME_CHARS_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+_WHITESPACE_RE = re.compile(r"\s+")
+
+type ShortcutTextWriter = Callable[[Path, str], None]
+
+
+@dataclass(frozen=True)
+class SlowpicsShortcutResult:
+    """Result of attempting to create a slow.pics URL shortcut."""
+
+    success: bool
+    path: Path | None = None
+    warning: str | None = None
+
+
+def create_slowpics_url_shortcut(
+    *,
+    workspace: WorkspacePaths,
+    slowpics_url: str,
+    metadata_title: str | None,
+    upload_title: str | None,
+    text_writer: ShortcutTextWriter = write_text_atomic,
+) -> SlowpicsShortcutResult:
+    """Create a deterministic Windows InternetShortcut-style file."""
+    try:
+        output_dir = _select_shortcut_directory(workspace)
+    except (OSError, RuntimeError) as exc:
+        return SlowpicsShortcutResult(
+            success=False,
+            warning=f"slow.pics shortcut: failed to resolve URL shortcut directory: {exc}",
+        )
+    if output_dir is None:
+        return SlowpicsShortcutResult(
+            success=False,
+            warning=(
+                "slow.pics shortcut: could not choose a safe output directory from "
+                "the run, screenshots, and generated paths"
+            ),
+        )
+
+    shortcut_path = output_dir / _shortcut_filename(
+        metadata_title=metadata_title,
+        upload_title=upload_title,
+        slowpics_url=slowpics_url,
+    )
+    content = f"[InternetShortcut]\nURL={slowpics_url}\n"
+    try:
+        text_writer(shortcut_path, content)
+    except OSError as exc:
+        return SlowpicsShortcutResult(
+            success=False,
+            path=shortcut_path,
+            warning=f"slow.pics shortcut: failed to write URL shortcut {shortcut_path}: {exc}",
+        )
+
+    return SlowpicsShortcutResult(success=True, path=shortcut_path)
+
+
+def _select_shortcut_directory(workspace: WorkspacePaths) -> Path | None:
+    if workspace.run_dir is not None:
+        return workspace.run_dir
+
+    root = workspace.root.resolve()
+    screenshots_dir = workspace.screenshots_dir.resolve()
+    generated_dir = workspace.generated_dir.resolve()
+
+    if _normalized_anchor(screenshots_dir) != _normalized_anchor(generated_dir):
+        return None
+
+    try:
+        common_parent = Path(os.path.commonpath((str(screenshots_dir), str(generated_dir))))
+    except ValueError:
+        return None
+    common_parent = common_parent.resolve()
+
+    if not _is_safe_shortcut_parent(common_parent, root):
+        return None
+    return common_parent
+
+
+def _is_safe_shortcut_parent(parent: Path, root: Path) -> bool:
+    if _normalized_anchor(parent) != _normalized_anchor(root):
+        return False
+    if not parent.is_relative_to(root):
+        return False
+    if parent == _anchor_path(parent):
+        return False
+    try:
+        if parent == Path.home().resolve():
+            return False
+    except RuntimeError:
+        return False
+    return True
+
+
+def _shortcut_filename(
+    *,
+    metadata_title: str | None,
+    upload_title: str | None,
+    slowpics_url: str,
+) -> str:
+    for candidate in (metadata_title, upload_title):
+        if candidate is None:
+            continue
+        stem = _safe_filename_stem(candidate)
+        if stem is not None:
+            return f"{stem}.url"
+    return f"{_fallback_stem_from_url(slowpics_url)}.url"
+
+
+def _safe_filename_stem(value: str) -> str | None:
+    stem = _UNSAFE_FILENAME_CHARS_RE.sub(" ", value)
+    stem = _WHITESPACE_RE.sub(" ", stem).strip(" .")
+    if not stem:
+        return None
+    if stem.upper() in _WINDOWS_RESERVED_FILENAMES:
+        stem = f"{stem}-slowpics"
+    return stem
+
+
+def _fallback_stem_from_url(slowpics_url: str) -> str:
+    parsed = urlparse(slowpics_url)
+    key = Path(parsed.path).name.strip()
+    stem = _safe_filename_stem(key)
+    if stem is not None:
+        return stem
+    return hashlib.sha256(slowpics_url.encode("utf-8")).hexdigest()[:12]
+
+
+def _anchor_path(path: Path) -> Path:
+    if path.anchor:
+        return Path(path.anchor)
+    return path
+
+
+def _normalized_anchor(path: Path) -> str:
+    return os.path.normcase(path.anchor)

--- a/src/frame_compare/services/slowpics_upload_plan.py
+++ b/src/frame_compare/services/slowpics_upload_plan.py
@@ -1,0 +1,157 @@
+"""Deterministic slow.pics upload membership planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from frame_compare.services.errors import SlowpicsError
+
+
+@dataclass(frozen=True, slots=True)
+class SlowpicsUploadClip:
+    """Service-owned primitive clip identity for slow.pics upload planning."""
+
+    label: str
+    image_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class SlowpicsPlannedImage:
+    """A single image slot in a planned slow.pics upload."""
+
+    row_index: int
+    selected_frame: int
+    image_index: int
+    clip_label: str
+    image_name: str
+    screenshot_path: Path
+    sort_order: int
+
+
+@dataclass(frozen=True, slots=True)
+class SlowpicsUploadRow:
+    """A slow.pics comparison row for one selected frame."""
+
+    row_index: int
+    selected_frame: int
+    row_name: str
+    sort_order: int
+    images: tuple[SlowpicsPlannedImage, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SlowpicsUploadPlan:
+    """Complete row-major slow.pics upload plan for rendered screenshots."""
+
+    rows: tuple[SlowpicsUploadRow, ...]
+
+    @property
+    def file_paths(self) -> list[Path]:
+        """Return planned screenshot files in row-major upload order."""
+        return [image.screenshot_path for row in self.rows for image in row.images]
+
+    @property
+    def screenshot_count(self) -> int:
+        return sum(len(row.images) for row in self.rows)
+
+
+def build_slowpics_upload_plan(
+    *,
+    selected_frames: list[int],
+    clips: list[SlowpicsUploadClip],
+    screenshots_by_label: dict[str, list[Path]],
+) -> SlowpicsUploadPlan:
+    """Build a deterministic upload plan from current render artifacts."""
+    if not selected_frames:
+        raise SlowpicsError("No selected frames available for slow.pics upload")
+    if not clips:
+        raise SlowpicsError("No clips available for slow.pics upload")
+
+    _validate_unique_clip_labels(clips)
+    _validate_image_names(clips)
+
+    rows: list[SlowpicsUploadRow] = []
+    for row_index, selected_frame in enumerate(selected_frames):
+        images: list[SlowpicsPlannedImage] = []
+        for image_index, clip in enumerate(clips):
+            screenshot_paths = _screenshots_for_clip(
+                clip=clip,
+                selected_frames=selected_frames,
+                screenshots_by_label=screenshots_by_label,
+            )
+            screenshot_path = screenshot_paths[row_index]
+            _validate_screenshot_file(
+                clip=clip, selected_frame=selected_frame, path=screenshot_path
+            )
+            images.append(
+                SlowpicsPlannedImage(
+                    row_index=row_index,
+                    selected_frame=selected_frame,
+                    image_index=image_index,
+                    clip_label=clip.label,
+                    image_name=clip.image_name,
+                    screenshot_path=screenshot_path,
+                    sort_order=image_index,
+                )
+            )
+        rows.append(
+            SlowpicsUploadRow(
+                row_index=row_index,
+                selected_frame=selected_frame,
+                row_name=str(selected_frame),
+                sort_order=row_index,
+                images=tuple(images),
+            )
+        )
+
+    return SlowpicsUploadPlan(rows=tuple(rows))
+
+
+def _validate_unique_clip_labels(clips: list[SlowpicsUploadClip]) -> None:
+    seen: set[str] = set()
+    for clip in clips:
+        if clip.label in seen:
+            raise SlowpicsError(f"Duplicate clip label in slow.pics upload plan: {clip.label!r}")
+        seen.add(clip.label)
+
+
+def _validate_image_names(clips: list[SlowpicsUploadClip]) -> None:
+    for clip in clips:
+        if not clip.image_name.strip():
+            raise SlowpicsError(
+                f"Empty slow.pics image display name for clip label {clip.label!r}"
+            )
+
+
+def _screenshots_for_clip(
+    *,
+    clip: SlowpicsUploadClip,
+    selected_frames: list[int],
+    screenshots_by_label: dict[str, list[Path]],
+) -> list[Path]:
+    screenshot_paths = screenshots_by_label.get(clip.label)
+    if screenshot_paths is None:
+        raise SlowpicsError(f"Missing screenshots for clip label {clip.label!r}")
+
+    expected_count = len(selected_frames)
+    actual_count = len(screenshot_paths)
+    if actual_count != expected_count:
+        raise SlowpicsError(
+            "Mismatched slow.pics screenshot count for "
+            f"{clip.label!r}: expected {expected_count}, found {actual_count}"
+        )
+    return screenshot_paths
+
+
+def _validate_screenshot_file(
+    *,
+    clip: SlowpicsUploadClip,
+    selected_frame: int,
+    path: Path,
+) -> None:
+    if not path.is_file():
+        raise SlowpicsError(
+            "Planned slow.pics screenshot is missing for "
+            f"{clip.label!r} frame {selected_frame}: {path}"
+        )

--- a/src/frame_compare/services/slowpics_webhook.py
+++ b/src/frame_compare/services/slowpics_webhook.py
@@ -152,19 +152,19 @@ def _deliver_slowpics_webhook_sync(
         ("Content-Length", str(len(body))),
         ("Connection", "close"),
     )
-    request = WebhookDeliveryRequest(
-        hostname=target.hostname,
-        port=target.port,
-        resolved_ip=target.resolved_ips[0],
-        host_header=target.host_header,
-        target=target.target,
-        headers=headers,
-        body=body,
-        timeout_seconds=WEBHOOK_TIMEOUT_SECONDS,
-    )
-
     last_status: int | None = None
     for attempt in range(1, WEBHOOK_ATTEMPTS + 1):
+        resolved_ip = target.resolved_ips[(attempt - 1) % len(target.resolved_ips)]
+        request = WebhookDeliveryRequest(
+            hostname=target.hostname,
+            port=target.port,
+            resolved_ip=resolved_ip,
+            host_header=target.host_header,
+            target=target.target,
+            headers=headers,
+            body=body,
+            timeout_seconds=WEBHOOK_TIMEOUT_SECONDS,
+        )
         try:
             response = connector(request)
         except TimeoutError:

--- a/src/frame_compare/services/slowpics_webhook.py
+++ b/src/frame_compare/services/slowpics_webhook.py
@@ -1,0 +1,350 @@
+"""Isolated slow.pics post-upload webhook delivery."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import socket
+import ssl
+from collections.abc import Callable
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+WEBHOOK_TIMEOUT_SECONDS = 10.0
+WEBHOOK_ATTEMPTS = 3
+WEBHOOK_CONTENT_TYPE = "application/json"
+WEBHOOK_FAILURE_WARNING = "slow.pics webhook: delivery failed after 3 attempts"
+WEBHOOK_VALIDATION_WARNING = (
+    "slow.pics webhook: delivery skipped because the configured webhook URL "
+    "is not an allowed external HTTPS endpoint"
+)
+
+type WebhookResolver = Callable[[str, int], tuple[str, ...]]
+type WebhookConnector = Callable[["WebhookDeliveryRequest"], "WebhookResponse"]
+
+
+@dataclass(frozen=True)
+class SlowpicsWebhookResult:
+    """Result of a post-upload webhook delivery attempt."""
+
+    success: bool
+    detail: str | None = None
+    warning: str | None = None
+
+
+@dataclass(frozen=True)
+class WebhookDeliveryRequest:
+    """Pinned-address HTTPS request data for a webhook delivery attempt."""
+
+    hostname: str
+    port: int
+    resolved_ip: str
+    host_header: str
+    target: str
+    headers: tuple[tuple[str, str], ...]
+    body: bytes
+    timeout_seconds: float
+
+
+@dataclass(frozen=True)
+class WebhookResponse:
+    """Minimal HTTP response data needed by webhook retry policy."""
+
+    status_code: int
+
+
+@dataclass(frozen=True)
+class _ValidatedWebhookTarget:
+    hostname: str
+    port: int
+    host_header: str
+    target: str
+    resolved_ips: tuple[str, ...]
+
+
+async def deliver_slowpics_webhook(
+    *,
+    webhook_url: str,
+    slowpics_url: str,
+    resolver: WebhookResolver | None = None,
+    connector: WebhookConnector | None = None,
+) -> SlowpicsWebhookResult:
+    """Deliver a slow.pics URL to a configured webhook with isolated HTTP state."""
+    resolved_resolver = resolve_webhook_addresses if resolver is None else resolver
+    resolved_connector = send_pinned_https_webhook_request if connector is None else connector
+    return await asyncio.to_thread(
+        _deliver_slowpics_webhook_sync,
+        webhook_url=webhook_url,
+        slowpics_url=slowpics_url,
+        resolver=resolved_resolver,
+        connector=resolved_connector,
+    )
+
+
+def resolve_webhook_addresses(hostname: str, port: int) -> tuple[str, ...]:
+    """Resolve a webhook hostname to candidate IP address strings."""
+    try:
+        results = socket.getaddrinfo(
+            hostname,
+            port,
+            family=socket.AF_UNSPEC,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except (OSError, UnicodeError, ValueError):
+        return ()
+
+    addresses: list[str] = []
+    seen: set[str] = set()
+    for result in results:
+        sockaddr = result[4]
+        if len(sockaddr) < 1:
+            continue
+        address = str(sockaddr[0])
+        if address not in seen:
+            addresses.append(address)
+            seen.add(address)
+    return tuple(addresses)
+
+
+def send_pinned_https_webhook_request(request: WebhookDeliveryRequest) -> WebhookResponse:
+    """Send one HTTPS POST to a prevalidated IP while verifying the original hostname."""
+    request_bytes = _http_request_bytes(request)
+    address = ipaddress.ip_address(request.resolved_ip)
+    family = socket.AF_INET6 if address.version == 6 else socket.AF_INET
+    sock = socket.socket(family, socket.SOCK_STREAM)
+    sock.settimeout(request.timeout_seconds)
+    try:
+        connect_address: tuple[str, int] | tuple[str, int, int, int]
+        if address.version == 6:
+            connect_address = (request.resolved_ip, request.port, 0, 0)
+        else:
+            connect_address = (request.resolved_ip, request.port)
+        sock.connect(connect_address)
+        context = ssl.create_default_context()
+        with context.wrap_socket(sock, server_hostname=request.hostname) as tls_sock:
+            tls_sock.settimeout(request.timeout_seconds)
+            tls_sock.sendall(request_bytes)
+            status_line = tls_sock.makefile("rb").readline(65536)
+    except OSError:
+        sock.close()
+        raise
+
+    return WebhookResponse(status_code=_parse_status_code(status_line))
+
+
+def _deliver_slowpics_webhook_sync(
+    *,
+    webhook_url: str,
+    slowpics_url: str,
+    resolver: WebhookResolver,
+    connector: WebhookConnector,
+) -> SlowpicsWebhookResult:
+    target = _validate_webhook_url(webhook_url, resolver)
+    if target is None:
+        return SlowpicsWebhookResult(success=False, warning=WEBHOOK_VALIDATION_WARNING)
+
+    body = json.dumps({"content": slowpics_url}, separators=(",", ":")).encode("utf-8")
+    headers = (
+        ("Host", target.host_header),
+        ("Content-Type", WEBHOOK_CONTENT_TYPE),
+        ("Content-Length", str(len(body))),
+        ("Connection", "close"),
+    )
+    request = WebhookDeliveryRequest(
+        hostname=target.hostname,
+        port=target.port,
+        resolved_ip=target.resolved_ips[0],
+        host_header=target.host_header,
+        target=target.target,
+        headers=headers,
+        body=body,
+        timeout_seconds=WEBHOOK_TIMEOUT_SECONDS,
+    )
+
+    last_status: int | None = None
+    for attempt in range(1, WEBHOOK_ATTEMPTS + 1):
+        try:
+            response = connector(request)
+        except TimeoutError:
+            if attempt == WEBHOOK_ATTEMPTS:
+                return SlowpicsWebhookResult(success=False, warning=WEBHOOK_FAILURE_WARNING)
+            continue
+        except (OSError, UnicodeError, ValueError):
+            if attempt == WEBHOOK_ATTEMPTS:
+                return SlowpicsWebhookResult(success=False, warning=WEBHOOK_FAILURE_WARNING)
+            continue
+
+        last_status = response.status_code
+        if 200 <= response.status_code <= 299:
+            return SlowpicsWebhookResult(success=True, detail=f"HTTP {response.status_code}")
+        if 500 <= response.status_code <= 599 and attempt < WEBHOOK_ATTEMPTS:
+            continue
+        return SlowpicsWebhookResult(success=False, warning=WEBHOOK_FAILURE_WARNING)
+
+    detail = f"HTTP {last_status}" if last_status is not None else None
+    return SlowpicsWebhookResult(success=False, detail=detail, warning=WEBHOOK_FAILURE_WARNING)
+
+
+def _validate_webhook_url(
+    webhook_url: str,
+    resolver: WebhookResolver,
+) -> _ValidatedWebhookTarget | None:
+    try:
+        parsed = urlparse(webhook_url)
+    except ValueError:
+        return None
+
+    if parsed.scheme != "https":
+        return None
+    if parsed.username is not None or parsed.password is not None:
+        return None
+
+    try:
+        parsed_hostname = parsed.hostname
+        parsed_port = parsed.port
+    except ValueError:
+        return None
+    if parsed_hostname is None:
+        return None
+
+    hostname = parsed_hostname.rstrip(".")
+    if not hostname:
+        return None
+    if not _is_ascii_text(hostname):
+        return None
+    if _is_localhost_name(hostname):
+        return None
+
+    port = parsed_port or 443
+    if not 1 <= port <= 65535:
+        return None
+    host_header = _host_header(hostname, port)
+    target = parsed.path or "/"
+    if parsed.query:
+        target = f"{target}?{parsed.query}"
+    if not _is_safe_http_target(target):
+        return None
+    if not _is_safe_http_header_value(host_header):
+        return None
+
+    literal_address = _parse_ip_literal(hostname)
+    if literal_address is not None:
+        if not _is_allowed_public_address(literal_address):
+            return None
+        return _ValidatedWebhookTarget(
+            hostname=hostname,
+            port=port,
+            host_header=host_header,
+            target=target,
+            resolved_ips=(str(literal_address),),
+        )
+
+    try:
+        resolved_ips = resolver(hostname, port)
+    except (OSError, UnicodeError, ValueError):
+        return None
+    if not resolved_ips:
+        return None
+
+    parsed_addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for resolved_ip in resolved_ips:
+        address = _parse_ip_literal(resolved_ip)
+        if address is None:
+            return None
+        parsed_addresses.append(address)
+    if not parsed_addresses:
+        return None
+    if any(not _is_allowed_public_address(address) for address in parsed_addresses):
+        return None
+
+    return _ValidatedWebhookTarget(
+        hostname=hostname,
+        port=port,
+        host_header=host_header,
+        target=target,
+        resolved_ips=tuple(str(address) for address in parsed_addresses),
+    )
+
+
+def _is_localhost_name(hostname: str) -> bool:
+    normalized = hostname.lower().rstrip(".")
+    return normalized == "localhost" or normalized.endswith(".localhost")
+
+
+def _is_ascii_text(value: str) -> bool:
+    try:
+        value.encode("ascii")
+    except UnicodeError:
+        return False
+    return True
+
+
+def _is_safe_http_target(value: str) -> bool:
+    if not _is_ascii_text(value):
+        return False
+    return all(32 < ord(char) < 127 for char in value)
+
+
+def _is_safe_http_header_name(value: str) -> bool:
+    if not _is_ascii_text(value) or not value:
+        return False
+    return all(32 < ord(char) < 127 and char != ":" for char in value)
+
+
+def _is_safe_http_header_value(value: str) -> bool:
+    if not _is_ascii_text(value):
+        return False
+    return all(char == "\t" or 32 <= ord(char) < 127 for char in value)
+
+
+def _parse_ip_literal(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    try:
+        return ipaddress.ip_address(hostname.strip("[]"))
+    except ValueError:
+        return None
+
+
+def _is_allowed_public_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        address.is_global
+        and not address.is_loopback
+        and not address.is_private
+        and not address.is_link_local
+        and not address.is_multicast
+        and not address.is_reserved
+        and not address.is_unspecified
+    )
+
+
+def _host_header(hostname: str, port: int) -> str:
+    host = f"[{hostname}]" if ":" in hostname and not hostname.startswith("[") else hostname
+    if port == 443:
+        return host
+    return f"{host}:{port}"
+
+
+def _http_request_bytes(request: WebhookDeliveryRequest) -> bytes:
+    if not _is_safe_http_target(request.target):
+        raise OSError("Invalid webhook HTTP request")
+    for name, value in request.headers:
+        if not _is_safe_http_header_name(name) or not _is_safe_http_header_value(value):
+            raise OSError("Invalid webhook HTTP request")
+
+    lines = [f"POST {request.target} HTTP/1.1"]
+    lines.extend(f"{name}: {value}" for name, value in request.headers)
+    try:
+        header_bytes = ("\r\n".join(lines) + "\r\n\r\n").encode("ascii")
+    except UnicodeError:
+        raise OSError("Invalid webhook HTTP request") from None
+    return header_bytes + request.body
+
+
+def _parse_status_code(status_line: bytes) -> int:
+    try:
+        text = status_line.decode("iso-8859-1")
+        _version, status, _reason = text.split(" ", 2)
+        return int(status)
+    except (ValueError, UnicodeDecodeError):
+        raise OSError("Invalid webhook HTTP response") from None

--- a/src/frame_compare/utils/post_upload_actions.py
+++ b/src/frame_compare/utils/post_upload_actions.py
@@ -1,0 +1,24 @@
+"""Shared typed results for optional post-upload side effects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+type PostUploadActionKind = Literal["clipboard", "browser", "shortcut", "webhook"]
+
+
+@dataclass(frozen=True)
+class PostUploadActionResult:
+    """Result for an optional post-upload side effect."""
+
+    kind: PostUploadActionKind
+    success: bool
+    detail: str | None = None
+    path: Path | None = None
+    message: str | None = None
+    warning: str | None = None
+
+
+type PostUploadActionResults = tuple[PostUploadActionResult, ...]

--- a/tests/cli/test_run_command.py
+++ b/tests/cli/test_run_command.py
@@ -17,6 +17,7 @@ from frame_compare.cli.run_command import (
     RunCliRawArgs,
     RunCommandDeps,
     WriteConfigFn,
+    build_confirm_slowpics_upload_callback,
     build_run_request_from_cli,
     collect_interactive_slowpics_actions,
     handle_diagnose_paths,
@@ -25,7 +26,7 @@ from frame_compare.cli.run_command import (
     maybe_open_run_report,
     slowpics_browser_open_attempted,
 )
-from frame_compare.config.errors import ConfigNotFoundError, ConfigWriteError
+from frame_compare.config.errors import ConfigNotFoundError, ConfigValidationError, ConfigWriteError
 from frame_compare.config.loader import get_default_config
 from frame_compare.config.schema import (
     ConfigSchema,
@@ -36,15 +37,18 @@ from frame_compare.config.schema import (
     TonemapPreset,
 )
 from frame_compare.orchestration import RunDependencies, RunRequest, RunResult
+from frame_compare.orchestration.types import SlowpicsUploadConfirmationRequest
 
 
 class RecordingRunner:
     def __init__(self, result: RunResult | None = None) -> None:
         self.result = result or RunResult(success=True)
         self.requests: list[RunRequest] = []
+        self.dependencies: list[RunDependencies | None] = []
 
     def run(self, request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         self.requests.append(request)
+        self.dependencies.append(dependencies)
         return self.result
 
 
@@ -110,18 +114,22 @@ class DepsOptions:
     load_config: LoadConfigFn = _raise_unexpected_load
     write_config_to: WriteConfigFn = _raise_unexpected_write
     handle_error: HandleErrorFn = _handle_error
+    open_report: Callable[[Path], bool] | None = None
     stdout_is_tty: bool = False
+    stdin_is_tty: bool = False
     no_color_env_present: bool = False
     copy_to_clipboard: Callable[[str], None] | None = None
     open_url: Callable[[str], bool] | None = None
+    confirm_upload: Callable[..., bool] | None = None
 
 
 def _deps(options: DepsOptions | None = None, opened: list[Path] | None = None) -> RunCommandDeps:
     opts = options or DepsOptions()
     opened_reports = [] if opened is None else opened
 
-    def _open_report(report_path: Path) -> None:
+    def _open_report(report_path: Path) -> bool:
         opened_reports.append(report_path)
+        return True
 
     return RunCommandDeps(
         runner=opts.runner or RecordingRunner(),
@@ -130,12 +138,22 @@ def _deps(options: DepsOptions | None = None, opened: list[Path] | None = None) 
         handle_error=opts.handle_error,
         configure_logging=lambda *, level, format: None,
         console_factory=_console_factory,
-        open_report=_open_report,
+        open_report=opts.open_report or _open_report,
         copy_to_clipboard=opts.copy_to_clipboard or (lambda _text: None),
         open_url=opts.open_url or (lambda _url: True),
+        confirm_upload=opts.confirm_upload or (lambda _text, *, default: default),
         stdout_is_tty=opts.stdout_is_tty,
+        stdin_is_tty=opts.stdin_is_tty,
         no_color_env_present=opts.no_color_env_present,
     )
+
+
+def _prompt_required_config(*, report_enable: bool = True) -> ConfigSchema:
+    config = get_default_config()
+    config.slowpics.auto_upload = True
+    config.slowpics.confirm_upload_after_report = True
+    config.report.enable = report_enable
+    return config
 
 
 def test_build_run_request_from_cli_maps_all_runtime_options() -> None:
@@ -345,6 +363,264 @@ def test_handle_run_json_write_config_error_writes_machine_schema(
     payload = json.loads(capsys.readouterr().out)
     assert payload["success"] is False
     assert payload["error"]["code"] == "FC-1007"
+
+
+@pytest.mark.parametrize(
+    ("args_update", "deps_update", "config", "expected_message"),
+    [
+        (
+            {"quiet": True},
+            {"stdin_is_tty": True, "stdout_is_tty": True},
+            _prompt_required_config(),
+            "Report-confirmed slow.pics upload is not supported with --quiet.",
+        ),
+        (
+            {"quiet": False},
+            {"stdin_is_tty": False, "stdout_is_tty": True},
+            _prompt_required_config(),
+            "Report-confirmed slow.pics upload requires stdin to be attached to a TTY.",
+        ),
+        (
+            {"quiet": False},
+            {"stdin_is_tty": True, "stdout_is_tty": False},
+            _prompt_required_config(),
+            "Report-confirmed slow.pics upload requires stdout to be attached to a TTY.",
+        ),
+        (
+            {"quiet": False},
+            {"stdin_is_tty": True, "stdout_is_tty": True},
+            _prompt_required_config(report_enable=False),
+            "Report-confirmed slow.pics upload requires report.enable = true.",
+        ),
+    ],
+)
+def test_handle_run_rejects_report_confirmed_slowpics_preflight_before_runner(
+    args_update: dict[str, object],
+    deps_update: dict[str, object],
+    config: ConfigSchema,
+    expected_message: str,
+) -> None:
+    runner = RecordingRunner()
+    handled_errors: list[ConfigValidationError] = []
+
+    def _load_config(
+        config_path: Path | None = None,
+        overrides: dict[str, object] | None = None,
+    ) -> ConfigSchema:
+        return config
+
+    def _handle_validation_error(
+        error: Exception,
+        *,
+        no_color: bool,
+        verbose: bool,
+        verbose_hint: str | None = "--verbose",
+    ) -> int:
+        assert isinstance(error, ConfigValidationError)
+        handled_errors.append(error)
+        assert no_color is False
+        assert verbose is False
+        assert verbose_hint == "--verbose"
+        return int(ExitCode.CONFIG_ERROR)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        handle_run(
+            replace(_base_args(), **args_update),
+            _deps(
+                DepsOptions(
+                    runner=runner,
+                    load_config=_load_config,
+                    handle_error=_handle_validation_error,
+                    **deps_update,
+                )
+            ),
+        )
+
+    assert exc_info.value.exit_code == int(ExitCode.CONFIG_ERROR)
+    assert runner.requests == []
+    assert handled_errors
+    assert expected_message in {
+        str(error["msg"]) for error in handled_errors[0].validation_errors
+    }
+
+
+def test_handle_run_report_confirmed_slowpics_preflight_allows_no_upload_override() -> None:
+    runner = RecordingRunner()
+
+    def _load_config(
+        config_path: Path | None = None,
+        overrides: dict[str, object] | None = None,
+    ) -> ConfigSchema:
+        return _prompt_required_config()
+
+    handle_run(
+        replace(_base_args(), no_upload=True, quiet=False),
+        _deps(
+            DepsOptions(
+                runner=runner,
+                load_config=_load_config,
+                stdin_is_tty=False,
+                stdout_is_tty=False,
+            )
+        ),
+    )
+
+    assert len(runner.requests) == 1
+
+
+def test_handle_run_injects_confirmation_dependency_only_for_prompt_required_path() -> None:
+    prompt_runner = RecordingRunner()
+    normal_runner = RecordingRunner()
+
+    def _prompt_config(
+        config_path: Path | None = None,
+        overrides: dict[str, object] | None = None,
+    ) -> ConfigSchema:
+        return _prompt_required_config()
+
+    def _normal_config(
+        config_path: Path | None = None,
+        overrides: dict[str, object] | None = None,
+    ) -> ConfigSchema:
+        return get_default_config()
+
+    handle_run(
+        replace(_base_args(), quiet=False),
+        _deps(
+            DepsOptions(
+                runner=prompt_runner,
+                load_config=_prompt_config,
+                stdin_is_tty=True,
+                stdout_is_tty=True,
+            )
+        ),
+    )
+    handle_run(
+        replace(_base_args(), quiet=False),
+        _deps(
+            DepsOptions(
+                runner=normal_runner,
+                load_config=_normal_config,
+                stdin_is_tty=True,
+                stdout_is_tty=True,
+            )
+        ),
+    )
+
+    assert prompt_runner.dependencies[0] is not None
+    assert prompt_runner.dependencies[0].confirm_slowpics_upload is not None
+    assert normal_runner.dependencies == [None]
+
+
+def test_confirmation_callback_opens_report_before_prompt_and_defaults_decline() -> None:
+    opened: list[Path] = []
+
+    def _confirm_upload(text: str, *, default: bool) -> bool:
+        assert opened == [Path("report.html")]
+        assert text == "Review the local report, then upload this comparison to slow.pics?"
+        assert default is False
+        return True
+
+    callback = build_confirm_slowpics_upload_callback(
+        args=replace(_base_args(), quiet=False),
+        deps=_deps(
+            DepsOptions(
+                stdout_is_tty=True,
+                confirm_upload=_confirm_upload,
+            ),
+            opened,
+        ),
+        console=Console(file=StringIO(), no_color=True),
+        resolve_effective_config=get_default_config,
+    )
+
+    assert callback(SlowpicsUploadConfirmationRequest(report_path=Path("report.html"))) == (
+        "confirmed"
+    )
+
+
+def test_confirmation_callback_prints_report_path_when_auto_open_disabled() -> None:
+    disabled_auto_open = get_default_config()
+    disabled_auto_open.report.auto_open = False
+    output = StringIO()
+
+    callback = build_confirm_slowpics_upload_callback(
+        args=replace(_base_args(), quiet=False),
+        deps=_deps(
+            DepsOptions(
+                stdout_is_tty=True,
+                confirm_upload=lambda _text, *, default: False,
+            )
+        ),
+        console=Console(file=output, no_color=True, force_terminal=False),
+        resolve_effective_config=lambda: disabled_auto_open,
+    )
+
+    assert callback(SlowpicsUploadConfirmationRequest(report_path=Path("report.html"))) == (
+        "declined"
+    )
+    assert "Report: report.html" in output.getvalue()
+
+
+def test_confirmation_callback_prints_report_path_when_auto_open_attempt_fails() -> None:
+    output = StringIO()
+
+    callback = build_confirm_slowpics_upload_callback(
+        args=replace(_base_args(), quiet=False),
+        deps=_deps(
+            DepsOptions(
+                stdout_is_tty=True,
+                open_report=lambda _path: False,
+                confirm_upload=lambda _text, *, default: False,
+            )
+        ),
+        console=Console(file=output, no_color=True, force_terminal=False),
+        resolve_effective_config=get_default_config,
+    )
+
+    assert callback(SlowpicsUploadConfirmationRequest(report_path=Path("report.html"))) == (
+        "declined"
+    )
+    assert "Report: report.html" in output.getvalue()
+
+
+def test_handle_run_interrupts_when_confirmation_prompt_aborts() -> None:
+    class PromptAbortRunner(RecordingRunner):
+        def run(
+            self, request: RunRequest, dependencies: RunDependencies | None = None
+        ) -> RunResult:
+            self.requests.append(request)
+            self.dependencies.append(dependencies)
+            assert dependencies is not None
+            assert dependencies.confirm_slowpics_upload is not None
+            dependencies.confirm_slowpics_upload(
+                SlowpicsUploadConfirmationRequest(report_path=Path("report.html"))
+            )
+            raise AssertionError("upload should not continue after prompt abort")
+
+    def _load_config(
+        config_path: Path | None = None,
+        overrides: dict[str, object] | None = None,
+    ) -> ConfigSchema:
+        return _prompt_required_config()
+
+    with pytest.raises(typer.Exit) as exc_info:
+        handle_run(
+            replace(_base_args(), quiet=False),
+            _deps(
+                DepsOptions(
+                    runner=PromptAbortRunner(),
+                    load_config=_load_config,
+                    stdin_is_tty=True,
+                    stdout_is_tty=True,
+                    confirm_upload=lambda _text, *, default: (_ for _ in ()).throw(
+                        typer.Abort()
+                    ),
+                )
+            ),
+        )
+
+    assert exc_info.value.exit_code == int(ExitCode.INTERRUPTED)
 
 
 def test_maybe_open_run_report_requires_report_human_output_and_tty() -> None:
@@ -567,3 +843,71 @@ def test_handle_run_executes_interactive_actions_before_summary(monkeypatch) -> 
     )
 
     assert events == ["copy", "open", "summary"]
+
+
+def test_handle_run_confirmed_workflow_presents_report_before_post_upload_actions(
+    monkeypatch,
+) -> None:
+    events: list[str] = []
+    opened_reports: list[Path] = []
+
+    class ConfirmingRunner(RecordingRunner):
+        def run(
+            self, request: RunRequest, dependencies: RunDependencies | None = None
+        ) -> RunResult:
+            self.requests.append(request)
+            self.dependencies.append(dependencies)
+            assert dependencies is not None
+            assert dependencies.confirm_slowpics_upload is not None
+            decision = dependencies.confirm_slowpics_upload(
+                SlowpicsUploadConfirmationRequest(report_path=Path("report.html"))
+            )
+            return RunResult(
+                success=True,
+                slowpics_url="https://slow.pics/c/example",
+                report_path=Path("report.html"),
+                slowpics_upload_confirmation_status=decision,
+            )
+
+    def _print_summary(*_args: object, **_kwargs: object) -> None:
+        events.append("summary")
+
+    def _load_config(
+        config_path: Path | None = None,
+        overrides: dict[str, object] | None = None,
+    ) -> ConfigSchema:
+        return _prompt_required_config()
+
+    def _confirm_upload(_text: str, *, default: bool) -> bool:
+        assert default is False
+        assert opened_reports == [Path("report.html")]
+        events.append("prompt")
+        return True
+
+    def _copy_url(_url: str) -> None:
+        events.append("copy")
+
+    def _open_url(_url: str) -> bool:
+        events.append("slowpics-browser")
+        return True
+
+    monkeypatch.setattr("frame_compare.cli.run_command.print_result_summary", _print_summary)
+
+    handle_run(
+        replace(_base_args(), quiet=False),
+        _deps(
+            DepsOptions(
+                runner=ConfirmingRunner(),
+                load_config=_load_config,
+                stdin_is_tty=True,
+                stdout_is_tty=True,
+                copy_to_clipboard=_copy_url,
+                open_url=_open_url,
+                confirm_upload=_confirm_upload,
+            ),
+            opened_reports,
+        ),
+    )
+
+    assert events == ["prompt", "copy", "slowpics-browser", "summary"]
+    assert opened_reports == [Path("report.html")]

--- a/tests/cli/test_run_command.py
+++ b/tests/cli/test_run_command.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from io import StringIO
 from pathlib import Path
@@ -17,10 +18,12 @@ from frame_compare.cli.run_command import (
     RunCommandDeps,
     WriteConfigFn,
     build_run_request_from_cli,
+    collect_interactive_slowpics_actions,
     handle_diagnose_paths,
     handle_json_output,
     handle_run,
     maybe_open_run_report,
+    slowpics_browser_open_attempted,
 )
 from frame_compare.config.errors import ConfigNotFoundError, ConfigWriteError
 from frame_compare.config.loader import get_default_config
@@ -109,6 +112,8 @@ class DepsOptions:
     handle_error: HandleErrorFn = _handle_error
     stdout_is_tty: bool = False
     no_color_env_present: bool = False
+    copy_to_clipboard: Callable[[str], None] | None = None
+    open_url: Callable[[str], bool] | None = None
 
 
 def _deps(options: DepsOptions | None = None, opened: list[Path] | None = None) -> RunCommandDeps:
@@ -126,6 +131,8 @@ def _deps(options: DepsOptions | None = None, opened: list[Path] | None = None) 
         configure_logging=lambda *, level, format: None,
         console_factory=_console_factory,
         open_report=_open_report,
+        copy_to_clipboard=opts.copy_to_clipboard or (lambda _text: None),
+        open_url=opts.open_url or (lambda _url: True),
         stdout_is_tty=opts.stdout_is_tty,
         no_color_env_present=opts.no_color_env_present,
     )
@@ -400,3 +407,163 @@ def test_maybe_open_run_report_respects_config_and_reload_failure() -> None:
     )
 
     assert opened == [Path("report.html"), Path("report.html")]
+
+
+def test_interactive_slowpics_actions_require_url_enabled_config_human_tty() -> None:
+    copied: list[str] = []
+    opened: list[str] = []
+    deps = _deps(
+        DepsOptions(
+            stdout_is_tty=True,
+            copy_to_clipboard=copied.append,
+            open_url=lambda url: opened.append(url) is None or True,
+        )
+    )
+    result = RunResult(success=True, slowpics_url="https://slow.pics/c/example")
+
+    actions = collect_interactive_slowpics_actions(
+        result,
+        args=replace(_base_args(), quiet=False),
+        deps=deps,
+        config=get_default_config(),
+    )
+
+    assert copied == ["https://slow.pics/c/example"]
+    assert opened == ["https://slow.pics/c/example"]
+    assert [(action.kind, action.success) for action in actions] == [
+        ("clipboard", True),
+        ("browser", True),
+    ]
+
+    copied.clear()
+    opened.clear()
+    disabled = get_default_config()
+    disabled.slowpics.copy_url_to_clipboard = False
+    disabled.slowpics.open_in_browser = False
+
+    assert (
+        collect_interactive_slowpics_actions(
+            result,
+            args=replace(_base_args(), quiet=False),
+            deps=deps,
+            config=disabled,
+        )
+        == ()
+    )
+    assert (
+        collect_interactive_slowpics_actions(
+            result,
+            args=replace(_base_args(), quiet=False, json_output=True),
+            deps=deps,
+            config=get_default_config(),
+        )
+        == ()
+    )
+    assert (
+        collect_interactive_slowpics_actions(
+            result,
+            args=replace(_base_args(), quiet=True),
+            deps=deps,
+            config=get_default_config(),
+        )
+        == ()
+    )
+    assert (
+        collect_interactive_slowpics_actions(
+            result,
+            args=replace(_base_args(), quiet=False),
+            deps=_deps(DepsOptions(stdout_is_tty=False)),
+            config=get_default_config(),
+        )
+        == ()
+    )
+    assert (
+        collect_interactive_slowpics_actions(
+            RunResult(success=True),
+            args=replace(_base_args(), quiet=False),
+            deps=deps,
+            config=get_default_config(),
+        )
+        == ()
+    )
+    assert copied == []
+    assert opened == []
+
+
+def test_interactive_slowpics_action_failures_are_warning_only() -> None:
+    deps = _deps(
+        DepsOptions(
+            stdout_is_tty=True,
+            copy_to_clipboard=lambda _url: (_ for _ in ()).throw(RuntimeError("clipboard denied")),
+            open_url=lambda _url: False,
+        )
+    )
+
+    actions = collect_interactive_slowpics_actions(
+        RunResult(success=True, slowpics_url="https://slow.pics/c/example"),
+        args=replace(_base_args(), quiet=False),
+        deps=deps,
+        config=get_default_config(),
+    )
+
+    assert [(action.kind, action.success) for action in actions] == [
+        ("clipboard", False),
+        ("browser", False),
+    ]
+    assert actions[0].warning == "slow.pics clipboard: failed to copy URL: clipboard denied"
+    assert actions[1].warning == (
+        "slow.pics browser: failed to open URL: no browser accepted the request"
+    )
+    assert slowpics_browser_open_attempted(actions) is True
+
+
+def test_report_auto_open_can_be_suppressed_by_slowpics_browser_attempt() -> None:
+    opened: list[Path] = []
+
+    maybe_open_run_report(
+        RunResult(success=True, report_path=Path("report.html")),
+        args=replace(_base_args(), quiet=False),
+        deps=_deps(DepsOptions(stdout_is_tty=True), opened),
+        resolve_effective_config=get_default_config,
+        suppress_report_open=True,
+    )
+
+    assert opened == []
+
+
+def test_handle_run_executes_interactive_actions_before_summary(monkeypatch) -> None:
+    events: list[str] = []
+    runner = RecordingRunner(RunResult(success=True, slowpics_url="https://slow.pics/c/example"))
+
+    def _print_summary(*_args: object, **_kwargs: object) -> None:
+        events.append("summary")
+
+    def _load_config(
+        config_path: Path | None = None,
+        overrides: dict[str, object] | None = None,
+    ) -> ConfigSchema:
+        return get_default_config()
+
+    def _copy_url(_url: str) -> None:
+        events.append("copy")
+
+    def _open_url(_url: str) -> bool:
+        events.append("open")
+        return True
+
+    monkeypatch.setattr("frame_compare.cli.run_command.print_result_summary", _print_summary)
+
+    handle_run(
+        replace(_base_args(), quiet=False),
+        _deps(
+            DepsOptions(
+                runner=runner,
+                load_config=_load_config,
+                stdout_is_tty=True,
+                copy_to_clipboard=_copy_url,
+                open_url=_open_url,
+            )
+        ),
+    )
+
+    assert events == ["copy", "open", "summary"]

--- a/tests/cli/test_run_json_errors.py
+++ b/tests/cli/test_run_json_errors.py
@@ -72,6 +72,26 @@ def test_run_json_outputs_pinned_success_schema_and_stdout_is_pure_json(
     }
 
 
+def test_run_json_success_omits_warnings_from_stdout(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
+        return RunResult(
+            success=True,
+            warnings=["cleanup: failed to delete uploaded screenshot shots/a.png: locked"],
+        )
+
+    monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
+
+    result = _invoke_run_with_minimal_workspace(["--json"])
+
+    assert result.exit_code == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert "warnings" not in payload
+    assert "cleanup:" not in result.stdout
+
+
 def test_run_json_rejects_interactive_alignment_from_config_before_runner(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/cli/test_run_json_errors.py
+++ b/tests/cli/test_run_json_errors.py
@@ -157,6 +157,51 @@ def test_run_json_rejects_force_interactive_alignment_before_runner(
     }
 
 
+def test_run_json_rejects_report_confirmed_slowpics_before_runner(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
+        raise AssertionError("runner.run should not be invoked for invalid CLI/config combinations")
+
+    monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
+
+    with runner.isolated_filesystem():
+        root = Path("workspace")
+        config_path = _write_minimal_config(root)
+        config_path.write_text(
+            MINIMAL_CONFIG
+            + "\n[slowpics]\nauto_upload = true\nconfirm_upload_after_report = true\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                "--root",
+                str(root),
+                "--config",
+                str(config_path.relative_to(root)),
+                "--json",
+            ],
+        )
+
+    assert result.exit_code == int(ExitCode.CONFIG_ERROR)
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "FC-1003"
+    assert payload["error"]["message"] == (
+        "Report-confirmed slow.pics upload requires an interactive report-enabled run"
+    )
+    assert "warnings" not in payload
+    assert result.stdout.count("\n") == 1
+    assert {
+        tuple(entry["loc"]): entry["msg"]
+        for entry in payload["error"]["details"]["validation_errors"]
+    }[("cli", "json")] == "Report-confirmed slow.pics upload is not supported with --json."
+
+
 def test_run_json_outputs_error_schema_and_exit_code(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/cli/test_run_output.py
+++ b/tests/cli/test_run_output.py
@@ -246,6 +246,26 @@ def test_run_result_summary_prints_slowpics_url_and_untruncated_warnings(
     assert "more)" not in output
 
 
+def test_run_result_summary_prints_declined_upload_as_information(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
+        return RunResult(
+            success=True,
+            slowpics_upload_confirmation_status="declined",
+            report_path=Path("report.html"),
+        )
+
+    monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
+
+    result = _invoke_run_with_minimal_workspace([])
+
+    assert result.exit_code == 0
+    output = _normalize_cli_output(result.stdout)
+    assert "slow.pics upload skipped by confirmation" in output
+    assert "Warnings" not in output
+
+
 def test_run_result_summary_prints_interactive_slowpics_action_outcomes(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/cli/test_run_output.py
+++ b/tests/cli/test_run_output.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 from pytest import MonkeyPatch
 
@@ -242,6 +243,66 @@ def test_run_result_summary_prints_slowpics_url_and_untruncated_warnings(
     assert "• metadata skipped" in output
     assert "• upload reused" in output
     assert "more)" not in output
+
+
+def test_run_result_summary_prints_interactive_slowpics_action_outcomes(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    copied: list[str] = []
+    opened: list[str] = []
+
+    def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
+        return RunResult(success=True, slowpics_url="https://slow.pics/c/example")
+
+    monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
+    monkeypatch.setattr(
+        "frame_compare.cli.entry.sys",
+        SimpleNamespace(stdout=SimpleNamespace(isatty=lambda: True)),
+    )
+    monkeypatch.setattr("frame_compare.cli.entry._copy_text_to_clipboard", copied.append)
+    monkeypatch.setattr(
+        "frame_compare.cli.entry._open_url_in_browser",
+        lambda url: opened.append(url) is None or True,
+    )
+
+    result = _invoke_run_with_minimal_workspace([])
+
+    assert result.exit_code == 0
+    assert copied == ["https://slow.pics/c/example"]
+    assert opened == ["https://slow.pics/c/example"]
+    output = _normalize_cli_output(result.stdout)
+    assert "slow.pics" in output
+    assert "https://slow.pics/c/example" in output
+    assert "clipboard" in output
+    assert "slow.pics URL copied to clipboard" in output
+    assert "browser" in output
+    assert "slow.pics URL opened in browser" in output
+
+
+def test_run_result_summary_merges_interactive_slowpics_action_warnings(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
+        return RunResult(success=True, slowpics_url="https://slow.pics/c/example")
+
+    def _copy_url(_url: str) -> None:
+        raise RuntimeError("clipboard unavailable")
+
+    monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
+    monkeypatch.setattr(
+        "frame_compare.cli.entry.sys",
+        SimpleNamespace(stdout=SimpleNamespace(isatty=lambda: True)),
+    )
+    monkeypatch.setattr("frame_compare.cli.entry._copy_text_to_clipboard", _copy_url)
+    monkeypatch.setattr("frame_compare.cli.entry._open_url_in_browser", lambda _url: False)
+
+    result = _invoke_run_with_minimal_workspace([])
+
+    assert result.exit_code == 0
+    output = _normalize_cli_output(result.stdout)
+    assert "Warnings" in output
+    assert "• slow.pics clipboard: failed to copy URL: clipboard unavailable" in output
+    assert "• slow.pics browser: failed to open URL: no browser accepted the request" in output
 
 
 def test_run_quiet_suppresses_at_a_glance_but_keeps_minimal_summary(

--- a/tests/cli/test_run_output.py
+++ b/tests/cli/test_run_output.py
@@ -6,6 +6,7 @@ from pytest import MonkeyPatch
 
 from frame_compare.cli.entry import app
 from frame_compare.orchestration import RunDependencies, RunRequest, RunResult
+from frame_compare.orchestration.types import PostUploadActionResult
 
 from .cli_helpers import (
     MINIMAL_CONFIG,
@@ -303,6 +304,35 @@ def test_run_result_summary_merges_interactive_slowpics_action_warnings(
     assert "Warnings" in output
     assert "• slow.pics clipboard: failed to copy URL: clipboard unavailable" in output
     assert "• slow.pics browser: failed to open URL: no browser accepted the request" in output
+
+
+def test_run_result_summary_prints_duplicate_post_upload_warning_once(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    warning = "slow.pics shortcut: failed to write URL shortcut"
+
+    def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
+        return RunResult(
+            success=True,
+            slowpics_url="https://slow.pics/c/example",
+            post_upload_actions=(
+                PostUploadActionResult(
+                    kind="shortcut",
+                    success=False,
+                    warning=warning,
+                ),
+            ),
+            warnings=[warning],
+        )
+
+    monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
+
+    result = _invoke_run_with_minimal_workspace([])
+
+    assert result.exit_code == 0
+    output = _normalize_cli_output(result.stdout)
+    assert "Warnings" in output
+    assert output.count(warning) == 1
 
 
 def test_run_quiet_suppresses_at_a_glance_but_keeps_minimal_summary(

--- a/tests/cli/test_run_output.py
+++ b/tests/cli/test_run_output.py
@@ -335,6 +335,96 @@ def test_run_result_summary_prints_duplicate_post_upload_warning_once(
     assert output.count(warning) == 1
 
 
+def test_run_result_summary_prints_enabled_shortcut_and_webhook_outcomes(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    shortcut_path = Path("workspace") / "Example.url"
+
+    def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
+        return RunResult(
+            success=True,
+            slowpics_url="https://slow.pics/c/example",
+            post_upload_actions=(
+                PostUploadActionResult(
+                    kind="shortcut",
+                    success=True,
+                    path=shortcut_path,
+                    message="slow.pics URL shortcut written",
+                ),
+                PostUploadActionResult(
+                    kind="webhook",
+                    success=True,
+                    detail="HTTP 204",
+                    message="slow.pics webhook delivered",
+                ),
+            ),
+        )
+
+    monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
+
+    result = _invoke_run_with_minimal_workspace([])
+
+    assert result.exit_code == 0
+    output = _normalize_cli_output(result.stdout)
+    assert "shortcut" in output
+    assert str(shortcut_path) in output
+    assert "webhook" in output
+    assert "HTTP 204" in output
+    assert "disabled" not in output
+    assert "skipped" not in output
+
+
+def test_run_json_omits_post_upload_action_fields(monkeypatch: MonkeyPatch) -> None:
+    def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
+        return RunResult(
+            success=True,
+            slowpics_url="https://slow.pics/c/example",
+            post_upload_actions=(
+                PostUploadActionResult(
+                    kind="shortcut",
+                    success=True,
+                    path=Path("Example.url"),
+                    message="slow.pics URL shortcut written",
+                ),
+                PostUploadActionResult(
+                    kind="webhook",
+                    success=False,
+                    warning="slow.pics webhook: delivery failed after 3 attempts",
+                ),
+            ),
+            warnings=["slow.pics webhook: delivery failed after 3 attempts"],
+        )
+
+    monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
+
+    with runner.isolated_filesystem():
+        root = Path("workspace")
+        config_path = _write_minimal_config(root)
+
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                "--root",
+                str(root),
+                "--config",
+                str(config_path.relative_to(root)),
+                "--json",
+            ],
+            color=False,
+            terminal_width=200,
+            env={"NO_COLOR": "1", "TERM": "dumb"},
+        )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["slowpics_url"] == "https://slow.pics/c/example"
+    assert "post_upload_actions" not in payload
+    assert "shortcut" not in payload
+    assert "webhook" not in payload
+    assert result.stderr == ""
+
+
 def test_run_quiet_suppresses_at_a_glance_but_keeps_minimal_summary(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/cli/test_run_report_open.py
+++ b/tests/cli/test_run_report_open.py
@@ -8,6 +8,7 @@ from frame_compare.cli.entry import _maybe_open_report, app
 from frame_compare.config.errors import ConfigNotFoundError
 from frame_compare.config.loader import get_default_config
 from frame_compare.orchestration import RunDependencies, RunRequest, RunResult
+from frame_compare.orchestration.types import SlowpicsUploadConfirmationRequest
 
 from .cli_helpers import (
     MINIMAL_CONFIG,
@@ -36,7 +37,7 @@ def test_run_opens_report_for_interactive_tty_when_auto_open_enabled(
     )
     monkeypatch.setattr(
         "frame_compare.cli.entry._maybe_open_report",
-        lambda report_path: opened.setdefault("path", report_path),
+        lambda report_path: opened.setdefault("path", report_path) is not None,
     )
 
     result = _invoke_run_with_minimal_workspace([])
@@ -64,7 +65,7 @@ def test_run_does_not_open_report_when_auto_open_disabled_in_config(
     )
     monkeypatch.setattr(
         "frame_compare.cli.entry._maybe_open_report",
-        lambda report_path: opened.setdefault("path", report_path),
+        lambda report_path: opened.setdefault("path", report_path) is not None,
     )
 
     with runner.isolated_filesystem():
@@ -104,7 +105,7 @@ def test_run_does_not_open_report_when_stdout_is_not_a_tty(monkeypatch: MonkeyPa
     )
     monkeypatch.setattr(
         "frame_compare.cli.entry._maybe_open_report",
-        lambda report_path: opened.setdefault("path", report_path),
+        lambda report_path: opened.setdefault("path", report_path) is not None,
     )
 
     result = _invoke_run_with_minimal_workspace([])
@@ -130,7 +131,7 @@ def test_run_does_not_open_report_when_quiet(monkeypatch: MonkeyPatch) -> None:
     )
     monkeypatch.setattr(
         "frame_compare.cli.entry._maybe_open_report",
-        lambda report_path: opened.setdefault("path", report_path),
+        lambda report_path: opened.setdefault("path", report_path) is not None,
     )
 
     result = _invoke_run_with_minimal_workspace(["--quiet"])
@@ -156,7 +157,7 @@ def test_run_does_not_open_report_when_json_output_requested(monkeypatch: Monkey
     )
     monkeypatch.setattr(
         "frame_compare.cli.entry._maybe_open_report",
-        lambda report_path: opened.setdefault("path", report_path),
+        lambda report_path: opened.setdefault("path", report_path) is not None,
     )
 
     result = _invoke_run_with_minimal_workspace(["--json"])
@@ -191,7 +192,7 @@ def test_run_opens_report_when_post_run_config_reload_fails(monkeypatch: MonkeyP
     )
     monkeypatch.setattr(
         "frame_compare.cli.entry._maybe_open_report",
-        lambda report_path: opened.setdefault("path", report_path),
+        lambda report_path: opened.setdefault("path", report_path) is not None,
     )
 
     result = _invoke_run_with_minimal_workspace([])
@@ -228,7 +229,7 @@ def test_run_reloads_config_after_runner_and_respects_mid_run_auto_open_change(
         )
         monkeypatch.setattr(
             "frame_compare.cli.entry._maybe_open_report",
-            lambda report_path: opened.setdefault("path", report_path),
+            lambda report_path: opened.setdefault("path", report_path) is not None,
         )
 
         result = runner.invoke(
@@ -268,7 +269,7 @@ def test_run_slowpics_browser_open_suppresses_report_auto_open(
     )
     monkeypatch.setattr(
         "frame_compare.cli.entry._maybe_open_report",
-        lambda report_path: opened_reports.setdefault("path", report_path),
+        lambda report_path: opened_reports.setdefault("path", report_path) is not None,
     )
 
     result = _invoke_run_with_minimal_workspace([])
@@ -276,6 +277,74 @@ def test_run_slowpics_browser_open_suppresses_report_auto_open(
     assert result.exit_code == 0
     assert opened_urls == ["https://slow.pics/c/example"]
     assert "path" not in opened_reports
+
+
+def test_run_confirmed_slowpics_opens_report_before_later_slowpics_browser(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    opened_reports: list[Path] = []
+    opened_urls: list[str] = []
+
+    def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
+        assert dependencies is not None
+        assert dependencies.confirm_slowpics_upload is not None
+        decision = dependencies.confirm_slowpics_upload(
+            SlowpicsUploadConfirmationRequest(report_path=Path("report.html"))
+        )
+        return RunResult(
+            success=True,
+            slowpics_url="https://slow.pics/c/example",
+            report_path=Path("report.html"),
+            slowpics_upload_confirmation_status=decision,
+        )
+
+    def _confirm_upload(_text: str, *, default: bool) -> bool:
+        assert default is False
+        assert opened_reports == [Path("report.html")]
+        events.append("prompt")
+        return True
+
+    monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
+    monkeypatch.setattr(
+        "frame_compare.cli.entry.sys",
+        SimpleNamespace(
+            stdin=SimpleNamespace(isatty=lambda: True),
+            stdout=SimpleNamespace(isatty=lambda: True),
+        ),
+    )
+    monkeypatch.setattr("frame_compare.cli.entry.typer.confirm", _confirm_upload)
+    monkeypatch.setattr("frame_compare.cli.entry._copy_text_to_clipboard", lambda _url: None)
+    monkeypatch.setattr(
+        "frame_compare.cli.entry._open_url_in_browser",
+        lambda url: opened_urls.append(url) is None or True,
+    )
+    monkeypatch.setattr(
+        "frame_compare.cli.entry._maybe_open_report",
+        lambda report_path: opened_reports.append(report_path) is None,
+    )
+
+    with runner.isolated_filesystem():
+        root = Path("workspace")
+        config_path = _write_minimal_config(root)
+        config_path.write_text(
+            MINIMAL_CONFIG
+            + "\n[slowpics]\nauto_upload = true\nconfirm_upload_after_report = true\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            ["run", "--root", str(root), "--config", str(config_path.relative_to(root))],
+            color=False,
+            terminal_width=200,
+            env={"NO_COLOR": "1", "TERM": "dumb"},
+        )
+
+    assert result.exit_code == 0
+    assert events == ["prompt"]
+    assert opened_reports == [Path("report.html")]
+    assert opened_urls == ["https://slow.pics/c/example"]
 
 
 def test_run_report_auto_open_preserved_when_slowpics_browser_open_disabled(
@@ -303,7 +372,7 @@ def test_run_report_auto_open_preserved_when_slowpics_browser_open_disabled(
     )
     monkeypatch.setattr(
         "frame_compare.cli.entry._maybe_open_report",
-        lambda report_path: opened_reports.setdefault("path", report_path),
+        lambda report_path: opened_reports.setdefault("path", report_path) is not None,
     )
 
     with runner.isolated_filesystem():
@@ -334,7 +403,19 @@ def test_maybe_open_report_swallows_webbrowser_error(monkeypatch: MonkeyPatch) -
         lambda _uri: (_ for _ in ()).throw(webbrowser.Error("no browser")),
     )
 
-    _maybe_open_report(Path("report.html"))
+    assert _maybe_open_report(Path("report.html")) is False
+
+
+def test_maybe_open_report_returns_false_when_no_browser_accepts(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("frame_compare.cli.cli_helpers.os", SimpleNamespace(name="posix"))
+    monkeypatch.setattr(
+        "frame_compare.cli.cli_helpers.webbrowser.open",
+        lambda _uri: False,
+    )
+
+    assert _maybe_open_report(Path("report.html")) is False
 
 
 def test_maybe_open_report_keeps_startfile_path_on_windows(monkeypatch: MonkeyPatch) -> None:
@@ -349,7 +430,7 @@ def test_maybe_open_report_keeps_startfile_path_on_windows(monkeypatch: MonkeyPa
         lambda _uri: (_ for _ in ()).throw(AssertionError("webbrowser.open should not be called")),
     )
 
-    _maybe_open_report(Path("report.html"))
+    assert _maybe_open_report(Path("report.html")) is True
     assert called["path"] == "report.html"
 
 
@@ -365,9 +446,9 @@ def test_maybe_open_report_falls_back_to_webbrowser_when_startfile_fails(
     monkeypatch.setattr("frame_compare.cli.cli_helpers.os", fake_os)
     monkeypatch.setattr(
         "frame_compare.cli.cli_helpers.webbrowser.open",
-        lambda uri: called.setdefault("uri", uri),
+        lambda uri: called.setdefault("uri", uri) is not None,
     )
 
-    _maybe_open_report(Path("report.html"))
+    assert _maybe_open_report(Path("report.html")) is True
 
     assert called["uri"].startswith("file:")

--- a/tests/cli/test_run_report_open.py
+++ b/tests/cli/test_run_report_open.py
@@ -243,6 +243,90 @@ def test_run_reloads_config_after_runner_and_respects_mid_run_auto_open_change(
     assert "path" not in opened
 
 
+def test_run_slowpics_browser_open_suppresses_report_auto_open(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    opened_reports: dict[str, Path] = {}
+    opened_urls: list[str] = []
+
+    def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
+        return RunResult(
+            success=True,
+            slowpics_url="https://slow.pics/c/example",
+            report_path=Path("report.html"),
+        )
+
+    monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
+    monkeypatch.setattr(
+        "frame_compare.cli.entry.sys",
+        SimpleNamespace(stdout=SimpleNamespace(isatty=lambda: True)),
+    )
+    monkeypatch.setattr("frame_compare.cli.entry._copy_text_to_clipboard", lambda _url: None)
+    monkeypatch.setattr(
+        "frame_compare.cli.entry._open_url_in_browser",
+        lambda url: opened_urls.append(url) is None or True,
+    )
+    monkeypatch.setattr(
+        "frame_compare.cli.entry._maybe_open_report",
+        lambda report_path: opened_reports.setdefault("path", report_path),
+    )
+
+    result = _invoke_run_with_minimal_workspace([])
+
+    assert result.exit_code == 0
+    assert opened_urls == ["https://slow.pics/c/example"]
+    assert "path" not in opened_reports
+
+
+def test_run_report_auto_open_preserved_when_slowpics_browser_open_disabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    opened_reports: dict[str, Path] = {}
+    opened_urls: list[str] = []
+
+    def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
+        return RunResult(
+            success=True,
+            slowpics_url="https://slow.pics/c/example",
+            report_path=Path("report.html"),
+        )
+
+    monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
+    monkeypatch.setattr(
+        "frame_compare.cli.entry.sys",
+        SimpleNamespace(stdout=SimpleNamespace(isatty=lambda: True)),
+    )
+    monkeypatch.setattr("frame_compare.cli.entry._copy_text_to_clipboard", lambda _url: None)
+    monkeypatch.setattr(
+        "frame_compare.cli.entry._open_url_in_browser",
+        lambda url: opened_urls.append(url) is None or True,
+    )
+    monkeypatch.setattr(
+        "frame_compare.cli.entry._maybe_open_report",
+        lambda report_path: opened_reports.setdefault("path", report_path),
+    )
+
+    with runner.isolated_filesystem():
+        root = Path("workspace")
+        config_path = _write_minimal_config(root)
+        config_path.write_text(
+            MINIMAL_CONFIG + "\n[slowpics]\nopen_in_browser = false\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            ["run", "--root", str(root), "--config", str(config_path.relative_to(root))],
+            color=False,
+            terminal_width=200,
+            env={"NO_COLOR": "1", "TERM": "dumb"},
+        )
+
+    assert result.exit_code == 0
+    assert opened_urls == []
+    assert opened_reports["path"] == Path("report.html")
+
+
 def test_maybe_open_report_swallows_webbrowser_error(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr("frame_compare.cli.cli_helpers.os", SimpleNamespace(name="posix"))
     monkeypatch.setattr(

--- a/tests/cli/test_run_slowpics_options.py
+++ b/tests/cli/test_run_slowpics_options.py
@@ -1,0 +1,73 @@
+from click import Group
+from typer.main import get_command
+
+from frame_compare.cli.entry import app
+
+from .cli_helpers import _normalize_cli_output, runner
+
+UNSUPPORTED_SLOWPICS_RUN_FLAGS = (
+    "--slowpics-auto-upload",
+    "--auto-upload",
+    "--visibility",
+    "--slowpics-visibility",
+    "--delete-after-upload",
+    "--remove-after",
+    "--collection-name",
+    "--collection-suffix",
+    "--image-format",
+    "--optimize-images",
+    "--tags",
+    "--hentai",
+    "--copy-url",
+    "--open-slowpics",
+    "--create-shortcut",
+    "--webhook",
+    "--webhook-url",
+)
+
+
+def _declared_run_options() -> set[str]:
+    command = get_command(app)
+    assert isinstance(command, Group)
+    run_command = command.commands["run"]
+    return {
+        opt
+        for param in run_command.params
+        for opt in (*getattr(param, "opts", ()), *getattr(param, "secondary_opts", ()))
+    }
+
+
+def test_run_declares_no_slowpics_flags_except_no_upload() -> None:
+    declared_options = _declared_run_options()
+
+    assert "--no-upload" in declared_options
+    assert all(flag not in declared_options for flag in UNSUPPORTED_SLOWPICS_RUN_FLAGS)
+
+    slowpics_related = {
+        flag
+        for flag in declared_options
+        if (
+            "slowpics" in flag
+            or "slow-pics" in flag
+            or "upload" in flag
+            or "visibility" in flag
+            or "remove" in flag
+            or "delete" in flag
+            or "webhook" in flag
+        )
+    }
+    assert slowpics_related == {"--no-upload"}
+
+
+def test_run_rejects_unsupported_slowpics_flags() -> None:
+    for flag in UNSUPPORTED_SLOWPICS_RUN_FLAGS:
+        result = runner.invoke(
+            app,
+            ["run", flag, "value"],
+            color=False,
+            terminal_width=200,
+            env={"NO_COLOR": "1", "TERM": "dumb"},
+        )
+        output = _normalize_cli_output(result.stderr or result.stdout)
+        assert result.exit_code == 2, flag
+        assert "No such option" in output, flag

--- a/tests/cli/test_run_slowpics_options.py
+++ b/tests/cli/test_run_slowpics_options.py
@@ -11,6 +11,8 @@ UNSUPPORTED_SLOWPICS_RUN_FLAGS = (
     "--visibility",
     "--slowpics-visibility",
     "--delete-after-upload",
+    "--confirm-upload",
+    "--confirm-upload-after-report",
     "--remove-after",
     "--collection-name",
     "--collection-suffix",

--- a/tests/config/test_overrides.py
+++ b/tests/config/test_overrides.py
@@ -1,9 +1,14 @@
 """Tests for CLI override logic."""
 
+from dataclasses import fields
 from pathlib import Path
 
 from frame_compare.config.loader import get_default_config
-from frame_compare.config.overrides import CLIConfigOverrides, apply_cli_overrides
+from frame_compare.config.overrides import (
+    CLI_OVERRIDE_MAP,
+    CLIConfigOverrides,
+    apply_cli_overrides,
+)
 from frame_compare.config.schema import (
     ColorConfig,
     ConfigSchema,
@@ -33,6 +38,20 @@ def test_apply_cli_overrides_inverts_no_upload() -> None:
     new_config = apply_cli_overrides(config, cli_args)
 
     assert new_config.slowpics.auto_upload is False
+
+
+def test_cli_overrides_do_not_map_confirm_upload_after_report() -> None:
+    """Report-confirmed upload is config-only, not a CLI override surface."""
+    config = get_default_config()
+    config.slowpics.confirm_upload_after_report = True
+
+    new_config = apply_cli_overrides(config, CLIConfigOverrides(no_upload=True))
+
+    assert "slowpics.confirm_upload_after_report" not in CLI_OVERRIDE_MAP.values()
+    cli_override_fields = {field.name for field in fields(CLIConfigOverrides)}
+    assert "confirm_upload_after_report" not in cli_override_fields
+    assert new_config.slowpics.auto_upload is False
+    assert new_config.slowpics.confirm_upload_after_report is True
 
 
 def test_apply_cli_overrides_does_not_override_false_flag_defaults() -> None:

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -1,10 +1,12 @@
 """Tests for configuration schema validation."""
 
+import tomllib
 from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 
+from frame_compare.config.defaults import DEFAULT_CONFIG_TOML
 from frame_compare.config.loader import get_default_config
 from frame_compare.config.schema import (
     AnalysisConfig,
@@ -168,6 +170,10 @@ def test_schema_model_section_defaults_are_representative() -> None:
     assert color.preset == "reference"
     assert slowpics.visibility == Visibility.UNLISTED
     assert slowpics.max_retries == 3
+    assert slowpics.copy_url_to_clipboard is True
+    assert slowpics.open_in_browser is True
+    assert slowpics.create_url_shortcut is True
+    assert slowpics.webhook_url is None
     assert tmdb.enabled is True
     assert tmdb.api_key is None
     assert tmdb.timeout_seconds == 10.0
@@ -187,19 +193,40 @@ def test_schema_model_section_defaults_are_representative() -> None:
     assert logging.file is None
 
 
-def test_slowpics_config_public_surface_is_frozen_to_existing_fields_and_defaults() -> None:
-    """slow.pics config remains the documented existing public surface."""
+def test_slowpics_config_public_surface_is_frozen_to_approved_fields_and_defaults() -> None:
+    """slow.pics config remains the documented approved public surface."""
     expected_defaults = {
         "auto_upload": False,
         "visibility": "unlisted",
         "delete_after_upload": False,
         "timeout_seconds": 60.0,
         "max_retries": 3,
+        "copy_url_to_clipboard": True,
+        "open_in_browser": True,
+        "create_url_shortcut": True,
+        "webhook_url": None,
     }
 
     assert list(SlowpicsConfig.model_fields) == list(expected_defaults)
     assert SlowpicsConfig().model_dump(mode="json") == expected_defaults
     assert get_default_config().slowpics.model_dump(mode="json") == expected_defaults
+
+
+def test_default_config_toml_documents_approved_slowpics_defaults() -> None:
+    """Default config template keeps the approved slow.pics config surface visible."""
+    data = tomllib.loads(DEFAULT_CONFIG_TOML)
+
+    assert data["slowpics"] == {
+        "auto_upload": False,
+        "visibility": "unlisted",
+        "delete_after_upload": False,
+        "timeout_seconds": 60.0,
+        "max_retries": 3,
+        "copy_url_to_clipboard": True,
+        "open_in_browser": True,
+        "create_url_shortcut": True,
+    }
+    assert "# webhook_url = null" in DEFAULT_CONFIG_TOML
 
 
 def test_schema_model_enums_accept_config_strings_and_reject_unknown_values() -> None:

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -51,6 +51,7 @@ def test_default_config_values() -> None:
     assert config.audio_alignment.channel_strategy == "mono_downmix"
     assert config.audio_alignment.refinement_mode == "disabled"
     assert config.audio_alignment.comparison_streams == {}
+    assert config.slowpics.confirm_upload_after_report is False
 
 
 def test_analysis_frame_count_bounds_too_low() -> None:
@@ -168,6 +169,7 @@ def test_schema_model_section_defaults_are_representative() -> None:
     assert color.target_nits == 100
     assert color.contrast_recovery == 0.3
     assert color.preset == "reference"
+    assert slowpics.confirm_upload_after_report is False
     assert slowpics.visibility == Visibility.UNLISTED
     assert slowpics.max_retries == 3
     assert slowpics.copy_url_to_clipboard is True
@@ -197,6 +199,7 @@ def test_slowpics_config_public_surface_is_frozen_to_approved_fields_and_default
     """slow.pics config remains the documented approved public surface."""
     expected_defaults = {
         "auto_upload": False,
+        "confirm_upload_after_report": False,
         "visibility": "unlisted",
         "delete_after_upload": False,
         "timeout_seconds": 60.0,
@@ -218,6 +221,7 @@ def test_default_config_toml_documents_approved_slowpics_defaults() -> None:
 
     assert data["slowpics"] == {
         "auto_upload": False,
+        "confirm_upload_after_report": False,
         "visibility": "unlisted",
         "delete_after_upload": False,
         "timeout_seconds": 60.0,
@@ -258,6 +262,12 @@ def test_schema_model_enums_accept_config_strings_and_reject_unknown_values() ->
 
     with pytest.raises(ValidationError):
         LoggingConfig.model_validate({"level": "debug"})
+
+
+def test_slowpics_confirm_upload_after_report_accepts_explicit_bool() -> None:
+    slowpics = SlowpicsConfig.model_validate({"confirm_upload_after_report": True})
+
+    assert slowpics.confirm_upload_after_report is True
 
 
 def test_audio_alignment_new_config_controls_validate_and_reject_unknown_values() -> None:

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -187,6 +187,21 @@ def test_schema_model_section_defaults_are_representative() -> None:
     assert logging.file is None
 
 
+def test_slowpics_config_public_surface_is_frozen_to_existing_fields_and_defaults() -> None:
+    """slow.pics config remains the documented existing public surface."""
+    expected_defaults = {
+        "auto_upload": False,
+        "visibility": "unlisted",
+        "delete_after_upload": False,
+        "timeout_seconds": 60.0,
+        "max_retries": 3,
+    }
+
+    assert list(SlowpicsConfig.model_fields) == list(expected_defaults)
+    assert SlowpicsConfig().model_dump(mode="json") == expected_defaults
+    assert get_default_config().slowpics.model_dump(mode="json") == expected_defaults
+
+
 def test_schema_model_enums_accept_config_strings_and_reject_unknown_values() -> None:
     screenshots = ScreenshotsConfig.model_validate(
         {

--- a/tests/manual/test_slowpics_live.py
+++ b/tests/manual/test_slowpics_live.py
@@ -1,0 +1,256 @@
+"""Passive live probes for the slow.pics browser upload protocol.
+
+These tests intentionally avoid image uploads and comparison creation. They are
+skipped by default because they use the live slow.pics site.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from html.parser import HTMLParser
+from urllib.parse import urljoin, urlparse
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.network
+
+_LIVE_SLOWPICS_ENABLED = os.environ.get("FRAME_COMPARE_LIVE_SLOWPICS") == "1"
+
+
+class _ScriptParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.scripts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "script":
+            return
+        attrs_by_name = dict(attrs)
+        src = attrs_by_name.get("src")
+        if src:
+            self.scripts.append(src)
+
+
+def _same_origin_scripts(page_url: httpx.URL, html: str) -> list[str]:
+    parser = _ScriptParser()
+    parser.feed(html)
+    page_url_text = str(page_url)
+    return [
+        urljoin(page_url_text, src)
+        for src in parser.scripts
+        if urlparse(urljoin(page_url_text, src)).netloc == "slow.pics"
+    ]
+
+
+def _literal_field_names(script: str) -> set[str]:
+    return set(re.findall(r"\bappend\(\s*['\"]([^'\"]+)['\"]", script))
+
+
+def _append_call_windows(script: str, *, width: int = 300) -> list[str]:
+    return [
+        script[match.start() : match.start() + width]
+        for match in re.finditer(r"\bappend\(", script)
+    ]
+
+
+def _assert_dynamic_field_evidence(
+    script: str,
+    field_name: str,
+    required_fragments: tuple[str, ...],
+) -> None:
+    if any(
+        all(fragment in window for fragment in required_fragments)
+        for window in _append_call_windows(script)
+    ):
+        return
+
+    pytest.fail(f"Expected FormData.append evidence for dynamic field {field_name!r}")
+
+
+def _assert_script_regex(script: str, pattern: str, description: str) -> None:
+    if re.search(pattern, script):
+        return
+
+    pytest.fail(f"Expected upload script evidence for {description}")
+
+
+_JS_IDENTIFIER = r"[A-Za-z_$][A-Za-z0-9_$]*"
+
+
+def _matching_brace_index(script: str, open_brace_index: int) -> int | None:
+    depth = 0
+    quote: str | None = None
+    escaped = False
+
+    for index in range(open_brace_index, len(script)):
+        char = script[index]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+
+        if char in ("'", '"', "`"):
+            quote = char
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+
+    return None
+
+
+def _named_function_bodies(script: str) -> list[tuple[str, str]]:
+    bodies: list[tuple[str, str]] = []
+    for match in re.finditer(rf"\bfunction\s+({_JS_IDENTIFIER})\s*\([^)]*\)\s*\{{", script):
+        body_start = match.end()
+        body_end = _matching_brace_index(script, body_start - 1)
+        if body_end is not None:
+            bodies.append((match.group(1), script[body_start:body_end]))
+    return bodies
+
+
+def _function_names_touching_cookie(script: str, *, writes: bool) -> set[str]:
+    cookie_pattern = (
+        r"document\s*\.\s*cookie\s*="
+        if writes
+        else r"document\s*\.\s*cookie(?!\s*=)"
+    )
+    return {
+        name
+        for name, body in _named_function_bodies(script)
+        if re.search(cookie_pattern, body)
+    }
+
+
+def _calls_browser_id_cookie_function(script: str, function_names: set[str]) -> bool:
+    return any(
+        re.search(rf"\b{re.escape(function_name)}\(\s*['\"]BROWSER-ID['\"]", script)
+        for function_name in function_names
+    )
+
+
+def _browser_id_near_cookie_expression(script: str, *, writes: bool) -> bool:
+    cookie_pattern = (
+        r"document\s*\.\s*cookie\s*="
+        if writes
+        else r"document\s*\.\s*cookie(?!\s*=)"
+    )
+    browser_id_pattern = r"['\"]BROWSER-ID['\"]"
+    return re.search(
+        rf"(?:{cookie_pattern}.{{0,500}}{browser_id_pattern})|"
+        rf"(?:{browser_id_pattern}.{{0,500}}{cookie_pattern})",
+        script,
+    ) is not None
+
+
+def _assert_browser_id_cookie_behavior(script: str) -> None:
+    cookie_readers = _function_names_touching_cookie(script, writes=False)
+    if not (
+        _calls_browser_id_cookie_function(script, cookie_readers)
+        or _browser_id_near_cookie_expression(script, writes=False)
+    ):
+        pytest.fail("Expected BROWSER-ID to be read from document.cookie")
+
+    cookie_writers = _function_names_touching_cookie(script, writes=True)
+    if not (
+        _calls_browser_id_cookie_function(script, cookie_writers)
+        or _browser_id_near_cookie_expression(script, writes=True)
+    ):
+        pytest.fail("Expected BROWSER-ID to be written through document.cookie")
+
+
+@pytest.mark.skipif(
+    not _LIVE_SLOWPICS_ENABLED,
+    reason="Set FRAME_COMPARE_LIVE_SLOWPICS=1 to run passive slow.pics probes",
+)
+def test_slowpics_comparison_page_exposes_passive_upload_protocol() -> None:
+    with httpx.Client(
+        base_url="https://slow.pics",
+        follow_redirects=True,
+        timeout=20.0,
+        headers={"User-Agent": "frame-compare-passive-slowpics-probe/1.0"},
+    ) as client:
+        page = client.get("/comparison")
+        page.raise_for_status()
+
+        assert page.url == httpx.URL("https://slow.pics/comparison")
+        assert "XSRF-TOKEN" in client.cookies
+
+        script_urls = _same_origin_scripts(page.url, page.text)
+        upload_script_url = next(
+            script_url for script_url in script_urls if "/js/upload-comparison-" in script_url
+        )
+        upload_script = client.get(upload_script_url)
+        upload_script.raise_for_status()
+
+    script_text = upload_script.text
+    literal_fields = _literal_field_names(script_text)
+
+    assert "/upload/comparison" in script_text
+    assert "/upload/image/" in script_text
+    assert "XSRF-TOKEN" in script_text
+    _assert_browser_id_cookie_behavior(script_text)
+    _assert_script_regex(
+        script_text,
+        r"['\"]?credentials['\"]?\s*:\s*['\"]same-origin['\"]",
+        'fetch credentials set to "same-origin"',
+    )
+    _assert_script_regex(
+        script_text,
+        r"['\"]X-XSRF-TOKEN['\"]\s*:",
+        "X-XSRF-TOKEN upload header",
+    )
+    _assert_script_regex(
+        script_text,
+        r"localStorage\s*\.\s*getItem\(\s*['\"]browserId['\"]\s*\)",
+        "browserId localStorage read",
+    )
+    _assert_script_regex(
+        script_text,
+        r"localStorage\s*\.\s*setItem\(\s*['\"]browserId['\"]",
+        "browserId localStorage write",
+    )
+
+    assert {
+        "collectionName",
+        "browserId",
+        "optimizeImages",
+        "desiredFileType",
+        "hentai",
+        "public",
+        "visibility",
+        "removeAfter",
+        "tmdbId",
+        "collectionUuid",
+        "imageUuid",
+        "file",
+    } <= literal_fields
+
+    _assert_dynamic_field_evidence(
+        script_text,
+        "comparisons[].name",
+        ("comparisons[", "].name"),
+    )
+    _assert_dynamic_field_evidence(
+        script_text,
+        "comparisons[].images[].name",
+        ("comparisons[", "].images[", "].name"),
+    )
+    _assert_dynamic_field_evidence(
+        script_text,
+        "comparisons[].images[].sortOrder",
+        ("comparisons[", "].images[", "].sortOrder"),
+    )
+    _assert_dynamic_field_evidence(
+        script_text,
+        "tags[]",
+        ("tags[", "]"),
+    )

--- a/tests/manual/test_slowpics_live.py
+++ b/tests/manual/test_slowpics_live.py
@@ -118,15 +118,9 @@ def _named_function_bodies(script: str) -> list[tuple[str, str]]:
 
 
 def _function_names_touching_cookie(script: str, *, writes: bool) -> set[str]:
-    cookie_pattern = (
-        r"document\s*\.\s*cookie\s*="
-        if writes
-        else r"document\s*\.\s*cookie(?!\s*=)"
-    )
+    cookie_pattern = r"document\s*\.\s*cookie\s*=" if writes else r"document\s*\.\s*cookie(?!\s*=)"
     return {
-        name
-        for name, body in _named_function_bodies(script)
-        if re.search(cookie_pattern, body)
+        name for name, body in _named_function_bodies(script) if re.search(cookie_pattern, body)
     }
 
 
@@ -138,17 +132,16 @@ def _calls_browser_id_cookie_function(script: str, function_names: set[str]) -> 
 
 
 def _browser_id_near_cookie_expression(script: str, *, writes: bool) -> bool:
-    cookie_pattern = (
-        r"document\s*\.\s*cookie\s*="
-        if writes
-        else r"document\s*\.\s*cookie(?!\s*=)"
-    )
+    cookie_pattern = r"document\s*\.\s*cookie\s*=" if writes else r"document\s*\.\s*cookie(?!\s*=)"
     browser_id_pattern = r"['\"]BROWSER-ID['\"]"
-    return re.search(
-        rf"(?:{cookie_pattern}.{{0,500}}{browser_id_pattern})|"
-        rf"(?:{browser_id_pattern}.{{0,500}}{cookie_pattern})",
-        script,
-    ) is not None
+    return (
+        re.search(
+            rf"(?:{cookie_pattern}.{{0,500}}{browser_id_pattern})|"
+            rf"(?:{browser_id_pattern}.{{0,500}}{cookie_pattern})",
+            script,
+        )
+        is not None
+    )
 
 
 def _assert_browser_id_cookie_behavior(script: str) -> None:
@@ -186,8 +179,13 @@ def test_slowpics_comparison_page_exposes_passive_upload_protocol() -> None:
 
         script_urls = _same_origin_scripts(page.url, page.text)
         upload_script_url = next(
-            script_url for script_url in script_urls if "/js/upload-comparison-" in script_url
+            (script_url for script_url in script_urls if "/js/upload-comparison-" in script_url),
+            None,
         )
+        if upload_script_url is None:
+            pytest.fail(
+                f"Upload script not found for {page.url}; same-origin scripts={script_urls!r}"
+            )
         upload_script = client.get(upload_script_url)
         upload_script.raise_for_status()
 

--- a/tests/orchestration/test_execute_run_lifecycle.py
+++ b/tests/orchestration/test_execute_run_lifecycle.py
@@ -17,6 +17,7 @@ from frame_compare.orchestration.coordinator import RunDependencies, RunRequest,
 from frame_compare.orchestration.errors import MixedSourceFpsError
 from frame_compare.orchestration.types import (
     MetadataPrefetch,
+    PostUploadActionResult,
     PrepState,
     PublishPhaseOutput,
     RenderArtifacts,
@@ -105,12 +106,21 @@ def test_execute_run_returns_success_and_records_preflight_timing(
 def test_execute_run_returns_preflight_and_runtime_warnings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    shortcut = PostUploadActionResult(
+        kind="shortcut",
+        success=True,
+        path=tmp_path / "Slowpics.url",
+        message="Shortcut written.",
+    )
     prep = PrepState(
         workspace=_workspace(tmp_path),
         config=ConfigSchema(),
         input_videos=[tmp_path / "reference.mkv"],
         clips=[clip_state(tmp_path / "reference.mkv", label="Reference")],
-        artifacts=RunArtifacts(warnings=["report: warned"]),
+        artifacts=RunArtifacts(
+            post_upload_actions=(shortcut,),
+            warnings=["report: warned"],
+        ),
         metadata_prefetch=MetadataPrefetch(None, False),
         preflight_warnings=["preflight: warned"],
         preflight_duration=0.0,
@@ -130,6 +140,7 @@ def test_execute_run_returns_preflight_and_runtime_warnings(
     result = asyncio.run(execute_run(RunRequest(root=tmp_path, quiet=True), deps=RunDependencies()))
 
     assert result.success is True
+    assert result.post_upload_actions == (shortcut,)
     assert result.warnings == ["preflight: warned", "report: warned"]
 
 

--- a/tests/orchestration/test_execute_run_lifecycle.py
+++ b/tests/orchestration/test_execute_run_lifecycle.py
@@ -15,7 +15,14 @@ from frame_compare.config.schema import ConfigSchema, OverlayMode, TonemapPreset
 from frame_compare.orchestration import coordinator
 from frame_compare.orchestration.coordinator import RunDependencies, RunRequest, execute_run
 from frame_compare.orchestration.errors import MixedSourceFpsError
-from frame_compare.orchestration.types import MetadataPrefetch, PrepState, RunArtifacts
+from frame_compare.orchestration.types import (
+    MetadataPrefetch,
+    PrepState,
+    PublishPhaseOutput,
+    RenderArtifacts,
+    RenderPhaseOutput,
+    RunArtifacts,
+)
 from frame_compare.utils.types import WorkspacePaths
 from frame_compare.vs.errors import TonemapRequiresVapourSynthError
 from frame_compare.vs.types import SourceInfo
@@ -81,6 +88,7 @@ def test_execute_run_returns_success_and_records_preflight_timing(
         "dovi",
         "publish",
         "report",
+        "post_report_cleanup",
     }
     assert set(result.phase_timings.keys()) == expected_keys
     assert result.phase_timings["preflight"] >= 0.0
@@ -91,6 +99,7 @@ def test_execute_run_returns_success_and_records_preflight_timing(
     assert result.phase_timings["dovi"] == 0.0
     assert result.phase_timings["publish"] == 0.0
     assert result.phase_timings["report"] == 0.0
+    assert result.phase_timings["post_report_cleanup"] >= 0.0
 
 
 def test_execute_run_returns_preflight_and_runtime_warnings(
@@ -122,6 +131,153 @@ def test_execute_run_returns_preflight_and_runtime_warnings(
 
     assert result.success is True
     assert result.warnings == ["preflight: warned", "report: warned"]
+
+
+def test_execute_run_cleanup_delete_error_returns_warning_not_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = ConfigSchema()
+    config.slowpics.auto_upload = True
+    config.slowpics.delete_after_upload = True
+    config.report.enable = False
+    uploaded = tmp_path / "screenshots" / "planned.png"
+    uploaded.parent.mkdir(parents=True, exist_ok=True)
+    uploaded.write_bytes(b"\x89PNG\r\n\x1a\n")
+    render = RenderArtifacts(
+        screenshots_by_label={"Reference": [uploaded]},
+        screenshot_dir=uploaded.parent,
+    )
+    prep = PrepState(
+        workspace=_workspace(tmp_path),
+        config=config,
+        input_videos=[tmp_path / "reference.mkv"],
+        clips=[clip_state(tmp_path / "reference.mkv", label="Reference")],
+        artifacts=RunArtifacts(),
+        metadata_prefetch=MetadataPrefetch(None, False),
+        preflight_warnings=[],
+        preflight_duration=0.0,
+        load_sources_start=datetime.now(),
+    )
+
+    async def fake_execute_prep(_request: RunRequest, _deps: RunDependencies) -> PrepState:
+        return prep
+
+    def fake_render_phase(*_args: object, **_kwargs: object) -> RenderPhaseOutput:
+        return RenderPhaseOutput(render=render)
+
+    async def fake_publish_phase(*_args: object, **_kwargs: object) -> PublishPhaseOutput:
+        return PublishPhaseOutput(
+            slowpics_url="https://slow.pics/c/example",
+            uploaded_file_paths=(uploaded,),
+        )
+
+    def fake_unlink(self: Path) -> None:
+        if self == uploaded:
+            raise PermissionError("locked")
+        Path.unlink(self)
+
+    monkeypatch.setattr(coordinator, "execute_prep", fake_execute_prep)
+    monkeypatch.setattr(coordinator, "emit_consolidated_fps_report", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_render_phase",
+        fake_render_phase,
+    )
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_publish_phase",
+        fake_publish_phase,
+    )
+    monkeypatch.setattr(Path, "unlink", fake_unlink)
+
+    request = RunRequest(
+        root=tmp_path,
+        skip_analysis=True,
+        skip_metadata=True,
+        skip_dovi=True,
+        quiet=True,
+    )
+    deps = RunDependencies(vs_loader=FakeVSLoader(), ffmpeg_runner=FakeFFmpegRunner())
+
+    result = asyncio.run(execute_run(request, deps=deps))
+
+    assert result.success is True
+    assert result.slowpics_url == "https://slow.pics/c/example"
+    assert result.warnings == [f"cleanup: failed to delete uploaded screenshot {uploaded}: locked"]
+
+
+def test_execute_run_report_warning_blocks_delete_after_upload_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = ConfigSchema()
+    config.slowpics.auto_upload = True
+    config.slowpics.delete_after_upload = True
+    config.report.enable = True
+    config.report.embed_images = True
+    uploaded = tmp_path / "screenshots" / "planned.png"
+    uploaded.parent.mkdir(parents=True, exist_ok=True)
+    uploaded.write_bytes(b"\x89PNG\r\n\x1a\n")
+    render = RenderArtifacts(
+        screenshots_by_label={"Reference": [uploaded]},
+        screenshot_dir=uploaded.parent,
+    )
+    prep = PrepState(
+        workspace=_workspace(tmp_path),
+        config=config,
+        input_videos=[tmp_path / "reference.mkv"],
+        clips=[clip_state(tmp_path / "reference.mkv", label="Reference")],
+        artifacts=RunArtifacts(),
+        metadata_prefetch=MetadataPrefetch(None, False),
+        preflight_warnings=[],
+        preflight_duration=0.0,
+        load_sources_start=datetime.now(),
+    )
+
+    async def fake_execute_prep(_request: RunRequest, _deps: RunDependencies) -> PrepState:
+        return prep
+
+    def fake_render_phase(*_args: object, **_kwargs: object) -> RenderPhaseOutput:
+        return RenderPhaseOutput(render=render)
+
+    async def fake_publish_phase(*_args: object, **_kwargs: object) -> PublishPhaseOutput:
+        return PublishPhaseOutput(
+            slowpics_url="https://slow.pics/c/example",
+            uploaded_file_paths=(uploaded,),
+        )
+
+    def fake_report_phase(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("report write failed")
+
+    monkeypatch.setattr(coordinator, "execute_prep", fake_execute_prep)
+    monkeypatch.setattr(coordinator, "emit_consolidated_fps_report", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_render_phase",
+        fake_render_phase,
+    )
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_publish_phase",
+        fake_publish_phase,
+    )
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_report_phase",
+        fake_report_phase,
+    )
+
+    request = RunRequest(
+        root=tmp_path,
+        skip_analysis=True,
+        skip_metadata=True,
+        skip_dovi=True,
+        quiet=True,
+    )
+    deps = RunDependencies(vs_loader=FakeVSLoader(), ffmpeg_runner=FakeFFmpegRunner())
+
+    result = asyncio.run(execute_run(request, deps=deps))
+
+    assert result.success is True
+    assert result.slowpics_url == "https://slow.pics/c/example"
+    assert any(warning.startswith("report:") for warning in result.warnings)
+    assert uploaded.exists()
 
 
 def test_execute_run_ffmpeg_render_rejects_hdr_when_tonemap_enabled(

--- a/tests/orchestration/test_execute_run_lifecycle.py
+++ b/tests/orchestration/test_execute_run_lifecycle.py
@@ -181,6 +181,13 @@ def test_execute_run_cleanup_delete_error_returns_warning_not_failure(
         return PublishPhaseOutput(
             slowpics_url="https://slow.pics/c/example",
             uploaded_file_paths=(uploaded,),
+            post_upload_actions=(
+                PostUploadActionResult(
+                    kind="shortcut",
+                    success=False,
+                    warning="slow.pics shortcut: could not choose a safe output directory",
+                ),
+            ),
         )
 
     def fake_unlink(self: Path) -> None:
@@ -213,7 +220,10 @@ def test_execute_run_cleanup_delete_error_returns_warning_not_failure(
 
     assert result.success is True
     assert result.slowpics_url == "https://slow.pics/c/example"
-    assert result.warnings == [f"cleanup: failed to delete uploaded screenshot {uploaded}: locked"]
+    assert result.warnings == [
+        f"cleanup: failed to delete uploaded screenshot {uploaded}: locked",
+        "slow.pics shortcut: could not choose a safe output directory",
+    ]
 
 
 def test_execute_run_report_warning_blocks_delete_after_upload_cleanup(

--- a/tests/orchestration/test_execute_run_lifecycle.py
+++ b/tests/orchestration/test_execute_run_lifecycle.py
@@ -226,6 +226,77 @@ def test_execute_run_cleanup_delete_error_returns_warning_not_failure(
     ]
 
 
+def test_execute_run_webhook_action_warning_is_warning_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = ConfigSchema()
+    config.slowpics.auto_upload = True
+    config.report.enable = False
+    webhook_warning = "slow.pics webhook: delivery failed after 3 attempts"
+    render = RenderArtifacts(
+        screenshots_by_label={"Reference": [tmp_path / "screenshots" / "planned.png"]},
+        screenshot_dir=tmp_path / "screenshots",
+    )
+    prep = PrepState(
+        workspace=_workspace(tmp_path),
+        config=config,
+        input_videos=[tmp_path / "reference.mkv"],
+        clips=[clip_state(tmp_path / "reference.mkv", label="Reference")],
+        artifacts=RunArtifacts(),
+        metadata_prefetch=MetadataPrefetch(None, False),
+        preflight_warnings=[],
+        preflight_duration=0.0,
+        load_sources_start=datetime.now(),
+    )
+
+    async def fake_execute_prep(_request: RunRequest, _deps: RunDependencies) -> PrepState:
+        return prep
+
+    def fake_render_phase(*_args: object, **_kwargs: object) -> RenderPhaseOutput:
+        return RenderPhaseOutput(render=render)
+
+    async def fake_publish_phase(*_args: object, **_kwargs: object) -> PublishPhaseOutput:
+        return PublishPhaseOutput(
+            slowpics_url="https://slow.pics/c/example",
+            post_upload_actions=(
+                PostUploadActionResult(
+                    kind="webhook",
+                    success=False,
+                    warning=webhook_warning,
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(coordinator, "execute_prep", fake_execute_prep)
+    monkeypatch.setattr(coordinator, "emit_consolidated_fps_report", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_render_phase",
+        fake_render_phase,
+    )
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_publish_phase",
+        fake_publish_phase,
+    )
+
+    request = RunRequest(
+        root=tmp_path,
+        skip_analysis=True,
+        skip_metadata=True,
+        skip_dovi=True,
+        quiet=True,
+    )
+    deps = RunDependencies(vs_loader=FakeVSLoader(), ffmpeg_runner=FakeFFmpegRunner())
+
+    result = asyncio.run(execute_run(request, deps=deps))
+
+    assert result.success is True
+    assert result.post_upload_actions == (
+        PostUploadActionResult(kind="webhook", success=False, warning=webhook_warning),
+    )
+    assert result.warnings == [webhook_warning]
+
+
 def test_execute_run_report_warning_blocks_delete_after_upload_cleanup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/orchestration/test_execute_run_phase_integration.py
+++ b/tests/orchestration/test_execute_run_phase_integration.py
@@ -12,7 +12,14 @@ from frame_compare.config.loader import load_config
 from frame_compare.orchestration import phase_tasks
 from frame_compare.orchestration.context import RunContext
 from frame_compare.orchestration.coordinator import RunDependencies, RunRequest, execute_run
-from frame_compare.orchestration.types import MetadataPrefetch, RenderArtifacts, RunArtifacts
+from frame_compare.orchestration.types import (
+    MetadataPrefetch,
+    PublishPhaseOutput,
+    RenderArtifacts,
+    RunArtifacts,
+    SlowpicsUploadConfirmationDecision,
+    SlowpicsUploadConfirmationRequest,
+)
 from frame_compare.services.types import AlignmentResult, TmdbMetadata
 from frame_compare.utils.types import WorkspacePaths
 
@@ -106,6 +113,73 @@ enable = false
     assert by_video["a_ref.mkv"] == [5, 50, 97]
     assert by_video["b_comp1.mkv"] == [4, 49, 96]
     assert by_video["c_comp2.mkv"] == [6, 51, 98]
+
+
+def test_execute_run_report_confirmed_decline_skips_publish(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_content = """\
+[paths]
+input_dir = "comparison_videos"
+screenshots_dir = "screenshots"
+generated_dir = "generated"
+config_dir = "config"
+
+[slowpics]
+auto_upload = true
+confirm_upload_after_report = true
+
+[audio_alignment]
+enable = false
+
+[screenshots]
+use_ffmpeg = true
+
+[report]
+enable = true
+"""
+    create_config(tmp_path, content=config_content)
+    input_dir = tmp_path / "comparison_videos"
+    create_video_files(input_dir, "a_source.mkv", "b_encode.mkv")
+    callback_calls: list[SlowpicsUploadConfirmationRequest] = []
+
+    def _decline(
+        request: SlowpicsUploadConfirmationRequest,
+    ) -> SlowpicsUploadConfirmationDecision:
+        callback_calls.append(request)
+        return "declined"
+
+    async def _unexpected_publish(*_args: object, **_kwargs: object) -> PublishPhaseOutput:
+        raise AssertionError("declined report-confirmed upload must not publish")
+
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_publish_phase",
+        _unexpected_publish,
+    )
+
+    result = asyncio.run(
+        execute_run(
+            RunRequest(
+                root=tmp_path,
+                frame_count=1,
+                skip_analysis=True,
+                skip_metadata=True,
+                skip_dovi=True,
+            ),
+            deps=RunDependencies(
+                vs_loader=FakeVSLoader(),
+                ffmpeg_runner=FakeFFmpegRunner(),
+                confirm_slowpics_upload=_decline,
+            ),
+        )
+    )
+
+    assert result.success is True
+    assert result.report_path is not None
+    assert callback_calls == [SlowpicsUploadConfirmationRequest(report_path=result.report_path)]
+    assert result.slowpics_upload_confirmation_status == "declined"
+    assert result.slowpics_url is None
+    assert "confirm_slowpics_upload" in result.phase_timings
 
 
 def test_run_metadata_phase_uses_prefetched_metadata_without_client(tmp_path: Path) -> None:

--- a/tests/orchestration/test_execution_phase_plan.py
+++ b/tests/orchestration/test_execution_phase_plan.py
@@ -11,6 +11,7 @@ from frame_compare.orchestration.coordinator import RunDependencies, RunRequest
 from frame_compare.orchestration.execution import _apply_phase_output, build_execution_phase_plan
 from frame_compare.orchestration.types import (
     AlignPhaseOutput,
+    ConfirmSlowpicsUploadPhaseOutput,
     ExecutionState,
     MetadataPrefetch,
     PostUploadActionResult,
@@ -77,6 +78,52 @@ def test_build_execution_phase_plan_preserves_align_boundary_and_progress_total(
 
     align_phase = next(phase for phase in plan.before_align if phase.name == "align")
     assert align_phase.progress_total == 1
+
+
+def test_build_execution_phase_plan_moves_report_before_publish_for_confirmed_upload(
+    tmp_path: Path,
+) -> None:
+    workspace = WorkspacePaths(
+        root=tmp_path,
+        input_dir=tmp_path / "comparison_videos",
+        run_dir=None,
+        screenshots_dir=tmp_path / "screenshots",
+        generated_dir=tmp_path / "generated",
+        config_dir=tmp_path / "config",
+        config_file=tmp_path / "config" / "config.toml",
+    )
+    config = ConfigSchema()
+    config.slowpics.auto_upload = True
+    config.slowpics.confirm_upload_after_report = True
+
+    prep = PrepState(
+        workspace=workspace,
+        config=config,
+        input_videos=[tmp_path / "ref.mkv"],
+        clips=[clip_state(tmp_path / "ref.mkv", label="Reference")],
+        artifacts=RunArtifacts(),
+        metadata_prefetch=MetadataPrefetch(None, False),
+        preflight_warnings=[],
+        preflight_duration=0.0,
+        load_sources_start=datetime.now(),
+    )
+
+    plan = build_execution_phase_plan(
+        request=RunRequest(root=tmp_path),
+        deps=RunDependencies(ffmpeg_runner=FakeFFmpegRunner()),
+        prep=prep,
+        state=ExecutionState(artifacts=prep.artifacts),
+    )
+
+    assert [phase.name for phase in plan.after_align] == [
+        "render",
+        "metadata",
+        "dovi",
+        "report",
+        "confirm_slowpics_upload",
+        "publish",
+        "post_report_cleanup",
+    ]
 
 
 def test_run_request_cli_config_overrides_capture_runtime_override_contract(tmp_path: Path) -> None:
@@ -181,6 +228,42 @@ def test_apply_phase_output_retains_publish_post_upload_actions(tmp_path: Path) 
     assert state.artifacts.slowpics_url == "https://slow.pics/c/example"
     assert state.artifacts.uploaded_slowpics_file_paths == (uploaded,)
     assert state.artifacts.post_upload_actions == (shortcut, webhook)
+
+
+def test_apply_phase_output_records_slowpics_confirmation_status_and_warnings(
+    tmp_path: Path,
+) -> None:
+    workspace = WorkspacePaths(
+        root=tmp_path,
+        input_dir=tmp_path / "comparison_videos",
+        run_dir=None,
+        screenshots_dir=tmp_path / "screenshots",
+        generated_dir=tmp_path / "generated",
+        config_dir=tmp_path / "config",
+        config_file=tmp_path / "config" / "config.toml",
+    )
+    reference = clip_state(tmp_path / "ref.mkv", label="Reference")
+    ctx = RunContext(
+        config=ConfigSchema(),
+        workspace=workspace,
+        reference=reference,
+        comparisons=[],
+    )
+    state = ExecutionState(artifacts=RunArtifacts())
+
+    _apply_phase_output(
+        ctx=ctx,
+        state=state,
+        output=ConfirmSlowpicsUploadPhaseOutput(
+            status="report_unavailable",
+            warnings=["slow.pics upload skipped because report confirmation was unavailable"],
+        ),
+    )
+
+    assert state.artifacts.slowpics_upload_confirmation_status == "report_unavailable"
+    assert state.warnings == [
+        "slow.pics upload skipped because report confirmation was unavailable"
+    ]
 
 
 def test_apply_phase_output_extends_warnings_from_render_output(tmp_path: Path) -> None:

--- a/tests/orchestration/test_execution_phase_plan.py
+++ b/tests/orchestration/test_execution_phase_plan.py
@@ -13,7 +13,9 @@ from frame_compare.orchestration.types import (
     AlignPhaseOutput,
     ExecutionState,
     MetadataPrefetch,
+    PostUploadActionResult,
     PrepState,
+    PublishPhaseOutput,
     RenderArtifacts,
     RenderPhaseOutput,
     RunArtifacts,
@@ -133,6 +135,52 @@ def test_apply_phase_output_handles_report_output_explicitly(tmp_path: Path) -> 
 
     assert state.artifacts.report_path == report_path
     assert state.artifacts.report_succeeded is True
+
+
+def test_apply_phase_output_retains_publish_post_upload_actions(tmp_path: Path) -> None:
+    workspace = WorkspacePaths(
+        root=tmp_path,
+        input_dir=tmp_path / "comparison_videos",
+        run_dir=None,
+        screenshots_dir=tmp_path / "screenshots",
+        generated_dir=tmp_path / "generated",
+        config_dir=tmp_path / "config",
+        config_file=tmp_path / "config" / "config.toml",
+    )
+    reference = clip_state(tmp_path / "ref.mkv", label="Reference")
+    ctx = RunContext(
+        config=ConfigSchema(),
+        workspace=workspace,
+        reference=reference,
+        comparisons=[],
+    )
+    state = ExecutionState(artifacts=RunArtifacts())
+    uploaded = tmp_path / "screenshots" / "reference.png"
+    shortcut = PostUploadActionResult(
+        kind="shortcut",
+        success=True,
+        path=tmp_path / "Slowpics.url",
+        message="Shortcut written.",
+    )
+    webhook = PostUploadActionResult(
+        kind="webhook",
+        success=False,
+        warning="webhook: delivery failed",
+    )
+
+    _apply_phase_output(
+        ctx=ctx,
+        state=state,
+        output=PublishPhaseOutput(
+            slowpics_url="https://slow.pics/c/example",
+            uploaded_file_paths=(uploaded,),
+            post_upload_actions=(shortcut, webhook),
+        ),
+    )
+
+    assert state.artifacts.slowpics_url == "https://slow.pics/c/example"
+    assert state.artifacts.uploaded_slowpics_file_paths == (uploaded,)
+    assert state.artifacts.post_upload_actions == (shortcut, webhook)
 
 
 def test_apply_phase_output_extends_warnings_from_render_output(tmp_path: Path) -> None:

--- a/tests/orchestration/test_execution_phase_plan.py
+++ b/tests/orchestration/test_execution_phase_plan.py
@@ -70,6 +70,7 @@ def test_build_execution_phase_plan_preserves_align_boundary_and_progress_total(
         "dovi",
         "publish",
         "report",
+        "post_report_cleanup",
     ]
 
     align_phase = next(phase for phase in plan.before_align if phase.name == "align")
@@ -124,9 +125,14 @@ def test_apply_phase_output_handles_report_output_explicitly(tmp_path: Path) -> 
     state = ExecutionState(artifacts=RunArtifacts())
     report_path = tmp_path / "report.html"
 
-    _apply_phase_output(ctx=ctx, state=state, output=ReportPhaseOutput(report_path=report_path))
+    _apply_phase_output(
+        ctx=ctx,
+        state=state,
+        output=ReportPhaseOutput(report_path=report_path, report_succeeded=True),
+    )
 
     assert state.artifacts.report_path == report_path
+    assert state.artifacts.report_succeeded is True
 
 
 def test_apply_phase_output_extends_warnings_from_render_output(tmp_path: Path) -> None:

--- a/tests/orchestration/test_phase_tasks.py
+++ b/tests/orchestration/test_phase_tasks.py
@@ -19,9 +19,15 @@ from frame_compare.analysis.types import (
     SelectionBreakdown,
     SelectionDetail,
 )
+from frame_compare.config.errors import ConfigValidationError
 from frame_compare.config.schema import SelectionMode
 from frame_compare.orchestration import phase_tasks
-from frame_compare.orchestration.types import RenderArtifacts, RunArtifacts
+from frame_compare.orchestration.types import (
+    RenderArtifacts,
+    RunArtifacts,
+    SlowpicsUploadConfirmationDecision,
+    SlowpicsUploadConfirmationRequest,
+)
 from frame_compare.services.types import MetadataConfig, TmdbMetadata
 from tests.orchestration.phase_task_helpers import (
     MINIMAL_CONFIG,
@@ -149,6 +155,69 @@ def test_run_artifacts_uses_render_artifacts_carrier() -> None:
 
     assert artifacts.render.screenshots_by_label == {"Reference": [screenshot]}
     assert artifacts.render.screenshot_dir == Path("screenshots")
+
+
+def test_run_confirm_slowpics_upload_phase_marks_report_unavailable_without_prompt(
+    tmp_path: Path,
+) -> None:
+    ctx = _context(tmp_path)
+    callback_calls: list[SlowpicsUploadConfirmationRequest] = []
+
+    def _callback(
+        request: SlowpicsUploadConfirmationRequest,
+    ) -> SlowpicsUploadConfirmationDecision:
+        callback_calls.append(request)
+        return "confirmed"
+
+    output = phase_tasks.run_confirm_slowpics_upload_phase(
+        ctx,
+        report_path=None,
+        report_succeeded=False,
+        confirm_slowpics_upload=_callback,
+    )
+
+    assert output.status == "report_unavailable"
+    assert output.warnings == [
+        "slow.pics upload skipped because report confirmation was unavailable"
+    ]
+    assert callback_calls == []
+
+
+def test_run_confirm_slowpics_upload_phase_requires_callback_when_report_available(
+    tmp_path: Path,
+) -> None:
+    ctx = _context(tmp_path)
+
+    with pytest.raises(ConfigValidationError, match="requires a confirmation callback"):
+        phase_tasks.run_confirm_slowpics_upload_phase(
+            ctx,
+            report_path=tmp_path / "report.html",
+            report_succeeded=True,
+            confirm_slowpics_upload=None,
+        )
+
+
+def test_run_confirm_slowpics_upload_phase_records_callback_decision(tmp_path: Path) -> None:
+    ctx = _context(tmp_path)
+    report_path = tmp_path / "report.html"
+    callback_calls: list[SlowpicsUploadConfirmationRequest] = []
+
+    def _callback(
+        request: SlowpicsUploadConfirmationRequest,
+    ) -> SlowpicsUploadConfirmationDecision:
+        callback_calls.append(request)
+        return "declined"
+
+    output = phase_tasks.run_confirm_slowpics_upload_phase(
+        ctx,
+        report_path=report_path,
+        report_succeeded=True,
+        confirm_slowpics_upload=_callback,
+    )
+
+    assert output.status == "declined"
+    assert output.warnings == []
+    assert callback_calls == [SlowpicsUploadConfirmationRequest(report_path=report_path)]
 
 
 def test_resolve_run_metadata_builds_metadata_config_and_delegates(

--- a/tests/orchestration/test_phase_tasks_outputs.py
+++ b/tests/orchestration/test_phase_tasks_outputs.py
@@ -21,6 +21,7 @@ from frame_compare.orchestration.phases import execute_phases
 from frame_compare.orchestration.types import (
     ExecutionState,
     MetadataPrefetch,
+    PostUploadActionResult,
     RenderArtifacts,
     RunArtifacts,
     RunRequest,
@@ -480,6 +481,18 @@ async def test_run_publish_phase_sets_url_from_publish_result(
     ]
     assert output.slowpics_url == "https://slow.pics/c/collateral"
     assert output.uploaded_file_paths == (ref_10, enc_10, ref_20, enc_20)
+    shortcut_path = tmp_path / "Collateral.url"
+    assert output.post_upload_actions == (
+        PostUploadActionResult(
+            kind="shortcut",
+            success=True,
+            path=shortcut_path,
+            message="slow.pics URL shortcut written",
+        ),
+    )
+    assert shortcut_path.read_text(encoding="utf-8") == (
+        "[InternetShortcut]\nURL=https://slow.pics/c/collateral\n"
+    )
 
 
 async def test_run_publish_phase_rejects_duplicate_clip_labels_at_translation_seam(
@@ -505,6 +518,49 @@ async def test_run_publish_phase_rejects_duplicate_clip_labels_at_translation_se
                 render=render,
                 selected_frames=[10],
             )
+
+
+async def test_run_publish_phase_skips_shortcut_when_config_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.create_url_shortcut = False
+    screenshot_dir = tmp_path / "screenshots"
+    screenshot_dir.mkdir()
+    screenshot = screenshot_dir / "10 - reference.png"
+    screenshot.write_bytes(b"\x89PNG\r\n\x1a\n")
+    render = RenderArtifacts(
+        screenshots_by_label={"Reference": [screenshot]},
+        screenshot_dir=screenshot_dir,
+    )
+
+    async def _fake_publish_to_slowpics(**kwargs: object) -> PublishResult:
+        upload_plan = cast(Any, kwargs["upload_plan"])
+        return PublishResult(
+            url="https://slow.pics/c/example",
+            screenshot_count=len(upload_plan.file_paths),
+            upload_duration_seconds=0.1,
+            uploaded_file_paths=tuple(upload_plan.file_paths),
+        )
+
+    def _unexpected_shortcut(**_kwargs: object) -> object:
+        raise AssertionError("shortcut should not be created when disabled")
+
+    monkeypatch.setattr(phase_tasks, "publish_to_slowpics", _fake_publish_to_slowpics)
+    monkeypatch.setattr(phase_tasks, "create_slowpics_url_shortcut", _unexpected_shortcut)
+
+    async with httpx.AsyncClient() as client:
+        output = await phase_tasks.run_publish_phase(
+            ctx,
+            client=client,
+            metadata=None,
+            render=render,
+            selected_frames=[10],
+        )
+
+    assert output.slowpics_url == "https://slow.pics/c/example"
+    assert output.uploaded_file_paths == (screenshot,)
+    assert output.post_upload_actions == ()
 
 
 def test_post_report_cleanup_skips_non_embedded_reports(tmp_path: Path) -> None:

--- a/tests/orchestration/test_phase_tasks_outputs.py
+++ b/tests/orchestration/test_phase_tasks_outputs.py
@@ -32,9 +32,8 @@ from frame_compare.orchestration.types import (
 )
 from frame_compare.services.errors import SlowpicsError
 from frame_compare.services.publishers import PublishResult
-from frame_compare.services.slowpics_webhook import (
-    WEBHOOK_VALIDATION_WARNING,
-    SlowpicsWebhookResult,
+from frame_compare.services.slowpics_post_upload import (
+    SlowpicsPostUploadRequest,
 )
 from frame_compare.services.types import TmdbMetadata
 from frame_compare.utils.progress import NullProgressReporter
@@ -179,7 +178,9 @@ def test_run_report_phase_passes_reference_source_frame_details(
     report_data = captured["report_data"]
     assert output.report_path == expected_path
     assert report_data.frames == [1, 2]
-    assert [(detail.label, detail.detail, detail.category) for detail in report_data.frame_details] == [
+    assert [
+        (detail.label, detail.detail, detail.category) for detail in report_data.frame_details
+    ] == [
         ("User", "Source frame 4 (00:00:00.167)", "user_override"),
         ("Bright", "Source frame 5", "quantile_bright"),
     ]
@@ -198,7 +199,7 @@ def test_run_render_phase_maps_aligned_frames_to_source_frames(
 
     def _fake_render_screenshots_from_batch(**kwargs: object) -> dict[str, list[Path]]:
         captured.update(kwargs)
-        options = kwargs["options"]
+        options = cast(Any, kwargs["options"])
         assert options.warnings is not None
         options.warnings.append("render: geometry alignment skipped")
         return {"Reference": [tmp_path / "reference.png"]}
@@ -405,12 +406,10 @@ def test_run_report_phase_without_screenshots_clears_existing_report_path(tmp_pa
     assert artifacts.report_path == tmp_path / "stale.html"
 
 
-async def test_run_publish_phase_sets_url_from_publish_result(
+async def test_run_publish_phase_sets_url_from_publish_result_and_delegates_post_upload_actions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    comparison = _clip(
-        tmp_path / "comparison_videos" / "encode-final-source.mkv", label="Encode 1"
-    )
+    comparison = _clip(tmp_path / "comparison_videos" / "encode-final-source.mkv", label="Encode 1")
     ctx = _context(tmp_path, comparisons=[comparison])
     metadata = TmdbMetadata(
         tmdb_id=3,
@@ -437,10 +436,11 @@ async def test_run_publish_phase_sets_url_from_publish_result(
     )
     captured: dict[str, Any] = {}
     captured_clip_names: list[tuple[str, str]] = []
+    captured_post_upload_request: SlowpicsPostUploadRequest | None = None
     real_build_slowpics_upload_plan = phase_tasks.build_slowpics_upload_plan
 
     def _capturing_build_slowpics_upload_plan(**kwargs: object) -> object:
-        clips = kwargs["clips"]
+        clips = cast(list[Any], kwargs["clips"])
         captured_clip_names.extend((clip.label, clip.image_name) for clip in clips)
         return real_build_slowpics_upload_plan(
             selected_frames=cast(list[int], kwargs["selected_frames"]),
@@ -458,10 +458,29 @@ async def test_run_publish_phase_sets_url_from_publish_result(
             uploaded_file_paths=tuple(upload_plan.file_paths),
         )
 
+    async def _fake_run_slowpics_post_upload_actions(
+        request: SlowpicsPostUploadRequest,
+    ) -> tuple[PostUploadActionResult, ...]:
+        nonlocal captured_post_upload_request
+        captured_post_upload_request = request
+        return (
+            PostUploadActionResult(
+                kind="shortcut",
+                success=True,
+                path=tmp_path / "Collateral.url",
+                message="slow.pics URL shortcut written",
+            ),
+        )
+
     monkeypatch.setattr(
         phase_tasks, "build_slowpics_upload_plan", _capturing_build_slowpics_upload_plan
     )
     monkeypatch.setattr(phase_tasks, "publish_to_slowpics", _fake_publish_to_slowpics)
+    monkeypatch.setattr(
+        phase_tasks,
+        "run_slowpics_post_upload_actions",
+        _fake_run_slowpics_post_upload_actions,
+    )
 
     async with httpx.AsyncClient() as client:
         output = await phase_tasks.run_publish_phase(
@@ -489,17 +508,19 @@ async def test_run_publish_phase_sets_url_from_publish_result(
     ]
     assert output.slowpics_url == "https://slow.pics/c/collateral"
     assert output.uploaded_file_paths == (ref_10, enc_10, ref_20, enc_20)
-    shortcut_path = tmp_path / "Collateral.url"
+    assert captured_post_upload_request is not None
+    assert captured_post_upload_request.workspace == ctx.workspace
+    assert captured_post_upload_request.config is ctx.config.slowpics
+    assert captured_post_upload_request.slowpics_url == "https://slow.pics/c/collateral"
+    assert captured_post_upload_request.metadata_title == "Collateral"
+    assert captured_post_upload_request.upload_title == screenshot_dir.name
     assert output.post_upload_actions == (
         PostUploadActionResult(
             kind="shortcut",
             success=True,
-            path=shortcut_path,
+            path=tmp_path / "Collateral.url",
             message="slow.pics URL shortcut written",
         ),
-    )
-    assert shortcut_path.read_text(encoding="utf-8") == (
-        "[InternetShortcut]\nURL=https://slow.pics/c/collateral\n"
     )
 
 
@@ -551,11 +572,17 @@ async def test_run_publish_phase_skips_shortcut_when_config_disabled(
             uploaded_file_paths=tuple(upload_plan.file_paths),
         )
 
-    def _unexpected_shortcut(**_kwargs: object) -> object:
-        raise AssertionError("shortcut should not be created when disabled")
+    async def _no_post_upload_actions(
+        _request: SlowpicsPostUploadRequest,
+    ) -> tuple[PostUploadActionResult, ...]:
+        return ()
 
     monkeypatch.setattr(phase_tasks, "publish_to_slowpics", _fake_publish_to_slowpics)
-    monkeypatch.setattr(phase_tasks, "create_slowpics_url_shortcut", _unexpected_shortcut)
+    monkeypatch.setattr(
+        phase_tasks,
+        "run_slowpics_post_upload_actions",
+        _no_post_upload_actions,
+    )
 
     async with httpx.AsyncClient() as client:
         output = await phase_tasks.run_publish_phase(
@@ -569,168 +596,6 @@ async def test_run_publish_phase_skips_shortcut_when_config_disabled(
     assert output.slowpics_url == "https://slow.pics/c/example"
     assert output.uploaded_file_paths == (screenshot,)
     assert output.post_upload_actions == ()
-
-
-async def test_run_publish_phase_delivers_configured_webhook_after_upload(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    ctx = _context(tmp_path)
-    ctx.config.slowpics.create_url_shortcut = False
-    ctx.config.slowpics.webhook_url = "https://hooks.example.test/webhook/token?secret=value"
-    screenshot_dir = tmp_path / "screenshots"
-    screenshot_dir.mkdir()
-    screenshot = screenshot_dir / "10 - reference.png"
-    screenshot.write_bytes(b"\x89PNG\r\n\x1a\n")
-    render = RenderArtifacts(
-        screenshots_by_label={"Reference": [screenshot]},
-        screenshot_dir=screenshot_dir,
-    )
-    captured: dict[str, object] = {}
-
-    async def _fake_publish_to_slowpics(**kwargs: object) -> PublishResult:
-        upload_plan = cast(Any, kwargs["upload_plan"])
-        return PublishResult(
-            url="https://slow.pics/c/example",
-            screenshot_count=len(upload_plan.file_paths),
-            upload_duration_seconds=0.1,
-            uploaded_file_paths=tuple(upload_plan.file_paths),
-        )
-
-    async def _fake_deliver_slowpics_webhook(**kwargs: object) -> SlowpicsWebhookResult:
-        captured.update(kwargs)
-        return SlowpicsWebhookResult(success=True, detail="HTTP 204")
-
-    monkeypatch.setattr(phase_tasks, "publish_to_slowpics", _fake_publish_to_slowpics)
-    monkeypatch.setattr(
-        phase_tasks, "deliver_slowpics_webhook", _fake_deliver_slowpics_webhook
-    )
-
-    async with httpx.AsyncClient() as client:
-        output = await phase_tasks.run_publish_phase(
-            ctx,
-            client=client,
-            metadata=None,
-            render=render,
-            selected_frames=[10],
-        )
-
-    assert captured == {
-        "webhook_url": "https://hooks.example.test/webhook/token?secret=value",
-        "slowpics_url": "https://slow.pics/c/example",
-    }
-    assert output.post_upload_actions == (
-        PostUploadActionResult(
-            kind="webhook",
-            success=True,
-            detail="HTTP 204",
-            message="slow.pics webhook delivered",
-        ),
-    )
-
-
-async def test_run_publish_phase_webhook_failure_is_warning_only_and_redacted(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    ctx = _context(tmp_path)
-    ctx.config.slowpics.create_url_shortcut = False
-    ctx.config.slowpics.webhook_url = "https://secret.example.test/webhook/token?secret=value"
-    screenshot_dir = tmp_path / "screenshots"
-    screenshot_dir.mkdir()
-    screenshot = screenshot_dir / "10 - reference.png"
-    screenshot.write_bytes(b"\x89PNG\r\n\x1a\n")
-    render = RenderArtifacts(
-        screenshots_by_label={"Reference": [screenshot]},
-        screenshot_dir=screenshot_dir,
-    )
-    warning = "slow.pics webhook: delivery failed after 3 attempts"
-    warning_calls: list[tuple[str, dict[str, object]]] = []
-
-    async def _fake_publish_to_slowpics(**kwargs: object) -> PublishResult:
-        upload_plan = cast(Any, kwargs["upload_plan"])
-        return PublishResult(
-            url="https://slow.pics/c/example",
-            screenshot_count=len(upload_plan.file_paths),
-            upload_duration_seconds=0.1,
-            uploaded_file_paths=tuple(upload_plan.file_paths),
-        )
-
-    async def _fake_deliver_slowpics_webhook(**_kwargs: object) -> SlowpicsWebhookResult:
-        return SlowpicsWebhookResult(success=False, warning=warning)
-
-    def _capture_warning(event: str, **kwargs: object) -> None:
-        warning_calls.append((event, kwargs))
-
-    monkeypatch.setattr(phase_tasks, "publish_to_slowpics", _fake_publish_to_slowpics)
-    monkeypatch.setattr(
-        phase_tasks, "deliver_slowpics_webhook", _fake_deliver_slowpics_webhook
-    )
-    monkeypatch.setattr(phase_tasks.log, "warning", _capture_warning)
-
-    async with httpx.AsyncClient() as client:
-        output = await phase_tasks.run_publish_phase(
-            ctx,
-            client=client,
-            metadata=None,
-            render=render,
-            selected_frames=[10],
-        )
-
-    assert output.slowpics_url == "https://slow.pics/c/example"
-    assert output.post_upload_actions == (
-        PostUploadActionResult(kind="webhook", success=False, warning=warning),
-    )
-    assert "secret.example.test" not in warning
-    assert "/webhook/token" not in warning
-    assert "secret=value" not in warning
-    assert warning_calls == [
-        ("slowpics_webhook_delivery_failed", {"warning": warning}),
-    ]
-
-
-async def test_run_publish_phase_webhook_validation_failure_preserves_upload_output(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    ctx = _context(tmp_path)
-    ctx.config.slowpics.create_url_shortcut = False
-    ctx.config.slowpics.webhook_url = "https://[::1"
-    screenshot_dir = tmp_path / "screenshots"
-    screenshot_dir.mkdir()
-    screenshot = screenshot_dir / "10 - reference.png"
-    screenshot.write_bytes(b"\x89PNG\r\n\x1a\n")
-    render = RenderArtifacts(
-        screenshots_by_label={"Reference": [screenshot]},
-        screenshot_dir=screenshot_dir,
-    )
-
-    async def _fake_publish_to_slowpics(**kwargs: object) -> PublishResult:
-        upload_plan = cast(Any, kwargs["upload_plan"])
-        return PublishResult(
-            url="https://slow.pics/c/example",
-            screenshot_count=len(upload_plan.file_paths),
-            upload_duration_seconds=0.1,
-            uploaded_file_paths=tuple(upload_plan.file_paths),
-        )
-
-    monkeypatch.setattr(phase_tasks, "publish_to_slowpics", _fake_publish_to_slowpics)
-
-    async with httpx.AsyncClient() as client:
-        output = await phase_tasks.run_publish_phase(
-            ctx,
-            client=client,
-            metadata=None,
-            render=render,
-            selected_frames=[10],
-        )
-
-    assert output.slowpics_url == "https://slow.pics/c/example"
-    assert output.uploaded_file_paths == (screenshot,)
-    assert output.post_upload_actions == (
-        PostUploadActionResult(
-            kind="webhook",
-            success=False,
-            warning=WEBHOOK_VALIDATION_WARNING,
-        ),
-    )
 
 
 async def test_report_confirmed_decline_skips_publish(
@@ -798,8 +663,9 @@ async def test_report_confirmed_available_report_confirms_then_publishes(
     publish_calls = 0
 
     def _confirm(
-        _request: SlowpicsUploadConfirmationRequest,
+        request: SlowpicsUploadConfirmationRequest,
     ) -> SlowpicsUploadConfirmationDecision:
+        del request
         return "confirmed"
 
     async def _fake_publish(*_args: object, **_kwargs: object) -> PublishPhaseOutput:
@@ -846,8 +712,9 @@ async def test_report_confirmed_report_failure_skips_prompt_and_publish(
         raise RuntimeError("report failed")
 
     def _unexpected_confirm(
-        _request: SlowpicsUploadConfirmationRequest,
+        request: SlowpicsUploadConfirmationRequest,
     ) -> SlowpicsUploadConfirmationDecision:
+        del request
         raise AssertionError("unavailable report must not prompt")
 
     async def _unexpected_publish(*_args: object, **_kwargs: object) -> PublishPhaseOutput:

--- a/tests/orchestration/test_phase_tasks_outputs.py
+++ b/tests/orchestration/test_phase_tasks_outputs.py
@@ -28,6 +28,10 @@ from frame_compare.orchestration.types import (
 )
 from frame_compare.services.errors import SlowpicsError
 from frame_compare.services.publishers import PublishResult
+from frame_compare.services.slowpics_webhook import (
+    WEBHOOK_VALIDATION_WARNING,
+    SlowpicsWebhookResult,
+)
 from frame_compare.services.types import TmdbMetadata
 from frame_compare.utils.progress import NullProgressReporter
 from frame_compare.vs.types import HDRMetadata
@@ -561,6 +565,168 @@ async def test_run_publish_phase_skips_shortcut_when_config_disabled(
     assert output.slowpics_url == "https://slow.pics/c/example"
     assert output.uploaded_file_paths == (screenshot,)
     assert output.post_upload_actions == ()
+
+
+async def test_run_publish_phase_delivers_configured_webhook_after_upload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.create_url_shortcut = False
+    ctx.config.slowpics.webhook_url = "https://hooks.example.test/webhook/token?secret=value"
+    screenshot_dir = tmp_path / "screenshots"
+    screenshot_dir.mkdir()
+    screenshot = screenshot_dir / "10 - reference.png"
+    screenshot.write_bytes(b"\x89PNG\r\n\x1a\n")
+    render = RenderArtifacts(
+        screenshots_by_label={"Reference": [screenshot]},
+        screenshot_dir=screenshot_dir,
+    )
+    captured: dict[str, object] = {}
+
+    async def _fake_publish_to_slowpics(**kwargs: object) -> PublishResult:
+        upload_plan = cast(Any, kwargs["upload_plan"])
+        return PublishResult(
+            url="https://slow.pics/c/example",
+            screenshot_count=len(upload_plan.file_paths),
+            upload_duration_seconds=0.1,
+            uploaded_file_paths=tuple(upload_plan.file_paths),
+        )
+
+    async def _fake_deliver_slowpics_webhook(**kwargs: object) -> SlowpicsWebhookResult:
+        captured.update(kwargs)
+        return SlowpicsWebhookResult(success=True, detail="HTTP 204")
+
+    monkeypatch.setattr(phase_tasks, "publish_to_slowpics", _fake_publish_to_slowpics)
+    monkeypatch.setattr(
+        phase_tasks, "deliver_slowpics_webhook", _fake_deliver_slowpics_webhook
+    )
+
+    async with httpx.AsyncClient() as client:
+        output = await phase_tasks.run_publish_phase(
+            ctx,
+            client=client,
+            metadata=None,
+            render=render,
+            selected_frames=[10],
+        )
+
+    assert captured == {
+        "webhook_url": "https://hooks.example.test/webhook/token?secret=value",
+        "slowpics_url": "https://slow.pics/c/example",
+    }
+    assert output.post_upload_actions == (
+        PostUploadActionResult(
+            kind="webhook",
+            success=True,
+            detail="HTTP 204",
+            message="slow.pics webhook delivered",
+        ),
+    )
+
+
+async def test_run_publish_phase_webhook_failure_is_warning_only_and_redacted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.create_url_shortcut = False
+    ctx.config.slowpics.webhook_url = "https://secret.example.test/webhook/token?secret=value"
+    screenshot_dir = tmp_path / "screenshots"
+    screenshot_dir.mkdir()
+    screenshot = screenshot_dir / "10 - reference.png"
+    screenshot.write_bytes(b"\x89PNG\r\n\x1a\n")
+    render = RenderArtifacts(
+        screenshots_by_label={"Reference": [screenshot]},
+        screenshot_dir=screenshot_dir,
+    )
+    warning = "slow.pics webhook: delivery failed after 3 attempts"
+    warning_calls: list[tuple[str, dict[str, object]]] = []
+
+    async def _fake_publish_to_slowpics(**kwargs: object) -> PublishResult:
+        upload_plan = cast(Any, kwargs["upload_plan"])
+        return PublishResult(
+            url="https://slow.pics/c/example",
+            screenshot_count=len(upload_plan.file_paths),
+            upload_duration_seconds=0.1,
+            uploaded_file_paths=tuple(upload_plan.file_paths),
+        )
+
+    async def _fake_deliver_slowpics_webhook(**_kwargs: object) -> SlowpicsWebhookResult:
+        return SlowpicsWebhookResult(success=False, warning=warning)
+
+    def _capture_warning(event: str, **kwargs: object) -> None:
+        warning_calls.append((event, kwargs))
+
+    monkeypatch.setattr(phase_tasks, "publish_to_slowpics", _fake_publish_to_slowpics)
+    monkeypatch.setattr(
+        phase_tasks, "deliver_slowpics_webhook", _fake_deliver_slowpics_webhook
+    )
+    monkeypatch.setattr(phase_tasks.log, "warning", _capture_warning)
+
+    async with httpx.AsyncClient() as client:
+        output = await phase_tasks.run_publish_phase(
+            ctx,
+            client=client,
+            metadata=None,
+            render=render,
+            selected_frames=[10],
+        )
+
+    assert output.slowpics_url == "https://slow.pics/c/example"
+    assert output.post_upload_actions == (
+        PostUploadActionResult(kind="webhook", success=False, warning=warning),
+    )
+    assert "secret.example.test" not in warning
+    assert "/webhook/token" not in warning
+    assert "secret=value" not in warning
+    assert warning_calls == [
+        ("slowpics_webhook_delivery_failed", {"warning": warning}),
+    ]
+
+
+async def test_run_publish_phase_webhook_validation_failure_preserves_upload_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.create_url_shortcut = False
+    ctx.config.slowpics.webhook_url = "https://[::1"
+    screenshot_dir = tmp_path / "screenshots"
+    screenshot_dir.mkdir()
+    screenshot = screenshot_dir / "10 - reference.png"
+    screenshot.write_bytes(b"\x89PNG\r\n\x1a\n")
+    render = RenderArtifacts(
+        screenshots_by_label={"Reference": [screenshot]},
+        screenshot_dir=screenshot_dir,
+    )
+
+    async def _fake_publish_to_slowpics(**kwargs: object) -> PublishResult:
+        upload_plan = cast(Any, kwargs["upload_plan"])
+        return PublishResult(
+            url="https://slow.pics/c/example",
+            screenshot_count=len(upload_plan.file_paths),
+            upload_duration_seconds=0.1,
+            uploaded_file_paths=tuple(upload_plan.file_paths),
+        )
+
+    monkeypatch.setattr(phase_tasks, "publish_to_slowpics", _fake_publish_to_slowpics)
+
+    async with httpx.AsyncClient() as client:
+        output = await phase_tasks.run_publish_phase(
+            ctx,
+            client=client,
+            metadata=None,
+            render=render,
+            selected_frames=[10],
+        )
+
+    assert output.slowpics_url == "https://slow.pics/c/example"
+    assert output.uploaded_file_paths == (screenshot,)
+    assert output.post_upload_actions == (
+        PostUploadActionResult(
+            kind="webhook",
+            success=False,
+            warning=WEBHOOK_VALIDATION_WARNING,
+        ),
+    )
 
 
 def test_post_report_cleanup_skips_non_embedded_reports(tmp_path: Path) -> None:

--- a/tests/orchestration/test_phase_tasks_outputs.py
+++ b/tests/orchestration/test_phase_tasks_outputs.py
@@ -22,9 +22,13 @@ from frame_compare.orchestration.types import (
     ExecutionState,
     MetadataPrefetch,
     PostUploadActionResult,
+    PublishPhaseOutput,
     RenderArtifacts,
+    ReportPhaseOutput,
     RunArtifacts,
     RunRequest,
+    SlowpicsUploadConfirmationDecision,
+    SlowpicsUploadConfirmationRequest,
 )
 from frame_compare.services.errors import SlowpicsError
 from frame_compare.services.publishers import PublishResult
@@ -729,6 +733,200 @@ async def test_run_publish_phase_webhook_validation_failure_preserves_upload_out
     )
 
 
+async def test_report_confirmed_decline_skips_publish(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.auto_upload = True
+    ctx.config.slowpics.confirm_upload_after_report = True
+    ctx.config.report.enable = True
+    report_path = tmp_path / "report.html"
+    state = ExecutionState(
+        artifacts=RunArtifacts(report_path=report_path, report_succeeded=True),
+        selected_frames=[10],
+    )
+    callback_calls: list[SlowpicsUploadConfirmationRequest] = []
+
+    def _decline(
+        request: SlowpicsUploadConfirmationRequest,
+    ) -> SlowpicsUploadConfirmationDecision:
+        callback_calls.append(request)
+        return "declined"
+
+    async def _unexpected_publish(*_args: object, **_kwargs: object) -> PublishPhaseOutput:
+        raise AssertionError("declined report-confirmed upload must not publish")
+
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_publish_phase",
+        _unexpected_publish,
+    )
+
+    async with httpx.AsyncClient() as client:
+        phases = build_phases_after_align(
+            request=RunRequest(root=tmp_path),
+            clock=lambda: datetime(2026, 5, 31, tzinfo=UTC),
+            ffmpeg_runner=cast(Any, _RenderRunner()),
+            http_client=client,
+            state=state,
+            metadata_prefetch=MetadataPrefetch(None, False),
+            config=ctx.config,
+            confirm_slowpics_upload=_decline,
+        )
+        selected_phases = [
+            phase for phase in phases if phase.name in {"confirm_slowpics_upload", "publish"}
+        ]
+        await execute_phases(selected_phases, ctx, NullProgressReporter())
+
+    assert callback_calls == [SlowpicsUploadConfirmationRequest(report_path=report_path)]
+    assert state.artifacts.slowpics_upload_confirmation_status == "declined"
+    assert state.artifacts.slowpics_url is None
+    assert state.artifacts.uploaded_slowpics_file_paths == ()
+
+
+async def test_report_confirmed_available_report_confirms_then_publishes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.auto_upload = True
+    ctx.config.slowpics.confirm_upload_after_report = True
+    ctx.config.report.enable = True
+    report_path = tmp_path / "report.html"
+    state = ExecutionState(
+        artifacts=RunArtifacts(report_path=report_path, report_succeeded=True),
+        selected_frames=[10],
+    )
+    publish_calls = 0
+
+    def _confirm(
+        _request: SlowpicsUploadConfirmationRequest,
+    ) -> SlowpicsUploadConfirmationDecision:
+        return "confirmed"
+
+    async def _fake_publish(*_args: object, **_kwargs: object) -> PublishPhaseOutput:
+        nonlocal publish_calls
+        publish_calls += 1
+        return PublishPhaseOutput(slowpics_url="https://slow.pics/c/confirmed")
+
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_publish_phase",
+        _fake_publish,
+    )
+
+    async with httpx.AsyncClient() as client:
+        phases = build_phases_after_align(
+            request=RunRequest(root=tmp_path),
+            clock=lambda: datetime(2026, 5, 31, tzinfo=UTC),
+            ffmpeg_runner=cast(Any, _RenderRunner()),
+            http_client=client,
+            state=state,
+            metadata_prefetch=MetadataPrefetch(None, False),
+            config=ctx.config,
+            confirm_slowpics_upload=_confirm,
+        )
+        selected_phases = [
+            phase for phase in phases if phase.name in {"confirm_slowpics_upload", "publish"}
+        ]
+        await execute_phases(selected_phases, ctx, NullProgressReporter())
+
+    assert publish_calls == 1
+    assert state.artifacts.slowpics_upload_confirmation_status == "confirmed"
+    assert state.artifacts.slowpics_url == "https://slow.pics/c/confirmed"
+
+
+async def test_report_confirmed_report_failure_skips_prompt_and_publish(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.auto_upload = True
+    ctx.config.slowpics.confirm_upload_after_report = True
+    ctx.config.report.enable = True
+    state = ExecutionState(artifacts=RunArtifacts(), selected_frames=[10])
+
+    def _failing_report(*_args: object, **_kwargs: object) -> ReportPhaseOutput:
+        raise RuntimeError("report failed")
+
+    def _unexpected_confirm(
+        _request: SlowpicsUploadConfirmationRequest,
+    ) -> SlowpicsUploadConfirmationDecision:
+        raise AssertionError("unavailable report must not prompt")
+
+    async def _unexpected_publish(*_args: object, **_kwargs: object) -> PublishPhaseOutput:
+        raise AssertionError("unavailable report must not publish")
+
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_report_phase",
+        _failing_report,
+    )
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_publish_phase",
+        _unexpected_publish,
+    )
+
+    async with httpx.AsyncClient() as client:
+        phases = build_phases_after_align(
+            request=RunRequest(root=tmp_path),
+            clock=lambda: datetime(2026, 5, 31, tzinfo=UTC),
+            ffmpeg_runner=cast(Any, _RenderRunner()),
+            http_client=client,
+            state=state,
+            metadata_prefetch=MetadataPrefetch(None, False),
+            config=ctx.config,
+            confirm_slowpics_upload=_unexpected_confirm,
+        )
+        selected_phases = [
+            phase
+            for phase in phases
+            if phase.name in {"report", "confirm_slowpics_upload", "publish"}
+        ]
+        await execute_phases(selected_phases, ctx, NullProgressReporter())
+
+    assert state.artifacts.slowpics_upload_confirmation_status == "report_unavailable"
+    assert state.artifacts.slowpics_url is None
+    assert state.warnings == [
+        "report: report failed",
+        "slow.pics upload skipped because report confirmation was unavailable",
+    ]
+
+
+async def test_report_confirmed_report_payload_uses_no_slowpics_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.auto_upload = True
+    ctx.config.slowpics.confirm_upload_after_report = True
+    ctx.config.report.enable = True
+    state = ExecutionState(
+        artifacts=RunArtifacts(slowpics_url="https://slow.pics/c/stale"),
+        selected_frames=[10],
+    )
+    captured_slowpics_url: str | None = "not-captured"
+
+    def _capture_report(*_args: object, **kwargs: object) -> ReportPhaseOutput:
+        nonlocal captured_slowpics_url
+        captured_slowpics_url = cast(str | None, kwargs["slowpics_url"])
+        return ReportPhaseOutput(report_path=tmp_path / "report.html", report_succeeded=True)
+
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_report_phase",
+        _capture_report,
+    )
+
+    phases = build_phases_after_align(
+        request=RunRequest(root=tmp_path),
+        clock=lambda: datetime(2026, 5, 31, tzinfo=UTC),
+        ffmpeg_runner=cast(Any, _RenderRunner()),
+        http_client=None,
+        state=state,
+        metadata_prefetch=MetadataPrefetch(None, False),
+        config=ctx.config,
+    )
+    report_phase = next(phase for phase in phases if phase.name == "report")
+    await execute_phases([report_phase], ctx, NullProgressReporter())
+
+    assert captured_slowpics_url is None
+    assert state.artifacts.report_path == tmp_path / "report.html"
+
+
 def test_post_report_cleanup_skips_non_embedded_reports(tmp_path: Path) -> None:
     ctx = _context(tmp_path)
     ctx.config.slowpics.delete_after_upload = True
@@ -926,6 +1124,7 @@ async def test_warn_only_publish_phase_keeps_sanitized_service_error_in_warning_
             http_client=client,
             state=state,
             metadata_prefetch=MetadataPrefetch(None, False),
+            config=ctx.config,
         )
         publish_phase = next(phase for phase in phases if phase.name == "publish")
 

--- a/tests/orchestration/test_phase_tasks_outputs.py
+++ b/tests/orchestration/test_phase_tasks_outputs.py
@@ -181,8 +181,8 @@ def test_run_report_phase_passes_reference_source_frame_details(
     assert [
         (detail.label, detail.detail, detail.category) for detail in report_data.frame_details
     ] == [
-        ("User", "Source frame 4 (00:00:00.167)", "user_override"),
-        ("Bright", "Source frame 5", "quantile_bright"),
+        ("User", "Source frame 4", "user_override"),
+        ("Frame 5", "Source frame 5", "quantile_bright"),
     ]
     assert captured["report_config"] == ctx.config.report
 

--- a/tests/orchestration/test_phase_tasks_outputs.py
+++ b/tests/orchestration/test_phase_tasks_outputs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -15,9 +16,19 @@ from frame_compare.analysis.types import (
 )
 from frame_compare.config.schema import OverlayMode
 from frame_compare.orchestration import phase_tasks
-from frame_compare.orchestration.types import MetadataPrefetch, RenderArtifacts, RunArtifacts
+from frame_compare.orchestration.execution import build_phases_after_align
+from frame_compare.orchestration.phases import execute_phases
+from frame_compare.orchestration.types import (
+    ExecutionState,
+    MetadataPrefetch,
+    RenderArtifacts,
+    RunArtifacts,
+    RunRequest,
+)
+from frame_compare.services.errors import SlowpicsError
 from frame_compare.services.publishers import PublishResult
 from frame_compare.services.types import TmdbMetadata
+from frame_compare.utils.progress import NullProgressReporter
 from frame_compare.vs.types import HDRMetadata
 from tests.orchestration.phase_task_helpers import (
     _clip,
@@ -388,7 +399,10 @@ def test_run_report_phase_without_screenshots_clears_existing_report_path(tmp_pa
 async def test_run_publish_phase_sets_url_from_publish_result(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    ctx = _context(tmp_path)
+    comparison = _clip(
+        tmp_path / "comparison_videos" / "encode-final-source.mkv", label="Encode 1"
+    )
+    ctx = _context(tmp_path, comparisons=[comparison])
     metadata = TmdbMetadata(
         tmdb_id=3,
         title="Collateral",
@@ -396,23 +410,316 @@ async def test_run_publish_phase_sets_url_from_publish_result(
         year=2004,
         media_type="movie",
     )
+    screenshot_dir = tmp_path / "screenshots"
+    screenshot_dir.mkdir()
+    ref_10 = screenshot_dir / "10 - reference.png"
+    enc_10 = screenshot_dir / "10 - encode.png"
+    ref_20 = screenshot_dir / "20 - reference.png"
+    enc_20 = screenshot_dir / "20 - encode.png"
+    stale = screenshot_dir / "stale.png"
+    for screenshot in (ref_10, enc_10, ref_20, enc_20, stale):
+        screenshot.write_bytes(b"\x89PNG\r\n\x1a\n")
+    render = RenderArtifacts(
+        screenshots_by_label={
+            "Reference": [ref_10, ref_20],
+            "Encode 1": [enc_10, enc_20],
+        },
+        screenshot_dir=screenshot_dir,
+    )
     captured: dict[str, Any] = {}
+    captured_clip_names: list[tuple[str, str]] = []
+    real_build_slowpics_upload_plan = phase_tasks.build_slowpics_upload_plan
+
+    def _capturing_build_slowpics_upload_plan(**kwargs: object) -> object:
+        clips = kwargs["clips"]
+        captured_clip_names.extend((clip.label, clip.image_name) for clip in clips)
+        return real_build_slowpics_upload_plan(
+            selected_frames=cast(list[int], kwargs["selected_frames"]),
+            clips=cast(Any, clips),
+            screenshots_by_label=cast(dict[str, list[Path]], kwargs["screenshots_by_label"]),
+        )
 
     async def _fake_publish_to_slowpics(**kwargs: object) -> PublishResult:
         captured.update(kwargs)
+        upload_plan = cast(Any, kwargs["upload_plan"])
         return PublishResult(
             url="https://slow.pics/c/collateral",
-            screenshot_count=2,
+            screenshot_count=len(upload_plan.file_paths),
             upload_duration_seconds=0.1,
+            uploaded_file_paths=tuple(upload_plan.file_paths),
         )
 
+    monkeypatch.setattr(
+        phase_tasks, "build_slowpics_upload_plan", _capturing_build_slowpics_upload_plan
+    )
     monkeypatch.setattr(phase_tasks, "publish_to_slowpics", _fake_publish_to_slowpics)
 
     async with httpx.AsyncClient() as client:
-        output = await phase_tasks.run_publish_phase(ctx, client=client, metadata=metadata)
+        output = await phase_tasks.run_publish_phase(
+            ctx,
+            client=client,
+            metadata=metadata,
+            render=render,
+            selected_frames=[10, 20],
+        )
         assert captured["client"] is client
 
-    assert captured["screenshot_dir"] == ctx.workspace.screenshots_dir
+    assert captured["screenshot_dir"] == screenshot_dir
     assert captured["config"] == ctx.config.slowpics
     assert captured["metadata"] == metadata
+    upload_plan = captured["upload_plan"]
+    assert upload_plan.file_paths == [ref_10, enc_10, ref_20, enc_20]
+    assert [row.row_name for row in upload_plan.rows] == ["10", "20"]
+    assert [image.image_name for image in upload_plan.rows[0].images] == [
+        "reference",
+        "encode-final-source",
+    ]
+    assert captured_clip_names == [
+        ("Reference", "reference"),
+        ("Encode 1", "encode-final-source"),
+    ]
     assert output.slowpics_url == "https://slow.pics/c/collateral"
+    assert output.uploaded_file_paths == (ref_10, enc_10, ref_20, enc_20)
+
+
+async def test_run_publish_phase_rejects_duplicate_clip_labels_at_translation_seam(
+    tmp_path: Path,
+) -> None:
+    comparison = _clip(tmp_path / "comparison_videos" / "encode.mkv", label="Reference")
+    ctx = _context(tmp_path, comparisons=[comparison])
+    screenshot_dir = tmp_path / "screenshots"
+    screenshot_dir.mkdir()
+    screenshot = screenshot_dir / "10 - reference.png"
+    screenshot.write_bytes(b"\x89PNG\r\n\x1a\n")
+    render = RenderArtifacts(
+        screenshots_by_label={"Reference": [screenshot]},
+        screenshot_dir=screenshot_dir,
+    )
+
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(SlowpicsError, match="Duplicate clip label in slow.pics upload input"):
+            await phase_tasks.run_publish_phase(
+                ctx,
+                client=client,
+                metadata=None,
+                render=render,
+                selected_frames=[10],
+            )
+
+
+def test_post_report_cleanup_skips_non_embedded_reports(tmp_path: Path) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.delete_after_upload = True
+    ctx.config.report.enable = True
+    ctx.config.report.embed_images = False
+    uploaded = (
+        tmp_path / "screenshots" / "planned-a.png",
+        tmp_path / "screenshots" / "planned-b.png",
+    )
+    stale = tmp_path / "screenshots" / "stale.png"
+    for path in (*uploaded, stale):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    output = phase_tasks.run_post_report_cleanup_phase(
+        ctx,
+        uploaded_file_paths=uploaded,
+        report_succeeded=True,
+    )
+
+    assert output.warnings == []
+    assert all(path.exists() for path in uploaded)
+    assert stale.exists()
+
+
+def test_post_report_cleanup_deletes_planned_files_after_embedded_report_success(
+    tmp_path: Path,
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.delete_after_upload = True
+    ctx.config.report.enable = True
+    ctx.config.report.embed_images = True
+    uploaded = (
+        tmp_path / "screenshots" / "planned-a.png",
+        tmp_path / "screenshots" / "planned-b.png",
+    )
+    stale = tmp_path / "screenshots" / "stale.png"
+    for path in (*uploaded, stale):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    output = phase_tasks.run_post_report_cleanup_phase(
+        ctx,
+        uploaded_file_paths=uploaded,
+        report_succeeded=True,
+    )
+
+    assert output.warnings == []
+    assert not any(path.exists() for path in uploaded)
+    assert stale.exists()
+
+
+def test_post_report_cleanup_deletes_planned_files_when_reports_disabled(
+    tmp_path: Path,
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.delete_after_upload = True
+    ctx.config.report.enable = False
+    ctx.config.report.embed_images = False
+    uploaded = (tmp_path / "screenshots" / "planned.png",)
+    stale = tmp_path / "screenshots" / "stale.png"
+    for path in (*uploaded, stale):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    output = phase_tasks.run_post_report_cleanup_phase(
+        ctx,
+        uploaded_file_paths=uploaded,
+        report_succeeded=False,
+    )
+
+    assert output.warnings == []
+    assert not uploaded[0].exists()
+    assert stale.exists()
+
+
+def test_post_report_cleanup_skips_without_upload_handoff(tmp_path: Path) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.delete_after_upload = True
+    ctx.config.report.enable = False
+    stale = tmp_path / "screenshots" / "stale.png"
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    output = phase_tasks.run_post_report_cleanup_phase(
+        ctx,
+        uploaded_file_paths=(),
+        report_succeeded=False,
+    )
+
+    assert output.warnings == []
+    assert stale.exists()
+
+
+def test_post_report_cleanup_requires_report_success_when_report_enabled(
+    tmp_path: Path,
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.delete_after_upload = True
+    ctx.config.report.enable = True
+    ctx.config.report.embed_images = True
+    uploaded = (tmp_path / "screenshots" / "planned.png",)
+    uploaded[0].parent.mkdir(parents=True, exist_ok=True)
+    uploaded[0].write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    output = phase_tasks.run_post_report_cleanup_phase(
+        ctx,
+        uploaded_file_paths=uploaded,
+        report_succeeded=False,
+    )
+
+    assert output.warnings == []
+    assert uploaded[0].exists()
+
+
+def test_post_report_cleanup_returns_warning_and_logs_for_delete_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.config.slowpics.delete_after_upload = True
+    ctx.config.report.enable = False
+    uploaded = (tmp_path / "screenshots" / "planned.png",)
+    uploaded[0].parent.mkdir(parents=True, exist_ok=True)
+    uploaded[0].write_bytes(b"\x89PNG\r\n\x1a\n")
+    warning_calls: list[tuple[str, dict[str, object]]] = []
+
+    def _raise_permission_error(self: Path) -> None:
+        if self == uploaded[0]:
+            raise PermissionError("locked")
+        Path.unlink(self)
+
+    def _capture_warning(event: str, **kwargs: object) -> None:
+        warning_calls.append((event, kwargs))
+
+    monkeypatch.setattr(Path, "unlink", _raise_permission_error)
+    monkeypatch.setattr(phase_tasks.log, "warning", _capture_warning)
+
+    output = phase_tasks.run_post_report_cleanup_phase(
+        ctx,
+        uploaded_file_paths=uploaded,
+        report_succeeded=False,
+    )
+
+    assert output.warnings == [
+        f"cleanup: failed to delete uploaded screenshot {uploaded[0]}: locked"
+    ]
+    assert warning_calls == [
+        (
+            "slowpics_uploaded_file_delete_failed",
+            {"path": str(uploaded[0]), "error": "locked"},
+        )
+    ]
+
+
+async def test_warn_only_publish_phase_keeps_sanitized_service_error_in_warning_and_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    comparison = _clip(tmp_path / "comparison_videos" / "encode.mkv", label="Encode 1")
+    ctx = _context(tmp_path, comparisons=[comparison])
+    ctx.config.slowpics.auto_upload = True
+    sanitized_error = SlowpicsError("Image upload failed with status 400")
+    warning_calls: list[tuple[str, dict[str, object]]] = []
+
+    async def _fake_run_publish_phase(*_args: object, **_kwargs: object) -> object:
+        raise sanitized_error
+
+    def _capture_warning(event: str, **kwargs: object) -> None:
+        warning_calls.append((event, kwargs))
+
+    monkeypatch.setattr(
+        "frame_compare.orchestration.execution.run_publish_phase",
+        _fake_run_publish_phase,
+    )
+    monkeypatch.setattr("frame_compare.orchestration.phases.log.warning", _capture_warning)
+
+    state = ExecutionState(
+        artifacts=RunArtifacts(
+            render=RenderArtifacts(
+                screenshots_by_label={
+                    "Reference": [tmp_path / "screenshots" / "reference.png"],
+                    "Encode 1": [tmp_path / "screenshots" / "encode.png"],
+                },
+                screenshot_dir=tmp_path / "screenshots",
+            )
+        ),
+        selected_frames=[10],
+    )
+    async with httpx.AsyncClient() as client:
+        phases = build_phases_after_align(
+            request=RunRequest(root=tmp_path),
+            clock=lambda: datetime(2026, 5, 31, tzinfo=UTC),
+            ffmpeg_runner=cast(Any, _RenderRunner()),
+            http_client=client,
+            state=state,
+            metadata_prefetch=MetadataPrefetch(None, False),
+        )
+        publish_phase = next(phase for phase in phases if phase.name == "publish")
+
+        await execute_phases([publish_phase], ctx, NullProgressReporter())
+
+    assert len(state.warnings) == 1
+    assert "publish:" in state.warnings[0]
+    assert "Image upload failed with status 400" in state.warnings[0]
+    assert warning_calls == [
+        (
+            "phase_warned",
+            {
+                "phase": "publish",
+                "error_type": "SlowpicsError",
+                "error": str(sanitized_error),
+                "exc_info": sanitized_error,
+            },
+        )
+    ]

--- a/tests/orchestration/test_phases.py
+++ b/tests/orchestration/test_phases.py
@@ -377,6 +377,7 @@ def test_publish_phase_skip_condition_uses_effective_slowpics_config() -> None:
         http_client=None,
         state=state,
         metadata_prefetch=MetadataPrefetch(None, False),
+        config=ConfigSchema(),
     )
 
     publish_phase = next(phase for phase in phases if phase.name == "publish")

--- a/tests/orchestration/test_run_dependencies.py
+++ b/tests/orchestration/test_run_dependencies.py
@@ -12,7 +12,11 @@ from frame_compare.orchestration.coordinator import (
     RunDependencies,
     execute_run,
 )
-from frame_compare.orchestration.types import RunRequest
+from frame_compare.orchestration.types import (
+    RunRequest,
+    SlowpicsUploadConfirmationDecision,
+    SlowpicsUploadConfirmationRequest,
+)
 from frame_compare.vs.loader import VSLoader
 from frame_compare.vs.types import HDRMetadata, SourceInfo
 
@@ -52,6 +56,17 @@ def test_run_dependencies_returns_injected_dependencies() -> None:
 
     assert deps.vs_loader is loader
     assert deps.ffmpeg_runner is runner
+
+
+def test_run_dependencies_accepts_slowpics_confirmation_callback() -> None:
+    def _confirm(
+        _request: SlowpicsUploadConfirmationRequest,
+    ) -> SlowpicsUploadConfirmationDecision:
+        return "confirmed"
+
+    deps = RunDependencies(confirm_slowpics_upload=_confirm)
+
+    assert deps.confirm_slowpics_upload is _confirm
 
 
 def test_run_dependencies_clock_returns_datetime() -> None:
@@ -103,3 +118,31 @@ def test_execute_run_initializes_local_dependencies_without_mutating_injected_de
     assert deps.ffmpeg_runner is None
     assert deps.progress is None
     assert deps.http_client is None
+
+
+def test_execute_run_preserves_slowpics_confirmation_callback_when_cloning_deps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from frame_compare.orchestration import coordinator
+
+    captured_local_deps: RunDependencies | None = None
+
+    def _confirm(
+        _request: SlowpicsUploadConfirmationRequest,
+    ) -> SlowpicsUploadConfirmationDecision:
+        return "confirmed"
+
+    async def fake_execute_prep(_request: RunRequest, local_deps: RunDependencies):
+        nonlocal captured_local_deps
+        captured_local_deps = local_deps
+        raise StopAfterDependencyInit
+
+    monkeypatch.setattr(coordinator, "execute_prep", fake_execute_prep)
+
+    deps = RunDependencies(confirm_slowpics_upload=_confirm)
+
+    with pytest.raises(StopAfterDependencyInit):
+        asyncio.run(execute_run(RunRequest(root=tmp_path, quiet=True), deps=deps))
+
+    assert captured_local_deps is not None
+    assert captured_local_deps.confirm_slowpics_upload is _confirm

--- a/tests/orchestration/test_run_result.py
+++ b/tests/orchestration/test_run_result.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+from pathlib import Path
 
 from frame_compare.orchestration import RunResult as PublicRunResult
 from frame_compare.orchestration.coordinator import RunResult
+from frame_compare.orchestration.types import PostUploadActionResult
 
 
 def test_run_result_defaults() -> None:
@@ -13,6 +15,7 @@ def test_run_result_defaults() -> None:
     assert result.screenshot_dir is None
     assert result.slowpics_url is None
     assert result.report_path is None
+    assert result.post_upload_actions == ()
 
     assert result.frame_count == 0
     assert result.clips_processed == 0
@@ -35,6 +38,24 @@ def test_run_result_default_factories_are_distinct() -> None:
     assert second.errors == []
     assert second.warnings == []
     assert second.phase_timings == {}
+    assert second.post_upload_actions == ()
+
+
+def test_run_result_accepts_typed_post_upload_action_results() -> None:
+    shortcut_path = Path("Slowpics.url")
+    action = PostUploadActionResult(
+        kind="shortcut",
+        success=True,
+        detail="slow.pics shortcut",
+        path=shortcut_path,
+        message="Shortcut written.",
+    )
+
+    result = RunResult(success=True, post_upload_actions=(action,))
+
+    assert result.post_upload_actions == (action,)
+    assert result.post_upload_actions[0].kind == "shortcut"
+    assert result.post_upload_actions[0].path == shortcut_path
 
 
 def test_run_result_is_frozen() -> None:

--- a/tests/services/test_publishers.py
+++ b/tests/services/test_publishers.py
@@ -3,8 +3,10 @@
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
+from http.cookies import SimpleCookie
 from pathlib import Path
 from unittest.mock import AsyncMock
+from uuid import UUID
 
 import httpx
 import pytest
@@ -12,14 +14,73 @@ import pytest
 from frame_compare.config.schema import SlowpicsConfig, Visibility
 from frame_compare.services.errors import (
     SlowpicsError,
-    SlowpicsRateLimitedError,
     SlowpicsUnavailableError,
 )
 from frame_compare.services.publishers import (
+    SLOWPICS_BROWSER_ID_SENTINEL,
+    SLOWPICS_USER_AGENT,
     SlowpicsPublisher,
     publish_to_slowpics,
 )
+from frame_compare.services.slowpics_upload_plan import (
+    SlowpicsPlannedImage,
+    SlowpicsUploadPlan,
+    SlowpicsUploadRow,
+)
 from frame_compare.services.types import TmdbMetadata
+
+
+def _png(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    return path
+
+
+def _plan(tmp_path: Path, *, rows: int = 2, cols: int = 2) -> SlowpicsUploadPlan:
+    upload_rows: list[SlowpicsUploadRow] = []
+    for row_index in range(rows):
+        images: list[SlowpicsPlannedImage] = []
+        for image_index in range(cols):
+            clip_label = "Reference" if image_index == 0 else f"Encode {image_index}"
+            image_name = "reference-source" if image_index == 0 else f"encode-source-{image_index}"
+            path = _png(tmp_path / "screenshots" / f"{row_index}-{image_index}.png")
+            images.append(
+                SlowpicsPlannedImage(
+                    row_index=row_index,
+                    selected_frame=10 + row_index,
+                    image_index=image_index,
+                    clip_label=clip_label,
+                    image_name=image_name,
+                    screenshot_path=path,
+                    sort_order=image_index,
+                )
+            )
+        upload_rows.append(
+            SlowpicsUploadRow(
+                row_index=row_index,
+                selected_frame=10 + row_index,
+                row_name=str(10 + row_index),
+                sort_order=row_index,
+                images=tuple(images),
+            )
+        )
+    return SlowpicsUploadPlan(rows=tuple(upload_rows))
+
+
+def _metadata_payload(
+    *,
+    rows: int = 2,
+    cols: int = 2,
+    first_comparison_key: str | None = "first-key",
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "key": "collection-key",
+        "collectionUuid": "collection-uuid-secret",
+        "images": [[f"image-{row}-{col}-secret" for col in range(cols)] for row in range(rows)],
+    }
+    if first_comparison_key is not None:
+        payload["firstComparisonKey"] = first_comparison_key
+    return payload
 
 
 def _multipart_field_value(request: httpx.Request, field_name: str) -> str:
@@ -29,6 +90,30 @@ def _multipart_field_value(request: httpx.Request, field_name: str) -> str:
     value_start = body.index("\r\n\r\n", field_start) + len("\r\n\r\n")
     value_end = body.index("\r\n--", value_start)
     return body[value_start:value_end]
+
+
+def _multipart_filenames(request: httpx.Request) -> list[str]:
+    body = request.content.decode("utf-8", errors="replace")
+    filenames: list[str] = []
+    for part in body.split("\r\n"):
+        marker = 'filename="'
+        if marker in part:
+            start = part.index(marker) + len(marker)
+            end = part.index('"', start)
+            filenames.append(part[start:end])
+    return filenames
+
+
+def _assert_generated_multipart_content_type(request: httpx.Request) -> None:
+    content_type = request.headers["Content-Type"]
+    assert content_type.startswith("multipart/form-data; boundary=")
+
+
+def _request_cookie_value(request: httpx.Request, cookie_name: str) -> str:
+    cookie_header = request.headers["Cookie"]
+    parsed = SimpleCookie[str]()
+    parsed.load(cookie_header)
+    return parsed[cookie_name].value
 
 
 @pytest.fixture
@@ -48,228 +133,239 @@ def mock_jitter(mocker):
 
 
 @pytest.fixture
-def mock_slowpics_success(respx_mock):
-    respx_mock.post("https://slow.pics/api/comparison").mock(
-        return_value=httpx.Response(200, json={"url": "https://slow.pics/c/abc123"})
-    )
-    return respx_mock
-
-
-@pytest.fixture
-def screenshot_dir(tmp_path: Path) -> Path:
-    dir_path = tmp_path / "screenshots"
-    dir_path.mkdir()
-    (dir_path / "test_00001.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
-    (dir_path / "test_00002.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
-    return dir_path
-
-
-@pytest.fixture
 async def async_client() -> AsyncIterator[httpx.AsyncClient]:
     async with httpx.AsyncClient() as client:
         yield client
 
 
+def _mock_successful_browser_flow(respx_mock, *, rows: int = 2, cols: int = 2) -> None:
+    respx_mock.get("https://slow.pics/comparison").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Set-Cookie": "XSRF-TOKEN=token%2Bdecoded; Domain=.slow.pics; Path=/"},
+        )
+    )
+    respx_mock.post("https://slow.pics/upload/comparison").mock(
+        return_value=httpx.Response(200, json=_metadata_payload(rows=rows, cols=cols))
+    )
+    for row in range(rows):
+        for col in range(cols):
+            respx_mock.post(f"https://slow.pics/upload/image/image-{row}-{col}-secret").mock(
+                return_value=httpx.Response(200)
+            )
+
+
 @pytest.mark.anyio
 async def test_publish_to_slowpics_success_returns_url(
-    screenshot_dir: Path,
+    tmp_path: Path,
     async_client: httpx.AsyncClient,
-    mock_slowpics_success,
-):
-    config = SlowpicsConfig()
-    result = await publish_to_slowpics(screenshot_dir, config, async_client)
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path)
+    _mock_successful_browser_flow(respx_mock)
 
-    assert result.url == "https://slow.pics/c/abc123"
-    assert result.screenshot_count == 2
+    result = await publish_to_slowpics(
+        tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
+    )
+
+    assert result.url == "https://slow.pics/c/first-key"
+    assert result.screenshot_count == 4
     assert result.upload_duration_seconds >= 0.0
 
 
 @pytest.mark.anyio
-async def test_publish_to_slowpics_rate_limited_raises_error(
-    screenshot_dir: Path,
+async def test_publish_to_slowpics_get_comparison_precedes_metadata_upload(
+    tmp_path: Path,
     async_client: httpx.AsyncClient,
     respx_mock,
-    mock_sleep,
-    mock_jitter,
-):
-    respx_mock.post("https://slow.pics/api/comparison").mock(
-        return_value=httpx.Response(429, headers={"Retry-After": "1"})
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    events: list[str] = []
+
+    def comparison_page(_request: httpx.Request) -> httpx.Response:
+        events.append("get")
+        return httpx.Response(
+            200,
+            headers={"Set-Cookie": "XSRF-TOKEN=token; Domain=.slow.pics; Path=/"},
+        )
+
+    def metadata_upload(_request: httpx.Request) -> httpx.Response:
+        events.append("metadata")
+        return httpx.Response(200, json=_metadata_payload(rows=1, cols=1))
+
+    respx_mock.get("https://slow.pics/comparison").mock(side_effect=comparison_page)
+    respx_mock.post("https://slow.pics/upload/comparison").mock(side_effect=metadata_upload)
+    respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(
+        return_value=httpx.Response(200)
     )
-    config = SlowpicsConfig(max_retries=1)
 
-    with pytest.raises(SlowpicsRateLimitedError):
-        await publish_to_slowpics(screenshot_dir, config, async_client)
-
-    assert mock_sleep.await_count == 1
-
-
-@pytest.mark.anyio
-async def test_publish_to_slowpics_server_error_raises_unavailable(
-    screenshot_dir: Path,
-    async_client: httpx.AsyncClient,
-    respx_mock,
-    mock_sleep,
-    mock_jitter,
-):
-    respx_mock.post("https://slow.pics/api/comparison").mock(return_value=httpx.Response(503))
-    config = SlowpicsConfig(max_retries=2)
-
-    with pytest.raises(SlowpicsUnavailableError):
-        await publish_to_slowpics(screenshot_dir, config, async_client)
-
-    assert mock_sleep.await_count == 2
-
-
-@pytest.mark.anyio
-async def test_publish_to_slowpics_timeout_raises_error(
-    screenshot_dir: Path,
-    async_client: httpx.AsyncClient,
-    respx_mock,
-    mock_sleep,
-    mock_jitter,
-):
-    respx_mock.post("https://slow.pics/api/comparison").mock(
-        side_effect=httpx.TimeoutException("Timeout")
+    await publish_to_slowpics(
+        tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
     )
-    config = SlowpicsConfig(max_retries=1)
 
-    with pytest.raises(SlowpicsError) as exc:
-        await publish_to_slowpics(screenshot_dir, config, async_client)
-
-    assert "timed out" in str(exc.value)
-    assert mock_sleep.await_count == 1
+    assert events == ["get", "metadata"]
 
 
 @pytest.mark.anyio
-async def test_publish_to_slowpics_request_error_exhaustion_raises_unavailable(
-    screenshot_dir: Path,
+async def test_publish_to_slowpics_sends_decoded_xsrf_browser_id_headers_and_user_agent(
+    tmp_path: Path,
     async_client: httpx.AsyncClient,
     respx_mock,
-    mock_sleep,
-    mock_jitter,
-):
-    respx_mock.post("https://slow.pics/api/comparison").mock(
-        side_effect=httpx.ConnectError("connection failed")
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    requests: list[httpx.Request] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/comparison":
+            return httpx.Response(
+                200,
+                headers={
+                    "Set-Cookie": "XSRF-TOKEN=token%2Bdecoded; Domain=.slow.pics; Path=/"
+                },
+            )
+        if request.url.path == "/upload/comparison":
+            return httpx.Response(200, json=_metadata_payload(rows=1, cols=1))
+        return httpx.Response(200)
+
+    respx_mock.get("https://slow.pics/comparison").mock(side_effect=capture)
+    respx_mock.post("https://slow.pics/upload/comparison").mock(side_effect=capture)
+    respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(side_effect=capture)
+
+    await publish_to_slowpics(
+        tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
     )
-    config = SlowpicsConfig(max_retries=1)
 
-    with pytest.raises(SlowpicsUnavailableError):
-        await publish_to_slowpics(screenshot_dir, config, async_client)
-
-    assert mock_sleep.await_count == 1
+    metadata_request = requests[1]
+    image_request = requests[2]
+    browser_id = _multipart_field_value(metadata_request, "browserId")
+    assert requests[0].headers["User-Agent"] == SLOWPICS_USER_AGENT
+    assert metadata_request.headers["User-Agent"] == SLOWPICS_USER_AGENT
+    assert image_request.headers["User-Agent"] == SLOWPICS_USER_AGENT
+    assert metadata_request.headers["X-XSRF-TOKEN"] == "token+decoded"
+    assert image_request.headers["X-XSRF-TOKEN"] == "token+decoded"
+    assert metadata_request.headers["Origin"] == "https://slow.pics"
+    assert metadata_request.headers["Referer"] == "https://slow.pics/comparison"
+    assert image_request.headers["Origin"] == "https://slow.pics"
+    assert image_request.headers["Referer"] == "https://slow.pics/comparison"
+    assert browser_id
+    assert _multipart_field_value(image_request, "browserId") == browser_id
+    assert f"BROWSER-ID={browser_id}" in metadata_request.headers["Cookie"]
+    assert async_client.cookies.get("BROWSER-ID") == browser_id
+    _assert_generated_multipart_content_type(metadata_request)
+    _assert_generated_multipart_content_type(image_request)
 
 
 @pytest.mark.anyio
-async def test_publish_to_slowpics_malformed_json_response_raises_error(
-    screenshot_dir: Path,
+async def test_publish_to_slowpics_reuses_existing_browser_id_cookie(
+    tmp_path: Path,
     async_client: httpx.AsyncClient,
     respx_mock,
-):
-    respx_mock.post("https://slow.pics/api/comparison").mock(
-        return_value=httpx.Response(200, text="not json")
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    async_client.cookies.set("BROWSER-ID", "existing-browser-id", domain="slow.pics", path="/")
+    requests: list[httpx.Request] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/comparison":
+            return httpx.Response(
+                200,
+                headers={"Set-Cookie": "XSRF-TOKEN=token; Domain=.slow.pics; Path=/"},
+            )
+        if request.url.path == "/upload/comparison":
+            return httpx.Response(200, json=_metadata_payload(rows=1, cols=1))
+        return httpx.Response(200)
+
+    respx_mock.get("https://slow.pics/comparison").mock(side_effect=capture)
+    respx_mock.post("https://slow.pics/upload/comparison").mock(side_effect=capture)
+    respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(side_effect=capture)
+
+    await publish_to_slowpics(
+        tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
     )
-    config = SlowpicsConfig()
 
-    with pytest.raises(SlowpicsError) as exc:
-        await publish_to_slowpics(screenshot_dir, config, async_client)
-
-    assert "Invalid response from slow.pics" in str(exc.value)
+    assert _multipart_field_value(requests[1], "browserId") == "existing-browser-id"
+    assert _multipart_field_value(requests[2], "browserId") == "existing-browser-id"
 
 
 @pytest.mark.anyio
-async def test_publish_to_slowpics_malformed_retry_after_uses_default_delay(
-    screenshot_dir: Path,
+async def test_publish_to_slowpics_replaces_sentinel_browser_id_cookie(
+    tmp_path: Path,
     async_client: httpx.AsyncClient,
     respx_mock,
-    mock_sleep,
-    mock_jitter,
-):
-    route = respx_mock.post("https://slow.pics/api/comparison")
-    route.side_effect = [
-        httpx.Response(429, headers={"Retry-After": "not-a-delay"}),
-        httpx.Response(200, json={"url": "https://slow.pics/c/abc123"}),
-    ]
-    config = SlowpicsConfig(max_retries=1)
-
-    result = await publish_to_slowpics(screenshot_dir, config, async_client)
-
-    assert result.url == "https://slow.pics/c/abc123"
-    mock_sleep.assert_awaited_once_with(60.0)
-
-
-@pytest.mark.anyio
-async def test_publish_to_slowpics_http_date_retry_after_sleeps_until_date(
-    screenshot_dir: Path,
-    async_client: httpx.AsyncClient,
-    respx_mock,
-    mock_sleep,
-    mock_jitter,
-):
-    retry_at = datetime.now(UTC) + timedelta(seconds=120)
-    route = respx_mock.post("https://slow.pics/api/comparison")
-    route.side_effect = [
-        httpx.Response(429, headers={"Retry-After": format_datetime(retry_at)}),
-        httpx.Response(200, json={"url": "https://slow.pics/c/abc123"}),
-    ]
-    config = SlowpicsConfig(max_retries=1)
-
-    result = await publish_to_slowpics(screenshot_dir, config, async_client)
-
-    assert result.url == "https://slow.pics/c/abc123"
-    mock_sleep.assert_awaited_once()
-    delay = mock_sleep.await_args.args[0]
-    assert isinstance(delay, float)
-    assert 0.0 < delay <= 120.0
-
-
-@pytest.mark.anyio
-async def test_publish_to_slowpics_retry_success(
-    screenshot_dir: Path,
-    async_client: httpx.AsyncClient,
-    respx_mock,
-    mock_sleep,
-    mock_jitter,
-):
-    # First 503, then 200
-    route = respx_mock.post("https://slow.pics/api/comparison")
-    route.side_effect = [
-        httpx.Response(503),
-        httpx.Response(200, json={"url": "https://slow.pics/c/abc123"}),
-    ]
-
-    config = SlowpicsConfig(max_retries=2)
-    result = await publish_to_slowpics(screenshot_dir, config, async_client)
-
-    assert result.url == "https://slow.pics/c/abc123"
-    assert mock_sleep.await_count == 1
-
-
-@pytest.mark.anyio
-async def test_publish_to_slowpics_4xx_fails_immediately(
-    screenshot_dir: Path,
-    async_client: httpx.AsyncClient,
-    respx_mock,
-    mock_sleep,
-):
-    respx_mock.post("https://slow.pics/api/comparison").mock(
-        return_value=httpx.Response(400, text="Bad Request")
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    async_client.cookies.set(
+        "BROWSER-ID",
+        SLOWPICS_BROWSER_ID_SENTINEL,
+        domain="slow.pics",
+        path="/",
     )
-    config = SlowpicsConfig()
+    requests: list[httpx.Request] = []
 
-    with pytest.raises(SlowpicsError):
-        await publish_to_slowpics(screenshot_dir, config, async_client)
+    def capture(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/comparison":
+            return httpx.Response(
+                200,
+                headers={"Set-Cookie": "XSRF-TOKEN=token; Domain=.slow.pics; Path=/"},
+            )
+        if request.url.path == "/upload/comparison":
+            return httpx.Response(200, json=_metadata_payload(rows=1, cols=1))
+        return httpx.Response(200)
 
-    assert mock_sleep.await_count == 0
+    respx_mock.get("https://slow.pics/comparison").mock(side_effect=capture)
+    respx_mock.post("https://slow.pics/upload/comparison").mock(side_effect=capture)
+    respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(side_effect=capture)
+
+    await publish_to_slowpics(
+        tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
+    )
+
+    browser_id = _multipart_field_value(requests[1], "browserId")
+    assert browser_id
+    assert browser_id != SLOWPICS_BROWSER_ID_SENTINEL
+    assert UUID(browser_id).version == 4
+    assert _multipart_field_value(requests[2], "browserId") == browser_id
+    assert _request_cookie_value(requests[1], "BROWSER-ID") == browser_id
+    assert _request_cookie_value(requests[2], "BROWSER-ID") == browser_id
+    assert SLOWPICS_BROWSER_ID_SENTINEL not in requests[1].headers["Cookie"]
+    assert SLOWPICS_BROWSER_ID_SENTINEL not in requests[2].headers["Cookie"]
+    assert async_client.cookies.get("BROWSER-ID") == browser_id
+    assert all(
+        cookie.value != SLOWPICS_BROWSER_ID_SENTINEL
+        for cookie in async_client.cookies.jar
+        if cookie.name == "BROWSER-ID"
+    )
 
 
 @pytest.mark.anyio
-async def test_publish_to_slowpics_uses_metadata_title(
-    screenshot_dir: Path,
+async def test_publish_to_slowpics_metadata_uses_plan_names_sort_order_and_visibility(
+    tmp_path: Path,
     async_client: httpx.AsyncClient,
-    mock_slowpics_success,
-    mocker,
-):
-    spy = mocker.spy(SlowpicsPublisher, "_prepare_upload")
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=2, cols=2)
+    metadata_requests: list[httpx.Request] = []
+    respx_mock.get("https://slow.pics/comparison").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Set-Cookie": "XSRF-TOKEN=token; Domain=.slow.pics; Path=/"},
+        )
+    )
+
+    def capture_metadata(request: httpx.Request) -> httpx.Response:
+        metadata_requests.append(request)
+        return httpx.Response(200, json=_metadata_payload())
+
+    respx_mock.post("https://slow.pics/upload/comparison").mock(side_effect=capture_metadata)
+    for row in range(2):
+        for col in range(2):
+            respx_mock.post(f"https://slow.pics/upload/image/image-{row}-{col}-secret").mock(
+                return_value=httpx.Response(200)
+            )
+
     metadata = TmdbMetadata(
         tmdb_id=1,
         title="My Movie",
@@ -277,134 +373,533 @@ async def test_publish_to_slowpics_uses_metadata_title(
         year=2021,
         media_type="movie",
     )
-    config = SlowpicsConfig()
+    await publish_to_slowpics(
+        tmp_path / "screenshots",
+        SlowpicsConfig(visibility=Visibility.PUBLIC),
+        async_client,
+        metadata=metadata,
+        upload_plan=upload_plan,
+    )
 
-    await publish_to_slowpics(screenshot_dir, config, async_client, metadata=metadata)
-
-    # Check title argument
-    assert spy.call_args[0][2] == "My Movie"
-
-
-@pytest.mark.anyio
-async def test_publish_to_slowpics_default_title_uses_directory_name(
-    screenshot_dir: Path,
-    async_client: httpx.AsyncClient,
-    mock_slowpics_success,
-    mocker,
-):
-    spy = mocker.spy(SlowpicsPublisher, "_prepare_upload")
-    config = SlowpicsConfig()
-
-    await publish_to_slowpics(screenshot_dir, config, async_client)
-
-    # Check title argument
-    assert spy.call_args[0][2] == screenshot_dir.name
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize(
-    ("visibility", "expected_public"),
-    [
-        (Visibility.PUBLIC, "true"),
-        (Visibility.UNLISTED, "false"),
-    ],
-)
-async def test_publish_to_slowpics_sends_supported_visibility_payload(
-    screenshot_dir: Path,
-    async_client: httpx.AsyncClient,
-    respx_mock,
-    visibility: Visibility,
-    expected_public: str,
-):
-    requests: list[httpx.Request] = []
-
-    def capture_request(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
-        return httpx.Response(200, json={"url": "https://slow.pics/c/abc123"})
-
-    respx_mock.post("https://slow.pics/api/comparison").mock(side_effect=capture_request)
-    config = SlowpicsConfig(visibility=visibility)
-
-    await publish_to_slowpics(screenshot_dir, config, async_client)
-
-    assert len(requests) == 1
-    assert _multipart_field_value(requests[0], "public") == expected_public
-    body = requests[0].content.decode("utf-8", errors="replace")
-    assert 'name="visibility"' not in body
-    assert 'name="private"' not in body
+    request = metadata_requests[0]
+    assert _multipart_field_value(request, "collectionName") == "My Movie"
+    assert _multipart_field_value(request, "optimizeImages") == "true"
+    assert _multipart_field_value(request, "desiredFileType") == "image/png"
+    assert _multipart_field_value(request, "hentai") == "false"
+    assert _multipart_field_value(request, "public") == "true"
+    assert _multipart_field_value(request, "visibility") == "PUBLIC"
+    assert _multipart_field_value(request, "removeAfter") == ""
+    assert _multipart_field_value(request, "comparisons[0].name") == "10"
+    assert _multipart_field_value(request, "comparisons[0].hentai") == "false"
+    assert _multipart_field_value(request, "comparisons[0].sortOrder") == "0"
+    assert _multipart_field_value(request, "comparisons[0].images[0].name") == "reference-source"
+    assert _multipart_field_value(request, "comparisons[0].images[0].sortOrder") == "0"
+    assert _multipart_field_value(request, "comparisons[1].name") == "11"
+    assert _multipart_field_value(request, "comparisons[1].sortOrder") == "1"
+    assert _multipart_field_value(request, "comparisons[1].images[1].name") == "encode-source-1"
+    assert _multipart_field_value(request, "comparisons[1].images[1].sortOrder") == "1"
 
 
 @pytest.mark.anyio
-async def test_publish_to_slowpics_empty_dir_raises_error(
+async def test_publish_to_slowpics_response_matrix_maps_to_matching_image_uploads(
     tmp_path: Path,
     async_client: httpx.AsyncClient,
-):
-    empty_dir = tmp_path / "empty"
-    empty_dir.mkdir()
-    config = SlowpicsConfig()
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=2, cols=2)
+    image_requests: list[httpx.Request] = []
+    _mock_successful_browser_flow(respx_mock)
+    for row in range(2):
+        for col in range(2):
+            respx_mock.post(f"https://slow.pics/upload/image/image-{row}-{col}-secret").mock(
+                side_effect=lambda request: image_requests.append(request) or httpx.Response(200)
+            )
 
-    with pytest.raises(SlowpicsError) as exc:
-        await publish_to_slowpics(empty_dir, config, async_client)
+    await publish_to_slowpics(
+        tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
+    )
 
-    assert "No PNG files found" in str(exc.value)
+    assert [request.url.path for request in image_requests] == [
+        "/upload/image/image-0-0-secret",
+        "/upload/image/image-0-1-secret",
+        "/upload/image/image-1-0-secret",
+        "/upload/image/image-1-1-secret",
+    ]
+    assert [_multipart_filenames(request) for request in image_requests] == [
+        ["0-0.png"],
+        ["0-1.png"],
+        ["1-0.png"],
+        ["1-1.png"],
+    ]
+    assert _multipart_field_value(image_requests[3], "collectionUuid") == "collection-uuid-secret"
+    assert _multipart_field_value(image_requests[3], "imageUuid") == "image-1-1-secret"
 
 
 @pytest.mark.anyio
-async def test_publish_to_slowpics_delete_after_upload_deletes_files_on_success(
-    screenshot_dir: Path,
+async def test_publish_to_slowpics_metadata_response_count_mismatch_fails_before_image_upload(
+    tmp_path: Path,
     async_client: httpx.AsyncClient,
-    mock_slowpics_success,
-):
-    config = SlowpicsConfig(delete_after_upload=True)
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=2, cols=2)
+    respx_mock.get("https://slow.pics/comparison").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Set-Cookie": "XSRF-TOKEN=token; Domain=.slow.pics; Path=/"},
+        )
+    )
+    respx_mock.post("https://slow.pics/upload/comparison").mock(
+        return_value=httpx.Response(200, json=_metadata_payload(rows=1, cols=2))
+    )
+    image_route = respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(
+        return_value=httpx.Response(200)
+    )
 
-    await publish_to_slowpics(screenshot_dir, config, async_client)
+    with pytest.raises(SlowpicsError, match="Invalid metadata response"):
+        await publish_to_slowpics(
+            tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
+        )
 
-    # Check files are gone
-    assert not any(screenshot_dir.glob("*.png"))
+    assert image_route.call_count == 0
 
 
 @pytest.mark.anyio
-async def test_publish_to_slowpics_delete_after_upload_does_not_delete_on_error(
-    screenshot_dir: Path,
+async def test_publish_to_slowpics_returned_url_falls_back_to_key(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    respx_mock.get("https://slow.pics/comparison").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Set-Cookie": "XSRF-TOKEN=token; Domain=.slow.pics; Path=/"},
+        )
+    )
+    respx_mock.post("https://slow.pics/upload/comparison").mock(
+        return_value=httpx.Response(
+            200, json=_metadata_payload(rows=1, cols=1, first_comparison_key=None)
+        )
+    )
+    respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(
+        return_value=httpx.Response(200)
+    )
+
+    result = await publish_to_slowpics(
+        tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
+    )
+
+    assert result.url == "https://slow.pics/c/collection-key"
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_does_not_request_legacy_api_endpoint(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    _mock_successful_browser_flow(respx_mock, rows=1, cols=1)
+    legacy_route = respx_mock.post("https://slow.pics/api/comparison").mock(
+        return_value=httpx.Response(500)
+    )
+
+    await publish_to_slowpics(
+        tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
+    )
+
+    assert legacy_route.call_count == 0
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_missing_xsrf_token_fails_before_metadata_post(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    respx_mock.get("https://slow.pics/comparison").mock(return_value=httpx.Response(200))
+    metadata_route = respx_mock.post("https://slow.pics/upload/comparison").mock(
+        return_value=httpx.Response(200, json=_metadata_payload(rows=1, cols=1))
+    )
+
+    with pytest.raises(SlowpicsError, match="Missing slow.pics XSRF token"):
+        await publish_to_slowpics(
+            tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
+        )
+
+    assert metadata_route.call_count == 0
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_malformed_metadata_response_fails_before_image_upload(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    respx_mock.get("https://slow.pics/comparison").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Set-Cookie": "XSRF-TOKEN=token; Domain=.slow.pics; Path=/"},
+        )
+    )
+    respx_mock.post("https://slow.pics/upload/comparison").mock(
+        return_value=httpx.Response(200, text="not json")
+    )
+    image_route = respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(
+        return_value=httpx.Response(200)
+    )
+
+    with pytest.raises(SlowpicsError, match="Invalid metadata response"):
+        await publish_to_slowpics(
+            tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
+        )
+
+    assert image_route.call_count == 0
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_partial_image_failure_does_not_delete_files(
+    tmp_path: Path,
     async_client: httpx.AsyncClient,
     respx_mock,
     mock_sleep,
     mock_jitter,
-):
-    # Setup: mock 503 to trigger SlowpicsUnavailableError after retries
-    respx_mock.post("https://slow.pics/api/comparison").mock(return_value=httpx.Response(503))
-    config = SlowpicsConfig(delete_after_upload=True, max_retries=1)
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=2)
+    files = upload_plan.file_paths
+    _mock_successful_browser_flow(respx_mock, rows=1, cols=2)
+    respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(
+        return_value=httpx.Response(200)
+    )
+    respx_mock.post("https://slow.pics/upload/image/image-0-1-secret").mock(
+        return_value=httpx.Response(503)
+    )
 
-    # Act + Assert exception
     with pytest.raises(SlowpicsUnavailableError):
-        await publish_to_slowpics(screenshot_dir, config, async_client)
+        await publish_to_slowpics(
+            tmp_path / "screenshots",
+            SlowpicsConfig(delete_after_upload=True, max_retries=1),
+            async_client,
+            upload_plan=upload_plan,
+        )
 
-    # Assert files remain after exception
-    assert len(list(screenshot_dir.glob("*.png"))) == 2
+    assert all(path.exists() for path in files)
+    assert mock_sleep.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_image_is_complete_response_is_success(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    _mock_successful_browser_flow(respx_mock, rows=1, cols=1)
+    respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(
+        return_value=httpx.Response(400, headers={"X-Error-Message": "IMAGE_IS_COMPLETE"})
+    )
+
+    result = await publish_to_slowpics(
+        tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
+    )
+
+    assert result.url == "https://slow.pics/c/first-key"
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_retry_policy_is_step_specific(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+    mock_sleep,
+    mock_jitter,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    comparison_route = respx_mock.get("https://slow.pics/comparison")
+    comparison_route.side_effect = [
+        httpx.Response(503),
+        httpx.Response(
+            200,
+            headers={"Set-Cookie": "XSRF-TOKEN=token; Domain=.slow.pics; Path=/"},
+        ),
+    ]
+    respx_mock.post("https://slow.pics/upload/comparison").mock(
+        return_value=httpx.Response(200, json=_metadata_payload(rows=1, cols=1))
+    )
+    image_route = respx_mock.post("https://slow.pics/upload/image/image-0-0-secret")
+    image_route.side_effect = [httpx.TimeoutException("timeout"), httpx.Response(200)]
+
+    await publish_to_slowpics(
+        tmp_path / "screenshots",
+        SlowpicsConfig(max_retries=1),
+        async_client,
+        upload_plan=upload_plan,
+    )
+
+    assert comparison_route.call_count == 2
+    assert image_route.call_count == 2
+    assert mock_sleep.await_count == 2
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "metadata_error",
+    [
+        httpx.TimeoutException("timeout with token-secret"),
+        httpx.ConnectError("connect failed with browser-secret"),
+    ],
+)
+async def test_publish_to_slowpics_metadata_timeout_and_request_error_do_not_retry(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+    mock_sleep,
+    metadata_error: Exception,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    respx_mock.get("https://slow.pics/comparison").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Set-Cookie": "XSRF-TOKEN=token-secret; Domain=.slow.pics; Path=/"},
+        )
+    )
+    metadata_route = respx_mock.post("https://slow.pics/upload/comparison").mock(
+        side_effect=metadata_error
+    )
+
+    with pytest.raises(SlowpicsError) as exc:
+        await publish_to_slowpics(
+            tmp_path / "screenshots",
+            SlowpicsConfig(max_retries=3),
+            async_client,
+            upload_plan=upload_plan,
+        )
+
+    assert "remote slow.pics state is unknown" in str(exc.value)
+    assert "token-secret" not in str(exc.value)
+    assert "browser-secret" not in str(exc.value)
+    assert metadata_route.call_count == 1
+    assert mock_sleep.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_metadata_retries_response_rate_limit(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+    mock_sleep,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    retry_at = datetime.now(UTC) + timedelta(seconds=120)
+    respx_mock.get("https://slow.pics/comparison").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Set-Cookie": "XSRF-TOKEN=token; Domain=.slow.pics; Path=/"},
+        )
+    )
+    metadata_route = respx_mock.post("https://slow.pics/upload/comparison")
+    metadata_route.side_effect = [
+        httpx.Response(429, headers={"Retry-After": format_datetime(retry_at)}),
+        httpx.Response(200, json=_metadata_payload(rows=1, cols=1)),
+    ]
+    respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(
+        return_value=httpx.Response(200)
+    )
+
+    result = await publish_to_slowpics(
+        tmp_path / "screenshots",
+        SlowpicsConfig(max_retries=1),
+        async_client,
+        upload_plan=upload_plan,
+    )
+
+    assert result.url == "https://slow.pics/c/first-key"
+    assert metadata_route.call_count == 2
+    mock_sleep.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_metadata_retries_response_server_error(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+    mock_sleep,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    respx_mock.get("https://slow.pics/comparison").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Set-Cookie": "XSRF-TOKEN=token; Domain=.slow.pics; Path=/"},
+        )
+    )
+    metadata_route = respx_mock.post("https://slow.pics/upload/comparison")
+    metadata_route.side_effect = [
+        httpx.Response(503),
+        httpx.Response(200, json=_metadata_payload(rows=1, cols=1)),
+    ]
+    respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(
+        return_value=httpx.Response(200)
+    )
+
+    result = await publish_to_slowpics(
+        tmp_path / "screenshots",
+        SlowpicsConfig(max_retries=1),
+        async_client,
+        upload_plan=upload_plan,
+    )
+
+    assert result.url == "https://slow.pics/c/first-key"
+    assert metadata_route.call_count == 2
+    assert mock_sleep.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_does_not_delete_local_files_after_upload(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=2)
+    stale = _png(tmp_path / "screenshots" / "stale.png")
+    requests: list[httpx.Request] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/comparison":
+            return httpx.Response(
+                200,
+                headers={"Set-Cookie": "XSRF-TOKEN=token; Domain=.slow.pics; Path=/"},
+            )
+        if request.url.path == "/upload/comparison":
+            assert all(path.exists() for path in upload_plan.file_paths)
+            return httpx.Response(200, json=_metadata_payload(rows=1, cols=2))
+        assert all(path.exists() for path in upload_plan.file_paths)
+        return httpx.Response(200)
+
+    respx_mock.get("https://slow.pics/comparison").mock(side_effect=capture)
+    respx_mock.post("https://slow.pics/upload/comparison").mock(side_effect=capture)
+    respx_mock.post("https://slow.pics/upload/image/image-0-0-secret").mock(side_effect=capture)
+    respx_mock.post("https://slow.pics/upload/image/image-0-1-secret").mock(side_effect=capture)
+
+    await publish_to_slowpics(
+        tmp_path / "screenshots",
+        SlowpicsConfig(delete_after_upload=True),
+        async_client,
+        upload_plan=upload_plan,
+    )
+
+    assert all(path.exists() for path in upload_plan.file_paths)
+    assert stale.exists()
+    assert _multipart_field_value(requests[1], "removeAfter") == ""
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_sensitive_values_redacted_from_exceptions(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    respx_mock.get("https://slow.pics/comparison").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Set-Cookie": "XSRF-TOKEN=xsrf-secret; Domain=.slow.pics; Path=/"},
+        )
+    )
+    respx_mock.post("https://slow.pics/upload/comparison").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "key": "private-key-secret",
+                "firstComparisonKey": "first-key-secret",
+                "collectionUuid": "collection-uuid-secret",
+                "images": [["image-uuid-secret"]],
+            },
+        )
+    )
+    respx_mock.post("https://slow.pics/upload/image/image-uuid-secret").mock(
+        return_value=httpx.Response(
+            400,
+            text=(
+                "raw body xsrf-secret browser-secret collection-uuid-secret "
+                "image-uuid-secret private-key-secret https://webhook.example/path"
+            ),
+        )
+    )
+
+    with pytest.raises(SlowpicsError) as exc:
+        await publish_to_slowpics(
+            tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
+        )
+
+    message = str(exc.value)
+    assert "status 400" in message
+    assert "xsrf-secret" not in message
+    assert "browser-secret" not in message
+    assert "collection-uuid-secret" not in message
+    assert "image-uuid-secret" not in message
+    assert "private-key-secret" not in message
+    assert "webhook.example" not in message
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_empty_plan_raises_error(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+) -> None:
+    with pytest.raises(SlowpicsError, match="No PNG files found"):
+        await publish_to_slowpics(
+            tmp_path / "screenshots",
+            SlowpicsConfig(),
+            async_client,
+            upload_plan=SlowpicsUploadPlan(rows=()),
+        )
+
+
+@pytest.mark.anyio
+async def test_publish_to_slowpics_rejects_missing_planned_file_before_request(
+    tmp_path: Path,
+    async_client: httpx.AsyncClient,
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    upload_plan.file_paths[0].unlink()
+    route = respx_mock.get("https://slow.pics/comparison").mock(return_value=httpx.Response(200))
+
+    with pytest.raises(SlowpicsError, match="planned for slow.pics upload is missing"):
+        await publish_to_slowpics(
+            tmp_path / "screenshots", SlowpicsConfig(), async_client, upload_plan=upload_plan
+        )
+
+    assert route.call_count == 0
 
 
 @pytest.mark.anyio
 async def test_slowpics_publisher_upload_returns_url(
-    screenshot_dir: Path,
+    tmp_path: Path,
     async_client: httpx.AsyncClient,
-    mock_slowpics_success,
-):
-    config = SlowpicsConfig()
-    publisher = SlowpicsPublisher(config, async_client)
-    files = sorted(screenshot_dir.glob("*.png"))
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    _mock_successful_browser_flow(respx_mock, rows=1, cols=1)
+    publisher = SlowpicsPublisher(SlowpicsConfig(), async_client)
 
-    url = await publisher.upload(files)
-    assert url == "https://slow.pics/c/abc123"
+    url = await publisher.upload(upload_plan)
+
+    assert url == "https://slow.pics/c/first-key"
 
 
 @pytest.mark.anyio
 async def test_slowpics_publisher_does_not_own_client(
-    screenshot_dir: Path,
-    mock_slowpics_success,
-):
-    config = SlowpicsConfig()
+    tmp_path: Path,
+    respx_mock,
+) -> None:
+    upload_plan = _plan(tmp_path, rows=1, cols=1)
+    _mock_successful_browser_flow(respx_mock, rows=1, cols=1)
+
     async with httpx.AsyncClient() as client:
-        publisher = SlowpicsPublisher(config, client)
-        await publisher.upload(sorted(screenshot_dir.glob("*.png")))
-        # Client should still be open
+        publisher = SlowpicsPublisher(SlowpicsConfig(), client)
+        await publisher.upload(upload_plan)
         assert not client.is_closed

--- a/tests/services/test_report.py
+++ b/tests/services/test_report.py
@@ -509,12 +509,12 @@ def test_frame_detail_for_source_frame_uses_explicit_selection_detail() -> None:
 
     assert detail == FrameDetail(
         label="Opening comparison",
-        detail="Source frame 42 (00:00:01.750)",
+        detail="Source frame 42",
         category="chapter",
     )
 
 
-def test_frame_detail_for_source_frame_uses_breakdown_label_when_detail_absent() -> None:
+def test_frame_detail_for_source_frame_uses_frame_number_label_when_detail_absent() -> None:
     detail = frame_detail_for_source_frame(
         source_frame=42,
         selection_detail=None,
@@ -522,13 +522,13 @@ def test_frame_detail_for_source_frame_uses_breakdown_label_when_detail_absent()
     )
 
     assert detail == FrameDetail(
-        label="Bright",
+        label="Frame 42",
         detail="Source frame 42",
         category="quantile_bright",
     )
 
 
-def test_frame_detail_for_source_frame_uses_breakdown_label_when_detail_label_absent() -> None:
+def test_frame_detail_for_source_frame_uses_frame_number_label_when_detail_label_absent() -> None:
     detail = frame_detail_for_source_frame(
         source_frame=42,
         selection_detail=SourceFrameSelectionDetail(
@@ -540,9 +540,27 @@ def test_frame_detail_for_source_frame_uses_breakdown_label_when_detail_label_ab
     )
 
     assert detail == FrameDetail(
-        label="Bright",
-        detail="Source frame 42 (00:00:01.750)",
+        label="Frame 42",
+        detail="Source frame 42",
         category="quantile_bright",
+    )
+
+
+def test_frame_detail_for_source_frame_uses_frame_number_when_label_matches_category() -> None:
+    detail = frame_detail_for_source_frame(
+        source_frame=42,
+        selection_detail=SourceFrameSelectionDetail(
+            label="Motion",
+            timecode="00:00:01.750",
+            notes="motion",
+        ),
+        selection_label="Motion",
+    )
+
+    assert detail == FrameDetail(
+        label="Frame 42",
+        detail="Source frame 42",
+        category="motion",
     )
 
 

--- a/tests/services/test_report.py
+++ b/tests/services/test_report.py
@@ -12,6 +12,11 @@ from pytest_mock import MockerFixture
 
 from frame_compare.config.schema import ReportConfig, ViewerMode
 from frame_compare.services.errors import ReportError
+from frame_compare.services.report.category_display import (
+    humanize_category,
+    label_repeats_category,
+    normalized_display_token,
+)
 from frame_compare.services.report.display import (
     SourceFrameSelectionDetail,
     frame_detail_for_source_frame,
@@ -90,6 +95,58 @@ def _json_payload_from_report(path: Path) -> ReportPayload:
     start = content.find(marker) + len(marker)
     end = content.find("</script>", start)
     return json.loads(content[start:end])
+
+
+@pytest.mark.parametrize(
+    ("category", "expected"),
+    [
+        ("quantile_bright", "Bright"),
+        ("quantile_dark", "Dark"),
+        ("scene-cut", "Scene Cuts"),
+        ("scene_cut", "Scene Cuts"),
+        ("selected", "Selected"),
+        ("user_override", "User Override"),
+        (None, None),
+    ],
+)
+def test_humanize_category_maps_known_and_dynamic_categories(
+    category: str | None, expected: str | None
+) -> None:
+    assert humanize_category(category) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Scene Cuts", "scene cuts"),
+        ("scene_cut", "scene cut"),
+        ("  User---Override  ", "user override"),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_normalized_display_token_compares_display_equivalent_text(
+    value: str | None, expected: str | None
+) -> None:
+    assert normalized_display_token(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("label", "category", "expected"),
+    [
+        ("Bright", "quantile_bright", True),
+        ("Scene Cuts", "scene_cut", True),
+        ("scene cuts", "scene-cut", True),
+        ("Frame 42", "quantile_bright", False),
+        (None, "selected", False),
+        ("", "selected", False),
+        ("Selected", None, False),
+    ],
+)
+def test_label_repeats_category_uses_humanized_category_text(
+    label: str | None, category: str | None, expected: bool
+) -> None:
+    assert label_repeats_category(label, category) is expected
 
 
 def test_generate_report_creates_html_file(report_data: ReportData, tmp_path: Path) -> None:

--- a/tests/services/test_report_renderer.py
+++ b/tests/services/test_report_renderer.py
@@ -358,6 +358,7 @@ def test_build_html_renders_mode_aware_clip_controls(report_payload: ReportPaylo
     assert 'data-control-scope="pair" aria-label="Comparison pair"' in html
     assert 'data-control-scope="active" aria-label="Overlay clip" hidden' in html
     assert 'id="left-select" aria-label="Left clip"' in html
+    assert 'id="btn-swap-clips" class="rv-swap-button"' in html
     assert 'id="right-select" aria-label="Right clip"' in html
     assert 'id="active-select" aria-label="Overlay clip"' in html
 
@@ -404,10 +405,7 @@ def test_build_html_renders_header_metadata(
         "Default Pair": 'REF <main> vs ENC "candidate"',
         "slow.pics": "https://slow.pics/c/abc?x=1&y=2",
     }
-    assert [
-        (clip.label, clip.dynamic_range, clip.fields)
-        for clip in info_modal.clips
-    ] == [
+    assert [(clip.label, clip.dynamic_range, clip.fields) for clip in info_modal.clips] == [
         (
             "REF <main>",
             "SDR",
@@ -443,9 +441,10 @@ def test_build_html_exposes_current_frame_detail_hooks(
 ) -> None:
     html = build_html(report_payload)
 
-    assert 'data-current-frame-label' in html
-    assert 'data-current-frame-detail' in html
-    assert 'data-current-frame-category' in html
+    assert "data-current-frame-label" in html
+    assert "data-current-frame-detail" in html
+    assert "data-current-frame-category-divider" in html
+    assert "data-current-frame-category" in html
 
 
 def test_build_html_renders_empty_viewer_hooks_for_empty_payload(
@@ -466,6 +465,29 @@ def test_build_html_renders_empty_viewer_hooks_for_empty_payload(
     )
     assert '<div class="rv-empty-state" data-empty-state hidden></div>' in html
     assert 'class="rv-filmstrip-item"' not in html
+
+
+def test_build_html_avoids_duplicate_category_labels_when_label_matches_category(
+    report_payload: ReportPayload,
+) -> None:
+    payload: ReportPayload = {
+        **report_payload,
+        "frames": [
+            {
+                "number": 10,
+                "label": "Motion",
+                "detail": "Source frame 10",
+                "category": "motion",
+                "images": report_payload["frames"][0]["images"],
+            },
+        ],
+        "stats": {"frame_count": 1, "clip_count": 2},
+    }
+
+    html = build_html(payload)
+
+    assert '<span class="rv-filmstrip-label">Motion</span>' in html
+    assert "Motion • Motion" not in html
 
 
 def test_build_html_uses_internal_category_keys_for_reserved_category_text(
@@ -554,6 +576,8 @@ def test_build_html_renders_viewport_audit_controls(report_payload: ReportPayloa
     assert 'id="btn-fullscreen"' in html
     assert 'aria-label="Enter fullscreen"' in html
     assert 'aria-pressed="false"' in html
+    assert 'id="btn-overlays"' in html
+    assert 'aria-label="Hide overlays"' in html
 
 
 def test_build_html_renders_keyboard_help_accessibility_hooks(
@@ -565,9 +589,17 @@ def test_build_html_renders_keyboard_help_accessibility_hooks(
         'id="help-modal" class="rv-modal" aria-hidden="true" role="dialog" '
         'aria-modal="true" aria-labelledby="help-modal-title" tabindex="-1"'
     ) in html
-    assert 'id="help-modal-title" class="rv-modal-title">Keyboard Shortcuts</div>' in html
+    assert 'id="help-modal-title" class="rv-modal-title">Viewer Shortcuts</div>' in html
     assert (
-        '<div class="rv-shortcut-row"><span>Reset Viewport</span><span class="rv-key">R</span></div>'
+        '<div class="rv-shortcut-row"><span>Swap Clips</span><span class="rv-key">X</span></div>'
+        in html
+    )
+    assert (
+        '<div class="rv-shortcut-row"><span>Toggle Overlays</span><span class="rv-key">H</span></div>'
+        in html
+    )
+    assert (
+        '<div class="rv-shortcut-row"><span>Reset Viewport</span><span class="rv-key">R / Double-click</span></div>'
         in html
     )
     assert (
@@ -622,7 +654,8 @@ def test_viewer_assets_keep_divider_slider_only_and_pointer_safe() -> None:
     css = get_css()
     js = get_js()
 
-    assert '--font-sans: -apple-system, "BlinkMacSystemFont", "Segoe UI"' in css
+    assert "color-scheme: dark;" in css
+    assert '--font-sans: "Inter", "SF Pro Text", "Segoe UI Variable Text"' in css
     assert ".rv-viewer-stage" in css
     assert "touch-action: none;" in css
     assert "cursor: grab;" in css
@@ -633,11 +666,21 @@ def test_viewer_assets_keep_divider_slider_only_and_pointer_safe() -> None:
     assert "translate(var(--pan-x, 0px), var(--pan-y, 0px)) scale(var(--zoom-level, 1))" in css
     assert ".rv-right { transform: translate(var(--align-x, 0px), var(--align-y, 0px)); }" in css
     assert ".rv-overlay-label:empty { display: none; }" in css
+    assert "select option," in css
+    assert 'background-image: url("data:image/svg+xml,' in css
+    assert "bottom: 16px;" in _css_block(css, ".rv-overlay-label")
+    assert "left: 50%;" in _css_block(css, ".rv-stage-overlay-info")
+    assert "transform: translateX(-50%);" in _css_block(css, ".rv-stage-overlay-info")
 
     assert "leftLabelTxt = `${leftClip.label} (Left)`;" in js
     assert "rightLabelTxt = `${rightClip.label} (Right)`;" in js
+    assert "leftLabelTxt = leftClip.label;" in js
+    assert "rightLabelTxt = rightClip.label;" in js
     assert "leftLabelTxt = activeClip.label;" in js
     assert 'rightLabelTxt = "";' in js
+    assert "this.dom.stage.className = `rv-viewer-stage rv-mode-${mode}`;" not in js
+    assert "this.dom.stage.classList.remove(" in js
+    assert "this.dom.stage.classList.add(`rv-mode-${mode}`);" in js
 
     assert "addEventListener('pointerdown'" in js
     assert "addEventListener('pointermove'" in js
@@ -748,6 +791,7 @@ def test_viewer_assets_wire_report_scoped_viewport_persistence() -> None:
     assert "storage.setItem(this.state.storageKey, JSON.stringify(payload))" in js
     assert "mode: this.state.mode" in js
     assert "panX: this.state.panX" in js
+    assert "overlaysHidden: this.state.overlaysHidden" in js
     assert "alignmentPreset: this.state.alignmentPreset" in js
 
 
@@ -757,11 +801,20 @@ def test_viewer_assets_wire_pan_wheel_zoom_and_alignment_hooks() -> None:
     assert "panX: 0" in js
     assert "panY: 0" in js
     assert "this.dom.stage.addEventListener('wheel'" in js
+    assert "this.dom.stage.addEventListener('dblclick'" in js
     assert "this.zoomAtPoint(e.clientX, e.clientY, e.deltaY < 0 ? 1.1 : 1 / 1.1);" in js
     assert "this.setPan(this.state.panX + dx, this.state.panY + dy, { save: false });" in js
     assert "shouldPanFromPointer" in js
     assert "this.state.mode !== 'slider'" in js
     assert "updateSliderFromPointer(e);" in js
+    assert "pointerPositions: new Map()" in js
+    assert "capturedPointerIds: new Set()" in js
+    assert "pinchStartDistance: 0" in js
+    assert "trackedTouchPointers()" in js
+    assert "Math.hypot(dx, dy)" in js
+    assert "startPinchFromTrackedPointers()" in js
+    assert "updatePinchFromTrackedPointers()" in js
+    assert "finishPinchInteraction()" in js
     assert "this.dom.stage.classList.add('is-panning');" in js
     assert "this.dom.canvas.style.setProperty('--pan-x', `${this.state.panX}px`);" in js
     assert "alignmentPreset: 'none'" in js
@@ -792,6 +845,7 @@ def test_viewer_assets_keep_overlay_and_blink_clip_semantics() -> None:
     assert "this.dom.pairControls.hidden = isOverlay;" in js
     assert "this.dom.activeControls.hidden = !isOverlay;" in js
     assert "this.dom.leftSelect.disabled = isOverlay;" in js
+    assert "this.dom.btnSwapClips.disabled = isOverlay || this.clipCount() <= 1;" in js
     assert "this.dom.activeSelect.disabled = !isOverlay;" in js
     assert "this.dom.leftSelect.setAttribute('aria-label', 'Base clip');" in js
     assert "this.dom.rightSelect.setAttribute('aria-label', 'Compare clip');" in js
@@ -800,6 +854,11 @@ def test_viewer_assets_keep_overlay_and_blink_clip_semantics() -> None:
     assert "this.state.activeClipIdx === this.state.leftClipIdx" in js
     assert "? this.state.rightClipIdx" in js
     assert ": this.state.leftClipIdx" in js
+    assert (
+        "this.state.mode === 'slider' || this.state.mode === 'diff' || this.state.mode === 'blink'"
+        in js
+    )
+    assert "isBlink && this.state.activeClipIdx === this.state.rightClipIdx" in js
     assert "(this.state.activeClipIdx + 1) % this.state.data.clips.length" not in js
     assert "this.state.mode === 'diff' || this.state.mode === 'blink'" in js
 
@@ -809,6 +868,8 @@ def test_viewer_assets_wire_category_filtering_and_visible_navigation() -> None:
     js = get_js()
 
     assert ".rv-filter-chip.active" in css
+    assert ".rv-filter-chip::before" in css
+    assert "--category-accent: var(--accent);" in css
     assert "display: none;" in _css_block(css, ".rv-filmstrip-item[hidden]")
     assert ".rv-filmstrip-caption" in css
     assert ".rv-category-badge" in css
@@ -836,6 +897,7 @@ def test_viewer_assets_wire_metadata_and_error_empty_state_hooks() -> None:
     js = get_js()
 
     assert ".rv-stage-overlay-info" in css
+    assert ".rv-viewer-stage.rv-overlays-hidden .rv-overlay-label" in css
     assert ".rv-align-popover" in css
     assert '.rv-status[data-tone="error"]' in css
     assert '.rv-status[data-tone="warning"]' in css
@@ -853,8 +915,23 @@ def test_viewer_assets_wire_metadata_and_error_empty_state_hooks() -> None:
     assert "hasRenderableData()" in js
     assert "updateCurrentFrameMetadata(frameData)" in js
     assert "document.querySelector('[data-current-frame-detail]')" in js
+    assert "normalizedDisplayToken(value)" in js
+    assert "this.dom.currentFrameCategoryDivider.hidden = !showCategory;" in js
     assert "Selected frame image data is unavailable." in js
     assert "Report viewer markup is incomplete." in js
+
+
+def test_viewer_assets_toggle_overlays_and_keep_split_pairs_distinct() -> None:
+    js = get_js()
+
+    assert "setOverlaysHidden(hidden, options = {})" in js
+    assert "updateOverlayVisibility()" in js
+    assert "this.dom.btnOverlays.addEventListener('click'" in js
+    assert "case 'h': case 'H': this.setOverlaysHidden(!this.state.overlaysHidden); break;" in js
+    assert "case 'x': case 'X': this.swapPairClips(); break;" in js
+    assert "ensureDistinctPairSelection(mode = this.state.mode)" in js
+    assert "nextDistinctClipIndex(startIdx, excludedIdx, direction = 1)" in js
+    assert "this.state.rightClipIdx = this.nextDistinctClipIndex(" in js
 
 
 def test_viewer_assets_preload_adjacent_visible_frames_and_active_clips() -> None:

--- a/tests/services/test_report_renderer.py
+++ b/tests/services/test_report_renderer.py
@@ -216,6 +216,15 @@ def test_build_html_renders_header_metadata(
 
     assert "Generated 2026-05-22T12:00:00+00:00 • 2 frames • 2 clips" in html
     assert '<button id="btn-help" class="rv-header-help-btn" aria-label="Keyboard shortcuts" title="Help (?)">?</button>' in html
+    assert '<button id="btn-info" class="rv-header-info-btn" aria-label="Report information" title="Report Info (I)">ℹ</button>' in html
+    assert 'id="info-modal" class="rv-modal" aria-hidden="true" role="dialog"' in html
+    assert '<div id="info-modal-title" class="rv-modal-title">Report Information</div>' in html
+    assert '<h3>General</h3>' in html
+    assert '<h3>Clips</h3>' in html
+    assert '<dt>Resolution</dt><dd>1920x1080</dd>' in html
+    assert '<dt>FPS</dt><dd>24 fps</dd>' in html
+    assert '<dt>Frames</dt><dd>100</dd>' in html
+
 
 
 def test_build_html_exposes_current_frame_detail_hooks(

--- a/tests/services/test_report_renderer.py
+++ b/tests/services/test_report_renderer.py
@@ -25,6 +25,22 @@ class _ParsedSelect:
     options: list[_ParsedOption] = field(default_factory=list)
 
 
+@dataclass
+class _ParsedClipMetadata:
+    label: str = ""
+    dynamic_range: str = ""
+    fields: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class _ParsedInfoModal:
+    attrs: dict[str, str | None]
+    section_headings: list[str] = field(default_factory=list)
+    general: dict[str, str] = field(default_factory=dict)
+    links: dict[str, str] = field(default_factory=dict)
+    clips: list[_ParsedClipMetadata] = field(default_factory=list)
+
+
 class _SelectParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
@@ -61,6 +77,153 @@ class _SelectParser(HTMLParser):
             self._current_option_text = []
         elif tag == "select":
             self._current_select_id = None
+
+
+class _StartTagParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.by_id: dict[str, tuple[str, dict[str, str | None]]] = {}
+        self.tags_with_style: list[tuple[str, dict[str, str | None]]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = dict(attrs)
+        element_id = attr_map.get("id")
+        if element_id is not None:
+            self.by_id[element_id] = (tag, attr_map)
+        if "style" in attr_map:
+            self.tags_with_style.append((tag, attr_map))
+
+
+class _InfoModalParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.modal: _ParsedInfoModal | None = None
+        self._in_info_modal = False
+        self._info_div_depth = 0
+        self._capture_kind: str | None = None
+        self._capture_text: list[str] = []
+        self._current_term: str | None = None
+        self._current_clip: _ParsedClipMetadata | None = None
+        self._in_clip_heading = False
+        self._clip_heading_parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = dict(attrs)
+        if not self._in_info_modal and tag == "div" and attr_map.get("id") == "info-modal":
+            self._in_info_modal = True
+            self._info_div_depth = 1
+            self.modal = _ParsedInfoModal(attrs=attr_map)
+            return
+        if not self._in_info_modal:
+            return
+
+        classes = set((attr_map.get("class") or "").split())
+        if tag == "div":
+            self._info_div_depth += 1
+            if "rv-clip-meta-heading" in classes:
+                self._in_clip_heading = True
+                self._clip_heading_parts = []
+        elif tag == "li" and "rv-clip-meta-item" in classes:
+            self._current_clip = _ParsedClipMetadata()
+        elif tag == "h3":
+            self._start_capture("section")
+        elif tag == "dt":
+            self._start_capture("term")
+        elif tag == "dd":
+            self._start_capture("definition")
+        elif tag == "span" and self._in_clip_heading:
+            self._start_capture("clip-heading")
+        elif tag == "a" and self._capture_kind == "definition" and self._current_term is not None:
+            href = attr_map.get("href")
+            if href is not None and self.modal is not None:
+                self.modal.links[self._current_term] = href
+
+    def handle_data(self, data: str) -> None:
+        if self._capture_kind is not None:
+            self._capture_text.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if not self._in_info_modal:
+            return
+
+        if tag == "h3" and self._capture_kind == "section":
+            if self.modal is not None:
+                self.modal.section_headings.append(_normalize_text(self._capture_text))
+            self._stop_capture()
+        elif tag == "dt" and self._capture_kind == "term":
+            self._current_term = _normalize_text(self._capture_text)
+            self._stop_capture()
+        elif tag == "dd" and self._capture_kind == "definition":
+            definition = _normalize_text(self._capture_text)
+            self._store_definition(definition)
+            self._current_term = None
+            self._stop_capture()
+        elif tag == "span" and self._capture_kind == "clip-heading":
+            self._clip_heading_parts.append(_normalize_text(self._capture_text))
+            self._stop_capture()
+        elif tag == "li" and self._current_clip is not None:
+            if self.modal is not None:
+                self.modal.clips.append(self._current_clip)
+            self._current_clip = None
+        elif tag == "div":
+            if self._in_clip_heading:
+                self._in_clip_heading = False
+                if self._current_clip is not None:
+                    if self._clip_heading_parts:
+                        self._current_clip.label = self._clip_heading_parts[0]
+                    if len(self._clip_heading_parts) > 1:
+                        self._current_clip.dynamic_range = self._clip_heading_parts[1]
+            self._info_div_depth -= 1
+            if self._info_div_depth == 0:
+                self._in_info_modal = False
+
+    def _start_capture(self, kind: str) -> None:
+        self._capture_kind = kind
+        self._capture_text = []
+
+    def _stop_capture(self) -> None:
+        self._capture_kind = None
+        self._capture_text = []
+
+    def _store_definition(self, definition: str) -> None:
+        if self._current_term is None or self.modal is None:
+            return
+        if self._current_clip is not None:
+            self._current_clip.fields[self._current_term] = definition
+            return
+        self.modal.general[self._current_term] = definition
+
+
+def _normalize_text(parts: list[str]) -> str:
+    return " ".join("".join(parts).split())
+
+
+def _parse_start_tags(html: str) -> _StartTagParser:
+    parser = _StartTagParser()
+    parser.feed(html)
+    return parser
+
+
+def _parse_info_modal(html: str) -> _ParsedInfoModal:
+    parser = _InfoModalParser()
+    parser.feed(html)
+    assert parser.modal is not None
+    return parser.modal
+
+
+def _css_block(css: str, selector: str) -> str:
+    selector_start = css.index(selector)
+    block_start = css.index("{", selector_start)
+    depth = 0
+    for idx in range(block_start, len(css)):
+        char = css[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return css[block_start + 1 : idx]
+    raise AssertionError(f"Unterminated CSS block for selector: {selector}")
 
 
 @pytest.fixture
@@ -132,24 +295,32 @@ def _script_payload(html: str) -> ReportPayload:
 
 def test_build_html_renders_only_safe_slowpics_links(report_payload: ReportPayload) -> None:
     html = build_html(report_payload)
+    info_modal = _parse_info_modal(html)
 
     assert 'href="https://slow.pics/c/abc?x=1&amp;y=2"' in html
     assert 'target="_blank"' in html
     assert 'rel="noopener noreferrer"' in html
     assert "View on slow.pics" in html
+    assert info_modal.links["slow.pics"] == "https://slow.pics/c/abc?x=1&y=2"
+    assert info_modal.general["slow.pics"] == "https://slow.pics/c/abc?x=1&y=2"
 
     unsafe_payload: ReportPayload = {**report_payload, "slowpics_url": "javascript:alert(1)"}
     unsafe_html = build_html(unsafe_payload)
+    unsafe_info_modal = _parse_info_modal(unsafe_html)
 
     assert "javascript:alert(1)" in unsafe_html
     assert 'href="javascript:alert(1)"' not in unsafe_html
     assert "View on slow.pics" not in unsafe_html
+    assert "slow.pics" not in unsafe_info_modal.links
+    assert unsafe_info_modal.general["slow.pics"] == "javascript:alert(1)"
 
     no_upload_payload: ReportPayload = {**report_payload, "slowpics_url": None}
     no_upload_html = build_html(no_upload_payload)
+    no_upload_info_modal = _parse_info_modal(no_upload_html)
 
     assert "View on slow.pics" not in no_upload_html
     assert 'class="rv-link"' not in no_upload_html
+    assert no_upload_info_modal.general["slow.pics"] == "Not uploaded"
 
 
 def test_build_html_renders_frame_and_clip_selectors(report_payload: ReportPayload) -> None:
@@ -213,18 +384,58 @@ def test_build_html_renders_header_metadata(
     report_payload: ReportPayload,
 ) -> None:
     html = build_html(report_payload)
+    tags = _parse_start_tags(html)
+    info_modal = _parse_info_modal(html)
 
     assert "Generated 2026-05-22T12:00:00+00:00 • 2 frames • 2 clips" in html
-    assert '<button id="btn-help" class="rv-header-help-btn" aria-label="Keyboard shortcuts" title="Help (?)">?</button>' in html
-    assert '<button id="btn-info" class="rv-header-info-btn" aria-label="Report information" title="Report Info (I)">ℹ</button>' in html
-    assert 'id="info-modal" class="rv-modal" aria-hidden="true" role="dialog"' in html
-    assert '<div id="info-modal-title" class="rv-modal-title">Report Information</div>' in html
-    assert '<h3>General</h3>' in html
-    assert '<h3>Clips</h3>' in html
-    assert '<dt>Resolution</dt><dd>1920x1080</dd>' in html
-    assert '<dt>FPS</dt><dd>24 fps</dd>' in html
-    assert '<dt>Frames</dt><dd>100</dd>' in html
+    assert tags.by_id["btn-help"][1]["class"] == "rv-header-help-btn"
+    assert tags.by_id["btn-info"][1]["class"] == "rv-header-info-btn"
+    assert info_modal.attrs["class"] == "rv-modal"
+    assert info_modal.attrs["aria-hidden"] == "true"
+    assert info_modal.attrs["role"] == "dialog"
+    assert info_modal.section_headings == ["General", "Clips"]
+    assert info_modal.general == {
+        "Title": "Renderer Contract",
+        "Report ID": "report_0123456789abcdef0123456789abcdef",
+        "Generated": "2026-05-22T12:00:00+00:00",
+        "Frames": "2",
+        "Clips": "2",
+        "Default Mode": "slider",
+        "Default Pair": 'REF <main> vs ENC "candidate"',
+        "slow.pics": "https://slow.pics/c/abc?x=1&y=2",
+    }
+    assert [
+        (clip.label, clip.dynamic_range, clip.fields)
+        for clip in info_modal.clips
+    ] == [
+        (
+            "REF <main>",
+            "SDR",
+            {
+                "Name": "reference",
+                "Resolution": "1920x1080",
+                "FPS": "24 fps",
+                "Frames": "100",
+            },
+        ),
+        (
+            'ENC "candidate"',
+            "HDR",
+            {
+                "Name": "encode",
+                "Resolution": "1920x1080",
+                "FPS": "24 fps",
+                "Frames": "100",
+            },
+        ),
+    ]
 
+
+def test_build_html_avoids_inline_styles(report_payload: ReportPayload) -> None:
+    html = build_html(report_payload)
+    tags = _parse_start_tags(html)
+
+    assert tags.tags_with_style == []
 
 
 def test_build_html_exposes_current_frame_detail_hooks(
@@ -415,9 +626,9 @@ def test_viewer_assets_keep_divider_slider_only_and_pointer_safe() -> None:
     assert ".rv-viewer-stage" in css
     assert "touch-action: none;" in css
     assert "cursor: grab;" in css
-    assert ".rv-viewer-stage.is-panning { cursor: grabbing; }" in css
-    assert ".rv-divider {\n    display: none;" in css
-    assert ".rv-mode-slider .rv-divider { display: block; }" in css
+    assert "cursor: grabbing;" in _css_block(css, ".rv-viewer-stage.is-panning")
+    assert "display: none;" in _css_block(css, ".rv-divider")
+    assert "display: block;" in _css_block(css, ".rv-mode-slider .rv-divider")
     assert ".rv-viewer-stage:fullscreen" in css
     assert "translate(var(--pan-x, 0px), var(--pan-y, 0px)) scale(var(--zoom-level, 1))" in css
     assert ".rv-right { transform: translate(var(--align-x, 0px), var(--align-y, 0px)); }" in css
@@ -484,6 +695,7 @@ def test_viewer_assets_manage_help_focus_and_escape_semantics() -> None:
     js = get_js()
 
     assert "helpRestoreFocus: null" in js
+    assert "infoRestoreFocus: null" in js
     assert "openHelpModal()" in js
     assert "this.state.helpRestoreFocus = activeElement" in js
     assert "closeHelpModal(options = {})" in js
@@ -494,6 +706,10 @@ def test_viewer_assets_manage_help_focus_and_escape_semantics() -> None:
     assert "this.closeHelpModal();" in js
     assert "document.exitFullscreen?.();" in js
     assert "this.openHelpModal();" in js
+    assert "openInfoModal()" in js
+    assert "handleInfoModalKey(e)" in js
+    assert "this.state.infoRestoreFocus = activeElement" in js
+    assert "this.closeInfoModal();" in js
 
 
 def test_viewer_assets_stop_modal_escape_before_document_fullscreen_handler() -> None:
@@ -507,6 +723,18 @@ def test_viewer_assets_stop_modal_escape_before_document_fullscreen_handler() ->
         }"""
 
     assert modal_escape_guard in js
+
+
+def test_viewer_assets_close_alignment_popover_before_global_escape_and_shortcuts() -> None:
+    js = get_js()
+
+    assert "isAlignmentPopoverOpen()" in js
+    assert "setAlignmentPopoverOpen(isOpen, options = {})" in js
+    assert "this.closeAlignmentPopover({ restoreFocus: false });" in js
+    assert "e.stopPropagation();" in js
+    assert "if (this.isAlignmentPopoverOpen()) {" in js
+    assert "this.closeAlignmentPopover();" in js
+    assert "if (this.isAlignmentPopoverOpen()) return;" in js
 
 
 def test_viewer_assets_wire_report_scoped_viewport_persistence() -> None:
@@ -556,7 +784,7 @@ def test_viewer_assets_keep_overlay_and_blink_clip_semantics() -> None:
     css = get_css()
     js = get_js()
 
-    assert ".rv-control-group[hidden] { display: none; }" in css
+    assert "display: none;" in _css_block(css, ".rv-control-group[hidden]")
     assert "const selection = this.state.data.default_selection || {};" in js
     assert "this.state.leftClipIdx = left;" in js
     assert "this.state.rightClipIdx = right;" in js
@@ -581,7 +809,7 @@ def test_viewer_assets_wire_category_filtering_and_visible_navigation() -> None:
     js = get_js()
 
     assert ".rv-filter-chip.active" in css
-    assert ".rv-filmstrip-item[hidden] { display: none; }" in css
+    assert "display: none;" in _css_block(css, ".rv-filmstrip-item[hidden]")
     assert ".rv-filmstrip-caption" in css
     assert ".rv-category-badge" in css
 
@@ -611,7 +839,10 @@ def test_viewer_assets_wire_metadata_and_error_empty_state_hooks() -> None:
     assert ".rv-align-popover" in css
     assert '.rv-status[data-tone="error"]' in css
     assert '.rv-status[data-tone="warning"]' in css
-    assert ".rv-empty-state[hidden] { display: none; }" in css
+    assert "display: none;" in _css_block(css, ".rv-empty-state[hidden]")
+    assert ".rv-modal-content--wide" in css
+    assert ".rv-modal-actions" in css
+    assert ".rv-zoom-value" in css
 
     assert "readPayload()" in js
     assert "normalizePayload(payload)" in js
@@ -621,7 +852,6 @@ def test_viewer_assets_wire_metadata_and_error_empty_state_hooks() -> None:
     assert "if (control === this.dom.btnHelp) return;" in js
     assert "hasRenderableData()" in js
     assert "updateCurrentFrameMetadata(frameData)" in js
-    assert "document.querySelector('[data-current-frame-summary]')" in js
     assert "document.querySelector('[data-current-frame-detail]')" in js
     assert "Selected frame image data is unavailable." in js
     assert "Report viewer markup is incomplete." in js

--- a/tests/services/test_report_renderer.py
+++ b/tests/services/test_report_renderer.py
@@ -446,6 +446,20 @@ def test_build_html_exposes_current_frame_metadata_hooks(
     assert "data-current-frame-category" in html
 
 
+def test_build_html_positions_stage_labels_outside_image_layers(
+    report_payload: ReportPayload,
+) -> None:
+    html = build_html(report_payload)
+
+    left_layer_start = html.index('<div class="rv-layer rv-left">')
+    stage_labels_start = html.index('<div class="rv-stage-labels" aria-hidden="true">')
+    left_layer_markup = html[left_layer_start:stage_labels_start]
+
+    assert stage_labels_start > left_layer_start
+    assert 'id="label-left"' not in left_layer_markup
+    assert 'id="label-right"' not in left_layer_markup
+
+
 def test_build_html_renders_empty_viewer_hooks_for_empty_payload(
     report_payload: ReportPayload,
 ) -> None:
@@ -667,12 +681,23 @@ def test_viewer_assets_keep_divider_slider_only_and_pointer_safe() -> None:
     assert ".rv-overlay-label:empty { display: none; }" in css
     assert "select option," in css
     assert 'background-image: url("data:image/svg+xml,' in css
+    assert "position: absolute;" in _css_block(css, ".rv-stage-labels")
+    assert "display: none;" in _css_block(css, ".rv-mode-diff .rv-stage-labels")
     assert "bottom: 16px;" in _css_block(css, ".rv-overlay-label")
+    assert "color: var(--text-primary);" in _css_block(css, ".rv-overlay-label")
+    assert "backdrop-filter:" not in _css_block(css, ".rv-overlay-label")
     assert "left: 50%;" in _css_block(css, ".rv-stage-overlay-info")
     assert "transform: translateX(-50%);" in _css_block(css, ".rv-stage-overlay-info")
     assert "position: absolute;" in _css_block(css, ".rv-filmstrip-caption")
     assert "text-shadow:" in _css_block(css, ".rv-filmstrip-label")
 
+    assert "imageLoadPromises: new Map()," in js
+    assert "void this.ensureImageReady(src);" in js
+    assert "Promise.all([" in js
+    assert "this.ensureImageReady(imageState.leftSrc)" in js
+    assert "this.ensureImageReady(imageState.rightSrc)" in js
+    assert "window.requestAnimationFrame(() => commit());" in js
+    assert "preloadedSrcs" not in js
     assert "leftLabelTxt = `${leftClip.label} (Left)`;" in js
     assert "rightLabelTxt = `${rightClip.label} (Right)`;" in js
     assert "leftLabelTxt = leftClip.label;" in js
@@ -939,7 +964,7 @@ def test_viewer_assets_toggle_overlays_and_keep_split_pairs_distinct() -> None:
 def test_viewer_assets_preload_adjacent_visible_frames_and_active_clips() -> None:
     js = get_js()
 
-    assert "preloadedSrcs: new Set()" in js
+    assert "imageLoadPromises: new Map()" in js
     assert "this.preloadImages();" in js
     assert "preloadFrameIndexes()" in js
     assert "if (position > 0) indexes.push(visibleIndexes[position - 1]);" in js
@@ -954,6 +979,7 @@ def test_viewer_assets_preload_adjacent_visible_frames_and_active_clips() -> Non
     assert "const images = Array.isArray(frame.images) ? frame.images : [];" in js
     assert "const src = images[clipIdx]?.src;" in js
     assert "src.startsWith('data:')" in js
-    assert "this.state.preloadedSrcs.has(src)" in js
+    assert "this.state.imageLoadPromises.get(src)" in js
     assert "const image = new Image();" in js
     assert "image.src = src;" in js
+    assert "image.decode().catch(() => undefined).finally(finish);" in js

--- a/tests/services/test_report_renderer.py
+++ b/tests/services/test_report_renderer.py
@@ -941,6 +941,7 @@ def test_viewer_assets_wire_metadata_and_error_empty_state_hooks() -> None:
     assert "if (control === this.dom.btnHelp) return;" in js
     assert "hasRenderableData()" in js
     assert "updateCurrentFrameMetadata(frameData)" in js
+    assert "this.updateCurrentFrameMetadata(null);" in js
     assert "document.querySelector('[data-current-frame-detail]')" not in js
     assert "normalizedDisplayToken(value)" in js
     assert "this.dom.currentFrameCategoryDivider.hidden = !showCategory;" in js

--- a/tests/services/test_report_renderer.py
+++ b/tests/services/test_report_renderer.py
@@ -373,7 +373,7 @@ def test_build_html_renders_frame_metadata_and_category_filters(
     assert 'data-category-key="cat-0" data-category="selected" aria-pressed="false"' in html
     assert 'data-category-key="cat-1" data-category="scene-cut" aria-pressed="false"' in html
     assert '<span class="rv-filmstrip-label">Frame 10 • Selected</span>' in html
-    assert '<span class="rv-filmstrip-detail">Source frame 10</span>' in html
+    assert "Source frame 10</span>" not in html
     assert (
         '<span class="rv-filmstrip-accent" '
         'data-category-key="cat-1" data-category="scene-cut"></span>'
@@ -436,13 +436,12 @@ def test_build_html_avoids_inline_styles(report_payload: ReportPayload) -> None:
     assert tags.tags_with_style == []
 
 
-def test_build_html_exposes_current_frame_detail_hooks(
+def test_build_html_exposes_current_frame_metadata_hooks(
     report_payload: ReportPayload,
 ) -> None:
     html = build_html(report_payload)
 
     assert "data-current-frame-label" in html
-    assert "data-current-frame-detail" in html
     assert "data-current-frame-category-divider" in html
     assert "data-current-frame-category" in html
 
@@ -671,6 +670,8 @@ def test_viewer_assets_keep_divider_slider_only_and_pointer_safe() -> None:
     assert "bottom: 16px;" in _css_block(css, ".rv-overlay-label")
     assert "left: 50%;" in _css_block(css, ".rv-stage-overlay-info")
     assert "transform: translateX(-50%);" in _css_block(css, ".rv-stage-overlay-info")
+    assert "position: absolute;" in _css_block(css, ".rv-filmstrip-caption")
+    assert "text-shadow:" in _css_block(css, ".rv-filmstrip-label")
 
     assert "leftLabelTxt = `${leftClip.label} (Left)`;" in js
     assert "rightLabelTxt = `${rightClip.label} (Right)`;" in js
@@ -802,6 +803,7 @@ def test_viewer_assets_wire_pan_wheel_zoom_and_alignment_hooks() -> None:
     assert "panY: 0" in js
     assert "this.dom.stage.addEventListener('wheel'" in js
     assert "this.dom.stage.addEventListener('dblclick'" in js
+    assert "if (this.state.mode === 'overlay' || this.state.mode === 'diff') return;" in js
     assert "this.zoomAtPoint(e.clientX, e.clientY, e.deltaY < 0 ? 1.1 : 1 / 1.1);" in js
     assert "this.setPan(this.state.panX + dx, this.state.panY + dy, { save: false });" in js
     assert "shouldPanFromPointer" in js
@@ -914,7 +916,7 @@ def test_viewer_assets_wire_metadata_and_error_empty_state_hooks() -> None:
     assert "if (control === this.dom.btnHelp) return;" in js
     assert "hasRenderableData()" in js
     assert "updateCurrentFrameMetadata(frameData)" in js
-    assert "document.querySelector('[data-current-frame-detail]')" in js
+    assert "document.querySelector('[data-current-frame-detail]')" not in js
     assert "normalizedDisplayToken(value)" in js
     assert "this.dom.currentFrameCategoryDivider.hidden = !showCategory;" in js
     assert "Selected frame image data is unavailable." in js

--- a/tests/services/test_report_renderer.py
+++ b/tests/services/test_report_renderer.py
@@ -197,38 +197,25 @@ def test_build_html_renders_frame_metadata_and_category_filters(
     html = build_html(report_payload)
 
     assert 'data-control-scope="frame-filters" aria-label="Frame category filters"' in html
-    assert 'data-category-key="__fc_all__" aria-pressed="true">All</button>' in html
+    assert 'data-category-key="__fc_all__" aria-pressed="true">All (2)</button>' in html
     assert 'data-category-key="cat-0" data-category="selected" aria-pressed="false"' in html
     assert 'data-category-key="cat-1" data-category="scene-cut" aria-pressed="false"' in html
-    assert '<span class="rv-filmstrip-label">Frame 10</span>' in html
+    assert '<span class="rv-filmstrip-label">Frame 10 • Selected</span>' in html
     assert '<span class="rv-filmstrip-detail">Source frame 10</span>' in html
     assert (
-        '<span class="rv-category-badge rv-filmstrip-category" '
-        'data-category-key="cat-1" data-category="scene-cut">scene-cut</span>'
+        '<span class="rv-filmstrip-accent" '
+        'data-category-key="cat-1" data-category="scene-cut"></span>'
     ) in html
-    assert 'data-category-key="cat-0" data-category="selected">selected</span></button>' in html
     assert 'value="1" data-category-key="cat-1" data-category="scene-cut">Frame 20</option>' in html
 
 
-def test_build_html_renders_collapsed_progressive_metadata(
+def test_build_html_renders_header_metadata(
     report_payload: ReportPayload,
 ) -> None:
     html = build_html(report_payload)
 
-    assert '<section class="rv-metadata-bar" aria-label="Report metadata">' in html
-    assert '<details class="rv-disclosure" data-report-metadata>' in html
-    assert '<summary>Report <span class="rv-summary-value">slider</span></summary>' in html
-    assert "<dt>Report ID</dt>" in html
-    assert "report_0123456789abcdef0123456789abcdef" in html
-    assert "<dt>Default pair</dt>" in html
-    assert 'REF &lt;main&gt; vs ENC "candidate"' in html
-    assert '<details class="rv-disclosure" data-clip-metadata>' in html
-    assert '<li class="rv-clip-meta-item" data-clip-index="0">' in html
-    assert "<dt>Resolution</dt><dd>1920x1080</dd>" in html
-    assert "<dt>FPS</dt><dd>24 fps</dd>" in html
-    assert "<dt>Frames</dt><dd>100</dd>" in html
-    assert '<details class="rv-disclosure" data-frame-metadata>' in html
-    assert '<span class="rv-summary-value" data-current-frame-summary>Frame 10</span>' in html
+    assert "Generated 2026-05-22T12:00:00+00:00 • 2 frames • 2 clips" in html
+    assert '<button id="btn-help" class="rv-header-help-btn" aria-label="Keyboard shortcuts" title="Help (?)">?</button>' in html
 
 
 def test_build_html_exposes_current_frame_detail_hooks(
@@ -236,19 +223,9 @@ def test_build_html_exposes_current_frame_detail_hooks(
 ) -> None:
     html = build_html(report_payload)
 
-    assert "<dt>Label</dt><dd data-current-frame-label>Frame 10</dd>" in html
-    assert "<dt>Detail</dt><dd data-current-frame-detail>Source frame 10</dd>" in html
-    assert "<dt>Category</dt><dd data-current-frame-category>selected</dd>" in html
-
-
-def test_build_html_metadata_disclosures_default_collapsed(
-    report_payload: ReportPayload,
-) -> None:
-    html = build_html(report_payload)
-
-    assert '<details class="rv-disclosure" data-report-metadata open>' not in html
-    assert '<details class="rv-disclosure" data-clip-metadata open>' not in html
-    assert '<details class="rv-disclosure" data-frame-metadata open>' not in html
+    assert 'data-current-frame-label' in html
+    assert 'data-current-frame-detail' in html
+    assert 'data-current-frame-category' in html
 
 
 def test_build_html_renders_empty_viewer_hooks_for_empty_payload(
@@ -268,10 +245,6 @@ def test_build_html_renders_empty_viewer_hooks_for_empty_payload(
         in html
     )
     assert '<div class="rv-empty-state" data-empty-state hidden></div>' in html
-    assert '<div class="rv-metadata-empty">No clips in payload.</div>' in html
-    assert "<dd data-current-frame-label>No frame selected</dd>" in html
-    assert "<dd data-current-frame-detail>No frame detail available.</dd>" in html
-    assert "<dd data-current-frame-category>none</dd>" in html
     assert 'class="rv-filmstrip-item"' not in html
 
 
@@ -291,16 +264,15 @@ def test_build_html_uses_internal_category_keys_for_reserved_category_text(
 
     html = build_html(payload)
 
-    assert 'data-category-key="__fc_all__" aria-pressed="true">All</button>' in html
+    assert 'data-category-key="__fc_all__" aria-pressed="true">All (2)</button>' in html
     assert 'data-category-key="cat-0" data-category="__all__" aria-pressed="false"' in html
-    assert 'data-category-key="cat-0" data-category="__all__">__all__</span></button>' in html
     assert 'value="0" data-category-key="cat-0" data-category="__all__">Frame 10</option>' in html
     assert (
         'class="rv-filmstrip-item" data-idx="0" data-category-key="cat-0" data-category="__all__"'
     ) in html
     assert (
-        '<span class="rv-category-badge rv-filmstrip-category" '
-        'data-category-key="cat-0" data-category="__all__">__all__</span>'
+        '<span class="rv-filmstrip-accent" '
+        'data-category-key="cat-0" data-category="__all__"></span>'
     ) in html
     assert 'data-category-key="__all__"' not in html
 
@@ -626,8 +598,8 @@ def test_viewer_assets_wire_metadata_and_error_empty_state_hooks() -> None:
     css = get_css()
     js = get_js()
 
-    assert ".rv-metadata-bar" in css
-    assert ".rv-disclosure[open]" in css
+    assert ".rv-stage-overlay-info" in css
+    assert ".rv-align-popover" in css
     assert '.rv-status[data-tone="error"]' in css
     assert '.rv-status[data-tone="warning"]' in css
     assert ".rv-empty-state[hidden] { display: none; }" in css

--- a/tests/services/test_slowpics_post_upload.py
+++ b/tests/services/test_slowpics_post_upload.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from frame_compare.config.schema import ConfigSchema
+from frame_compare.services.slowpics_post_upload import (
+    SlowpicsPostUploadRequest,
+    run_slowpics_post_upload_actions,
+)
+from frame_compare.services.slowpics_shortcut import SlowpicsShortcutResult
+from frame_compare.services.slowpics_webhook import (
+    WEBHOOK_VALIDATION_WARNING,
+    SlowpicsWebhookResult,
+)
+from frame_compare.utils.post_upload_actions import PostUploadActionResult
+from frame_compare.utils.types import WorkspacePaths
+
+
+def _workspace(
+    root: Path,
+    *,
+    run_dir: Path | None = None,
+    screenshots_dir: Path | None = None,
+    generated_dir: Path | None = None,
+) -> WorkspacePaths:
+    return WorkspacePaths(
+        root=root,
+        input_dir=root / "comparison_videos",
+        run_dir=run_dir,
+        screenshots_dir=screenshots_dir or root / "screenshots",
+        generated_dir=generated_dir or root / "generated",
+        config_dir=root / "config",
+        config_file=root / "config" / "config.toml",
+    )
+
+
+def _request(
+    tmp_path: Path,
+    *,
+    run_dir: Path | None = None,
+    create_url_shortcut: bool = True,
+    webhook_url: str | None = None,
+    slowpics_url: str = "https://slow.pics/c/example",
+    metadata_title: str | None = None,
+    upload_title: str | None = None,
+) -> SlowpicsPostUploadRequest:
+    root = tmp_path / "workspace"
+    config = ConfigSchema().slowpics
+    config.create_url_shortcut = create_url_shortcut
+    config.webhook_url = webhook_url
+    return SlowpicsPostUploadRequest(
+        workspace=_workspace(root, run_dir=run_dir),
+        config=config,
+        slowpics_url=slowpics_url,
+        metadata_title=metadata_title,
+        upload_title=upload_title,
+    )
+
+
+async def test_run_slowpics_post_upload_actions_writes_shortcut_when_enabled(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "workspace" / "runs" / "Collateral"
+    request = _request(
+        tmp_path,
+        run_dir=run_dir,
+        slowpics_url="https://slow.pics/c/collateral-key",
+        metadata_title="Collateral",
+        upload_title="screenshots",
+    )
+
+    output = await run_slowpics_post_upload_actions(request)
+
+    shortcut_path = run_dir / "Collateral.url"
+    assert output == (
+        PostUploadActionResult(
+            kind="shortcut",
+            success=True,
+            path=shortcut_path,
+            message="slow.pics URL shortcut written",
+        ),
+    )
+    assert shortcut_path.read_text(encoding="utf-8") == (
+        "[InternetShortcut]\nURL=https://slow.pics/c/collateral-key\n"
+    )
+
+
+async def test_run_slowpics_post_upload_actions_returns_no_actions_when_disabled(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path, create_url_shortcut=False)
+
+    output = await run_slowpics_post_upload_actions(request)
+
+    assert output == ()
+
+
+async def test_run_slowpics_post_upload_actions_returns_shortcut_then_webhook(
+    tmp_path: Path, monkeypatch
+) -> None:
+    run_dir = tmp_path / "workspace" / "runs" / "Collateral"
+    request = _request(
+        tmp_path,
+        run_dir=run_dir,
+        webhook_url="https://hooks.example.test/webhook/token?secret=value",
+        slowpics_url="https://slow.pics/c/example",
+        metadata_title="Collateral",
+        upload_title="screenshots",
+    )
+    captured: dict[str, str] = {}
+
+    async def _fake_deliver_slowpics_webhook(
+        *, webhook_url: str, slowpics_url: str
+    ) -> SlowpicsWebhookResult:
+        captured["webhook_url"] = webhook_url
+        captured["slowpics_url"] = slowpics_url
+        return SlowpicsWebhookResult(success=True, detail="HTTP 204")
+
+    monkeypatch.setattr(
+        "frame_compare.services.slowpics_post_upload.deliver_slowpics_webhook",
+        _fake_deliver_slowpics_webhook,
+    )
+
+    output = await run_slowpics_post_upload_actions(request)
+
+    assert captured == {
+        "webhook_url": "https://hooks.example.test/webhook/token?secret=value",
+        "slowpics_url": "https://slow.pics/c/example",
+    }
+    assert output == (
+        PostUploadActionResult(
+            kind="shortcut",
+            success=True,
+            path=run_dir / "Collateral.url",
+            message="slow.pics URL shortcut written",
+        ),
+        PostUploadActionResult(
+            kind="webhook",
+            success=True,
+            detail="HTTP 204",
+            message="slow.pics webhook delivered",
+        ),
+    )
+
+
+async def test_run_slowpics_post_upload_actions_logs_shortcut_warning(
+    tmp_path: Path, monkeypatch
+) -> None:
+    warning_calls: list[tuple[str, dict[str, object]]] = []
+    warning = "slow.pics shortcut: failed to resolve URL shortcut directory: locked"
+    failure_path = tmp_path / "workspace" / "runs" / "Example" / "Example.url"
+
+    def _fake_create_shortcut(**_kwargs: object) -> SlowpicsShortcutResult:
+        return SlowpicsShortcutResult(success=False, path=failure_path, warning=warning)
+
+    def _capture_warning(event: str, **kwargs: object) -> None:
+        warning_calls.append((event, kwargs))
+
+    monkeypatch.setattr(
+        "frame_compare.services.slowpics_post_upload.create_slowpics_url_shortcut",
+        _fake_create_shortcut,
+    )
+    monkeypatch.setattr("frame_compare.services.slowpics_post_upload.log.warning", _capture_warning)
+
+    output = await run_slowpics_post_upload_actions(
+        _request(tmp_path, create_url_shortcut=True, metadata_title="Example")
+    )
+
+    assert output == (
+        PostUploadActionResult(
+            kind="shortcut",
+            success=False,
+            path=failure_path,
+            warning=warning,
+        ),
+    )
+    assert warning_calls == [
+        (
+            "slowpics_shortcut_create_failed",
+            {"path": str(failure_path), "warning": warning},
+        ),
+    ]
+
+
+async def test_run_slowpics_post_upload_actions_webhook_failure_is_warning_only_and_redacted(
+    tmp_path: Path, monkeypatch
+) -> None:
+    warning = "slow.pics webhook: delivery failed after 3 attempts"
+    warning_calls: list[tuple[str, dict[str, object]]] = []
+
+    async def _fake_deliver_slowpics_webhook(
+        *,
+        webhook_url: str,
+        slowpics_url: str,
+    ) -> SlowpicsWebhookResult:
+        assert webhook_url == "https://secret.example.test/webhook/token?secret=value"
+        assert slowpics_url == "https://slow.pics/c/example"
+        return SlowpicsWebhookResult(success=False, warning=warning)
+
+    def _capture_warning(event: str, **kwargs: object) -> None:
+        warning_calls.append((event, kwargs))
+
+    monkeypatch.setattr(
+        "frame_compare.services.slowpics_post_upload.deliver_slowpics_webhook",
+        _fake_deliver_slowpics_webhook,
+    )
+    monkeypatch.setattr("frame_compare.services.slowpics_post_upload.log.warning", _capture_warning)
+
+    output = await run_slowpics_post_upload_actions(
+        _request(
+            tmp_path,
+            create_url_shortcut=False,
+            webhook_url="https://secret.example.test/webhook/token?secret=value",
+        )
+    )
+
+    assert output == (PostUploadActionResult(kind="webhook", success=False, warning=warning),)
+    assert "secret.example.test" not in warning
+    assert "/webhook/token" not in warning
+    assert "secret=value" not in warning
+    assert warning_calls == [
+        ("slowpics_webhook_delivery_failed", {"warning": warning}),
+    ]
+
+
+async def test_run_slowpics_post_upload_actions_webhook_validation_failure_returns_warning(
+    tmp_path: Path,
+) -> None:
+    output = await run_slowpics_post_upload_actions(
+        _request(tmp_path, create_url_shortcut=False, webhook_url="https://[::1")
+    )
+
+    assert output == (
+        PostUploadActionResult(
+            kind="webhook",
+            success=False,
+            warning=WEBHOOK_VALIDATION_WARNING,
+        ),
+    )

--- a/tests/services/test_slowpics_shortcut.py
+++ b/tests/services/test_slowpics_shortcut.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from frame_compare.services.slowpics_shortcut import create_slowpics_url_shortcut
+from frame_compare.utils.types import WorkspacePaths
+
+
+def _workspace(
+    root: Path,
+    *,
+    run_dir: Path | None = None,
+    screenshots_dir: Path | None = None,
+    generated_dir: Path | None = None,
+) -> WorkspacePaths:
+    return WorkspacePaths(
+        root=root,
+        input_dir=root / "comparison_videos",
+        run_dir=run_dir,
+        screenshots_dir=screenshots_dir or root / "screenshots",
+        generated_dir=generated_dir or root / "generated",
+        config_dir=root / "config",
+        config_file=root / "config" / "config.toml",
+    )
+
+
+def test_create_slowpics_url_shortcut_prefers_run_dir_and_metadata_title(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    run_dir = root / "runs" / "Collateral"
+    result = create_slowpics_url_shortcut(
+        workspace=_workspace(
+            root,
+            run_dir=run_dir,
+            screenshots_dir=root / "elsewhere" / "screenshots",
+            generated_dir=root / "elsewhere" / "generated",
+        ),
+        slowpics_url="https://slow.pics/c/collateral-key",
+        metadata_title="Collateral",
+        upload_title="screenshots",
+    )
+
+    shortcut_path = run_dir / "Collateral.url"
+    assert result.success is True
+    assert result.path == shortcut_path
+    assert result.warning is None
+    assert shortcut_path.read_text(encoding="utf-8") == (
+        "[InternetShortcut]\nURL=https://slow.pics/c/collateral-key\n"
+    )
+
+
+def test_create_slowpics_url_shortcut_uses_safe_common_parent_without_run_dir(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    output_parent = root / "output"
+    result = create_slowpics_url_shortcut(
+        workspace=_workspace(
+            root,
+            screenshots_dir=output_parent / "screenshots",
+            generated_dir=output_parent / "generated",
+        ),
+        slowpics_url="https://slow.pics/c/example-key",
+        metadata_title=None,
+        upload_title="Encode Screenshots",
+    )
+
+    shortcut_path = output_parent / "Encode Screenshots.url"
+    assert result.success is True
+    assert result.path == shortcut_path
+    assert shortcut_path.read_text(encoding="utf-8") == (
+        "[InternetShortcut]\nURL=https://slow.pics/c/example-key\n"
+    )
+
+
+def test_create_slowpics_url_shortcut_returns_warning_for_parent_outside_root(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    output_parent = tmp_path / "outside"
+
+    result = create_slowpics_url_shortcut(
+        workspace=_workspace(
+            root,
+            screenshots_dir=output_parent / "screenshots",
+            generated_dir=output_parent / "generated",
+        ),
+        slowpics_url="https://slow.pics/c/example-key",
+        metadata_title="Collateral",
+        upload_title="screenshots",
+    )
+
+    assert result.success is False
+    assert result.path is None
+    assert result.warning is not None
+    assert "could not choose a safe output directory" in result.warning
+    assert not output_parent.exists()
+
+
+def test_create_slowpics_url_shortcut_treats_home_common_parent_as_unsafe() -> None:
+    home = Path.home().resolve()
+
+    result = create_slowpics_url_shortcut(
+        workspace=_workspace(
+            home,
+            screenshots_dir=home / "frame-compare-shortcut-test-screenshots",
+            generated_dir=home / "frame-compare-shortcut-test-generated",
+        ),
+        slowpics_url="https://slow.pics/c/example-key",
+        metadata_title="Collateral",
+        upload_title="screenshots",
+    )
+
+    assert result.success is False
+    assert result.warning is not None
+    assert "could not choose a safe output directory" in result.warning
+
+
+def test_create_slowpics_url_shortcut_sanitizes_title_and_falls_back_to_url_key(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    output_parent = root / "output"
+
+    title_result = create_slowpics_url_shortcut(
+        workspace=_workspace(
+            root,
+            screenshots_dir=output_parent / "screenshots",
+            generated_dir=output_parent / "generated",
+        ),
+        slowpics_url="https://slow.pics/c/title-key",
+        metadata_title='The: Movie / Finale * "Special"',
+        upload_title="screenshots",
+    )
+    fallback_result = create_slowpics_url_shortcut(
+        workspace=_workspace(
+            root,
+            screenshots_dir=output_parent / "screenshots",
+            generated_dir=output_parent / "generated",
+        ),
+        slowpics_url="https://slow.pics/c/url-key",
+        metadata_title="<>:?*",
+        upload_title=None,
+    )
+
+    assert title_result.path == output_parent / "The Movie Finale Special.url"
+    assert fallback_result.path == output_parent / "url-key.url"
+
+
+def test_create_slowpics_url_shortcut_overwrites_same_deterministic_path(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    run_dir = root / "runs" / "Example"
+    shortcut_path = run_dir / "Example.url"
+    shortcut_path.parent.mkdir(parents=True)
+    shortcut_path.write_text("stale", encoding="utf-8")
+
+    first = create_slowpics_url_shortcut(
+        workspace=_workspace(root, run_dir=run_dir),
+        slowpics_url="https://slow.pics/c/one",
+        metadata_title="Example",
+        upload_title=None,
+    )
+    second = create_slowpics_url_shortcut(
+        workspace=_workspace(root, run_dir=run_dir),
+        slowpics_url="https://slow.pics/c/two",
+        metadata_title="Example",
+        upload_title=None,
+    )
+
+    assert first.path == shortcut_path
+    assert second.path == shortcut_path
+    assert shortcut_path.read_text(encoding="utf-8") == (
+        "[InternetShortcut]\nURL=https://slow.pics/c/two\n"
+    )
+
+
+def test_create_slowpics_url_shortcut_returns_warning_for_write_failure(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+
+    def _raise_write_error(_path: Path, _content: str) -> None:
+        raise PermissionError("locked")
+
+    result = create_slowpics_url_shortcut(
+        workspace=_workspace(root, run_dir=root / "runs" / "Example"),
+        slowpics_url="https://slow.pics/c/example-key",
+        metadata_title="Example",
+        upload_title=None,
+        text_writer=_raise_write_error,
+    )
+
+    assert result.success is False
+    assert result.path == root / "runs" / "Example" / "Example.url"
+    assert result.warning is not None
+    assert "failed to write URL shortcut" in result.warning
+    assert "locked" in result.warning

--- a/tests/services/test_slowpics_upload_plan.py
+++ b/tests/services/test_slowpics_upload_plan.py
@@ -1,0 +1,152 @@
+"""Tests for deterministic slow.pics upload planning."""
+
+from pathlib import Path
+
+import pytest
+
+from frame_compare.services.errors import SlowpicsError
+from frame_compare.services.slowpics_upload_plan import (
+    SlowpicsUploadClip,
+    build_slowpics_upload_plan,
+)
+
+
+def _png(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    return path
+
+
+def test_upload_plan_preserves_selected_frame_row_order(tmp_path: Path) -> None:
+    reference_files = [_png(tmp_path / f"ref-{frame}.png") for frame in (42, 7, 99)]
+
+    plan = build_slowpics_upload_plan(
+        selected_frames=[42, 7, 99],
+        clips=[SlowpicsUploadClip(label="Reference", image_name="Reference")],
+        screenshots_by_label={"Reference": reference_files},
+    )
+
+    assert [row.selected_frame for row in plan.rows] == [42, 7, 99]
+    assert [row.row_name for row in plan.rows] == ["42", "7", "99"]
+    assert [row.sort_order for row in plan.rows] == [0, 1, 2]
+    assert plan.file_paths == reference_files
+
+
+def test_upload_plan_preserves_reference_then_comparison_image_order(tmp_path: Path) -> None:
+    ref = _png(tmp_path / "10 - ref.png")
+    encode_a = _png(tmp_path / "10 - encode-a.png")
+    encode_b = _png(tmp_path / "10 - encode-b.png")
+
+    plan = build_slowpics_upload_plan(
+        selected_frames=[10],
+        clips=[
+            SlowpicsUploadClip(label="Reference", image_name="Reference"),
+            SlowpicsUploadClip(label="Encode A", image_name="Encode A"),
+            SlowpicsUploadClip(label="Encode B", image_name="Encode B"),
+        ],
+        screenshots_by_label={
+            "Reference": [ref],
+            "Encode A": [encode_a],
+            "Encode B": [encode_b],
+        },
+    )
+
+    row = plan.rows[0]
+    assert [image.clip_label for image in row.images] == ["Reference", "Encode A", "Encode B"]
+    assert [image.image_index for image in row.images] == [0, 1, 2]
+    assert [image.sort_order for image in row.images] == [0, 1, 2]
+    assert plan.file_paths == [ref, encode_a, encode_b]
+
+
+def test_upload_plan_uses_source_filename_stems_for_image_names(tmp_path: Path) -> None:
+    ref = _png(tmp_path / "screenshots" / "ui-reference-frame-10.png")
+    encode = _png(tmp_path / "screenshots" / "ui-encode-frame-10.png")
+
+    plan = build_slowpics_upload_plan(
+        selected_frames=[10],
+        clips=[
+            SlowpicsUploadClip(label="Reference", image_name="source.reference.cut"),
+            SlowpicsUploadClip(label="Encode UI Label", image_name="encode-final-v2"),
+        ],
+        screenshots_by_label={
+            "Reference": [ref],
+            "Encode UI Label": [encode],
+        },
+    )
+
+    row = plan.rows[0]
+    assert [image.image_name for image in row.images] == [
+        "source.reference.cut",
+        "encode-final-v2",
+    ]
+    assert [image.screenshot_path for image in row.images] == [ref, encode]
+
+
+def test_upload_plan_ignores_stale_directory_png(tmp_path: Path) -> None:
+    screenshot_dir = tmp_path / "screenshots"
+    current_ref = _png(screenshot_dir / "10 - ref.png")
+    current_encode = _png(screenshot_dir / "10 - encode.png")
+    _png(screenshot_dir / "stale.png")
+
+    plan = build_slowpics_upload_plan(
+        selected_frames=[10],
+        clips=[
+            SlowpicsUploadClip(label="Reference", image_name="Reference"),
+            SlowpicsUploadClip(label="Encode", image_name="Encode"),
+        ],
+        screenshots_by_label={
+            "Reference": [current_ref],
+            "Encode": [current_encode],
+        },
+    )
+
+    assert plan.file_paths == [current_ref, current_encode]
+
+
+def test_upload_plan_rejects_missing_screenshot_file(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.png"
+
+    with pytest.raises(SlowpicsError, match="Planned slow.pics screenshot is missing"):
+        build_slowpics_upload_plan(
+            selected_frames=[10],
+            clips=[SlowpicsUploadClip(label="Reference", image_name="Reference")],
+            screenshots_by_label={"Reference": [missing]},
+        )
+
+
+def test_upload_plan_rejects_mismatched_screenshot_counts(tmp_path: Path) -> None:
+    only_file = _png(tmp_path / "10 - ref.png")
+
+    with pytest.raises(SlowpicsError, match="Mismatched slow.pics screenshot count"):
+        build_slowpics_upload_plan(
+            selected_frames=[10, 20],
+            clips=[SlowpicsUploadClip(label="Reference", image_name="Reference")],
+            screenshots_by_label={"Reference": [only_file]},
+        )
+
+
+def test_upload_plan_rejects_missing_clip_labels(tmp_path: Path) -> None:
+    _png(tmp_path / "10 - ref.png")
+
+    with pytest.raises(SlowpicsError, match="Missing screenshots for clip label 'Encode'"):
+        build_slowpics_upload_plan(
+            selected_frames=[10],
+            clips=[
+                SlowpicsUploadClip(label="Reference", image_name="Reference"),
+                SlowpicsUploadClip(label="Encode", image_name="Encode"),
+            ],
+            screenshots_by_label={
+                "Reference": [tmp_path / "10 - ref.png"],
+            },
+        )
+
+
+def test_upload_plan_rejects_empty_image_display_names(tmp_path: Path) -> None:
+    screenshot = _png(tmp_path / "10 - ref.png")
+
+    with pytest.raises(SlowpicsError, match="Empty slow.pics image display name"):
+        build_slowpics_upload_plan(
+            selected_frames=[10],
+            clips=[SlowpicsUploadClip(label="Reference", image_name="  ")],
+            screenshots_by_label={"Reference": [screenshot]},
+        )

--- a/tests/services/test_slowpics_webhook.py
+++ b/tests/services/test_slowpics_webhook.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from frame_compare.services.slowpics_webhook import (
+    WEBHOOK_ATTEMPTS,
+    WEBHOOK_CONTENT_TYPE,
+    WEBHOOK_FAILURE_WARNING,
+    WEBHOOK_TIMEOUT_SECONDS,
+    WEBHOOK_VALIDATION_WARNING,
+    SlowpicsWebhookResult,
+    WebhookDeliveryRequest,
+    WebhookResponse,
+    deliver_slowpics_webhook,
+    send_pinned_https_webhook_request,
+)
+
+type Resolver = Callable[[str, int], tuple[str, ...]]
+
+
+def _public_resolver(_hostname: str, _port: int) -> tuple[str, ...]:
+    return ("93.184.216.34",)
+
+
+async def _deliver(
+    webhook_url: str,
+    *,
+    resolver: Resolver = _public_resolver,
+    connector: Callable[[WebhookDeliveryRequest], WebhookResponse],
+) -> SlowpicsWebhookResult:
+    return await deliver_slowpics_webhook(
+        webhook_url=webhook_url,
+        slowpics_url="https://slow.pics/c/example",
+        resolver=resolver,
+        connector=connector,
+    )
+
+
+def _unexpected_connector(_request: WebhookDeliveryRequest) -> WebhookResponse:
+    raise AssertionError("webhook connector should not be called")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://hooks.example.test/path",
+        "https://localhost/path",
+        "https://worker.localhost/path",
+    ],
+)
+async def test_rejects_non_https_and_localhost_names(url: str) -> None:
+    result = await _deliver(url, connector=_unexpected_connector)
+
+    assert result.success is False
+    assert result.warning is not None
+    assert "hooks.example.test" not in result.warning
+    assert "localhost" not in result.warning
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "127.0.0.1",
+        "10.0.0.1",
+        "169.254.1.1",
+        "224.0.0.1",
+        "240.0.0.1",
+        "0.0.0.0",
+        "::1",
+        "fc00::1",
+        "fe80::1",
+        "ff02::1",
+        "::",
+    ],
+)
+async def test_rejects_non_public_ip_literals(address: str) -> None:
+    host = f"[{address}]" if ":" in address else address
+    result = await _deliver(f"https://{host}/path", connector=_unexpected_connector)
+
+    assert result.success is False
+    assert result.warning is not None
+
+
+@pytest.mark.parametrize(
+    ("answers", "expected_called"),
+    [
+        ((), False),
+        (("10.0.0.1",), False),
+        (("93.184.216.34", "10.0.0.1"), False),
+        (("93.184.216.34",), True),
+    ],
+)
+async def test_dns_policy_rejects_empty_disallowed_or_mixed_answers(
+    answers: tuple[str, ...],
+    expected_called: bool,
+) -> None:
+    calls: list[WebhookDeliveryRequest] = []
+
+    def _resolver(_hostname: str, _port: int) -> tuple[str, ...]:
+        return answers
+
+    def _connector(request: WebhookDeliveryRequest) -> WebhookResponse:
+        calls.append(request)
+        return WebhookResponse(status_code=204)
+
+    result = await _deliver(
+        "https://hooks.example.test/path",
+        resolver=_resolver,
+        connector=_connector,
+    )
+
+    assert result.success is expected_called
+    assert len(calls) == (1 if expected_called else 0)
+
+
+async def test_resolution_failure_is_rejected_without_connecting() -> None:
+    def _resolver(_hostname: str, _port: int) -> tuple[str, ...]:
+        return ()
+
+    result = await _deliver(
+        "https://secret.example.test/path",
+        resolver=_resolver,
+        connector=_unexpected_connector,
+    )
+
+    assert result.success is False
+    assert result.warning is not None
+    assert "secret.example.test" not in result.warning
+    assert "/path" not in result.warning
+
+
+async def test_malformed_ipv6_url_returns_sanitized_validation_warning() -> None:
+    result = await _deliver("https://[::1", connector=_unexpected_connector)
+
+    assert result == SlowpicsWebhookResult(
+        success=False,
+        warning=WEBHOOK_VALIDATION_WARNING,
+    )
+    assert "::1" not in result.warning
+
+
+@pytest.mark.parametrize(
+    ("url", "sensitive_fragments"),
+    [
+        ("https://éxample.test/path", ("éxample.test",)),
+        ("https://hooks.example.test/påth", ("hooks.example.test", "påth")),
+        (
+            "https://hooks.example.test/path?secret=ø",
+            ("hooks.example.test", "secret=ø"),
+        ),
+    ],
+)
+async def test_non_ascii_url_components_return_sanitized_validation_warning(
+    url: str,
+    sensitive_fragments: tuple[str, ...],
+) -> None:
+    result = await _deliver(url, connector=_unexpected_connector)
+
+    assert result == SlowpicsWebhookResult(
+        success=False,
+        warning=WEBHOOK_VALIDATION_WARNING,
+    )
+    assert result.warning is not None
+    for fragment in sensitive_fragments:
+        assert fragment not in result.warning
+
+
+async def test_delivery_connects_to_resolved_ip_preserving_hostname_sni_and_host_header() -> None:
+    calls: list[WebhookDeliveryRequest] = []
+
+    def _connector(request: WebhookDeliveryRequest) -> WebhookResponse:
+        calls.append(request)
+        return WebhookResponse(status_code=204)
+
+    result = await _deliver(
+        "https://hooks.example.test:8443/webhook/token?secret=value",
+        connector=_connector,
+    )
+
+    assert result == SlowpicsWebhookResult(success=True, detail="HTTP 204")
+    assert len(calls) == 1
+    request = calls[0]
+    assert request.resolved_ip == "93.184.216.34"
+    assert request.hostname == "hooks.example.test"
+    assert request.port == 8443
+    assert request.host_header == "hooks.example.test:8443"
+    assert request.target == "/webhook/token?secret=value"
+    assert request.timeout_seconds == WEBHOOK_TIMEOUT_SECONDS
+    assert request.body == b'{"content":"https://slow.pics/c/example"}'
+    assert dict(request.headers) == {
+        "Host": "hooks.example.test:8443",
+        "Content-Type": WEBHOOK_CONTENT_TYPE,
+        "Content-Length": str(len(request.body)),
+        "Connection": "close",
+    }
+    assert "Cookie" not in dict(request.headers)
+    assert "Origin" not in dict(request.headers)
+    assert "Referer" not in dict(request.headers)
+    assert "X-XSRF-TOKEN" not in dict(request.headers)
+
+
+async def test_connector_serialization_failure_returns_sanitized_warning() -> None:
+    calls = 0
+
+    def _connector(_request: WebhookDeliveryRequest) -> WebhookResponse:
+        nonlocal calls
+        calls += 1
+        raise UnicodeEncodeError("ascii", "tøken", 1, 2, "ordinal not in range")
+
+    result = await _deliver(
+        "https://hooks.example.test/webhook/token?secret=value",
+        connector=_connector,
+    )
+
+    assert result == SlowpicsWebhookResult(
+        success=False,
+        warning=WEBHOOK_FAILURE_WARNING,
+    )
+    assert calls == WEBHOOK_ATTEMPTS
+    assert result.warning is not None
+    assert "hooks.example.test" not in result.warning
+    assert "/webhook/token" not in result.warning
+    assert "secret=value" not in result.warning
+
+
+def test_request_serialization_rejects_non_ascii_target_before_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _unexpected_socket(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("socket should not be opened for invalid request bytes")
+
+    monkeypatch.setattr("frame_compare.services.slowpics_webhook.socket.socket", _unexpected_socket)
+    request = WebhookDeliveryRequest(
+        hostname="hooks.example.test",
+        port=443,
+        resolved_ip="93.184.216.34",
+        host_header="hooks.example.test",
+        target="/webhook/tøken",
+        headers=(
+            ("Host", "hooks.example.test"),
+            ("Content-Type", WEBHOOK_CONTENT_TYPE),
+            ("Content-Length", "2"),
+            ("Connection", "close"),
+        ),
+        body=b"{}",
+        timeout_seconds=WEBHOOK_TIMEOUT_SECONDS,
+    )
+
+    with pytest.raises(OSError, match="Invalid webhook HTTP request"):
+        send_pinned_https_webhook_request(request)
+
+
+async def test_redirect_response_is_failure_without_followup_request() -> None:
+    calls: list[WebhookDeliveryRequest] = []
+
+    def _connector(request: WebhookDeliveryRequest) -> WebhookResponse:
+        calls.append(request)
+        return WebhookResponse(status_code=302)
+
+    result = await _deliver("https://hooks.example.test/path", connector=_connector)
+
+    assert result.success is False
+    assert result.warning is not None
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "failure",
+    ["timeout", "connection", "server"],
+)
+async def test_retryable_timeout_connection_and_server_failures_attempt_three_times(
+    failure: str,
+) -> None:
+    calls: list[WebhookDeliveryRequest] = []
+
+    def _connector(request: WebhookDeliveryRequest) -> WebhookResponse:
+        calls.append(request)
+        if failure == "timeout":
+            raise TimeoutError("timed out")
+        if failure == "connection":
+            raise OSError("connection failed")
+        return WebhookResponse(status_code=503)
+
+    result = await _deliver("https://hooks.example.test/path", connector=_connector)
+
+    assert result.success is False
+    assert result.warning is not None
+    assert len(calls) == WEBHOOK_ATTEMPTS
+    assert [request.timeout_seconds for request in calls] == [
+        WEBHOOK_TIMEOUT_SECONDS,
+        WEBHOOK_TIMEOUT_SECONDS,
+        WEBHOOK_TIMEOUT_SECONDS,
+    ]
+
+
+async def test_warnings_redact_configured_webhook_url_details() -> None:
+    def _connector(_request: WebhookDeliveryRequest) -> WebhookResponse:
+        return WebhookResponse(status_code=503)
+
+    result = await _deliver(
+        "https://secret.example.test/webhook/token?secret=value",
+        connector=_connector,
+    )
+
+    assert result.success is False
+    assert result.warning is not None
+    assert "secret.example.test" not in result.warning
+    assert "webhook" in result.warning
+    assert "/webhook/token" not in result.warning
+    assert "secret=value" not in result.warning

--- a/tests/services/test_slowpics_webhook.py
+++ b/tests/services/test_slowpics_webhook.py
@@ -138,6 +138,7 @@ async def test_malformed_ipv6_url_returns_sanitized_validation_warning() -> None
         success=False,
         warning=WEBHOOK_VALIDATION_WARNING,
     )
+    assert result.warning is not None
     assert "::1" not in result.warning
 
 
@@ -292,6 +293,31 @@ async def test_retryable_timeout_connection_and_server_failures_attempt_three_ti
         WEBHOOK_TIMEOUT_SECONDS,
         WEBHOOK_TIMEOUT_SECONDS,
         WEBHOOK_TIMEOUT_SECONDS,
+    ]
+
+
+async def test_retryable_failures_rotate_across_validated_addresses() -> None:
+    calls: list[WebhookDeliveryRequest] = []
+
+    def _resolver(_hostname: str, _port: int) -> tuple[str, ...]:
+        return ("93.184.216.34", "1.1.1.1")
+
+    def _connector(request: WebhookDeliveryRequest) -> WebhookResponse:
+        calls.append(request)
+        raise TimeoutError("timed out")
+
+    result = await _deliver(
+        "https://hooks.example.test/path",
+        resolver=_resolver,
+        connector=_connector,
+    )
+
+    assert result.success is False
+    assert result.warning is not None
+    assert [request.resolved_ip for request in calls] == [
+        "93.184.216.34",
+        "1.1.1.1",
+        "93.184.216.34",
     ]
 
 

--- a/tests/test_cli_contract_docs.py
+++ b/tests/test_cli_contract_docs.py
@@ -86,6 +86,10 @@ def test_current_cli_contract_documents_slowpics_config_surface_and_defaults() -
         "delete_after_upload",
         "timeout_seconds",
         "max_retries",
+        "copy_url_to_clipboard",
+        "open_in_browser",
+        "create_url_shortcut",
+        "webhook_url",
     ]
     for expected in (
         "`auto_upload = false`",
@@ -93,6 +97,10 @@ def test_current_cli_contract_documents_slowpics_config_surface_and_defaults() -
         "`delete_after_upload = false`",
         "`timeout_seconds = 60.0`",
         "`max_retries = 3`",
+        "`copy_url_to_clipboard = true`",
+        "`open_in_browser = true`",
+        "`create_url_shortcut = true`",
+        "`webhook_url = null`",
         "`delete_after_upload` is local-only",
         "report-safe",
         "`removeAfter`",
@@ -105,7 +113,7 @@ def test_current_cli_contract_documents_slowpics_config_surface_and_defaults() -
     ):
         assert expected in normalized_slowpics_section
     assert (
-        "These five fields are the full current public `[slowpics]` config surface"
+        "These nine fields are the full current public `[slowpics]` config surface"
         in normalized_slowpics_section
     )
 
@@ -117,10 +125,6 @@ def test_current_cli_contract_documents_slowpics_config_surface_and_defaults() -
         "tags",
         "hentai",
         "remove_after",
-        "copy_url",
-        "open_after_upload",
-        "shortcut",
-        "webhook",
     ):
         assert unsupported_field not in SlowpicsConfig.model_fields
 

--- a/tests/test_cli_contract_docs.py
+++ b/tests/test_cli_contract_docs.py
@@ -2,8 +2,23 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from click import Group
+from typer.main import get_command
+
+from frame_compare.cli.entry import app
 from frame_compare.config.overrides import CLI_OVERRIDE_MAP
-from frame_compare.config.schema import Visibility
+from frame_compare.config.schema import SlowpicsConfig, Visibility
+
+
+def _declared_run_options() -> set[str]:
+    command = get_command(app)
+    assert isinstance(command, Group)
+    run_command = command.commands["run"]
+    return {
+        opt
+        for param in run_command.params
+        for opt in (*getattr(param, "opts", ()), *getattr(param, "secondary_opts", ()))
+    }
 
 
 def test_current_cli_contract_is_wired_into_repo_authority_surfaces() -> None:
@@ -50,6 +65,137 @@ def test_current_cli_contract_matches_live_override_map() -> None:
         flag = f"--{cli_name.replace('_', '-')}"
         assert flag in cli_contract
         assert config_path in cli_contract
+
+
+def test_current_cli_contract_documents_slowpics_config_surface_and_defaults() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    cli_contract = (repo_root / "docs" / "current-cli-contract.md").read_text(encoding="utf-8")
+    slowpics_heading = "## Config-Only slow.pics Surface"
+    screenshot_heading = "## Config-Only Screenshot Surface"
+    assert slowpics_heading in cli_contract, f"Missing heading: {slowpics_heading}"
+
+    slowpics_section = cli_contract.split(slowpics_heading, maxsplit=1)[1].split(
+        screenshot_heading,
+        maxsplit=1,
+    )[0]
+    normalized_slowpics_section = " ".join(slowpics_section.split())
+
+    assert list(SlowpicsConfig.model_fields) == [
+        "auto_upload",
+        "visibility",
+        "delete_after_upload",
+        "timeout_seconds",
+        "max_retries",
+    ]
+    for expected in (
+        "`auto_upload = false`",
+        '`visibility = "unlisted"`',
+        "`delete_after_upload = false`",
+        "`timeout_seconds = 60.0`",
+        "`max_retries = 3`",
+        "`delete_after_upload` is local-only",
+        "report-safe",
+        "`removeAfter`",
+    ):
+        assert expected in slowpics_section
+    for expected in (
+        "exact planned local screenshot files that were successfully uploaded",
+        "Deletion is skipped for non-embedded reports",
+        "warn-only report failures",
+    ):
+        assert expected in normalized_slowpics_section
+    assert (
+        "These five fields are the full current public `[slowpics]` config surface"
+        in normalized_slowpics_section
+    )
+
+    for unsupported_field in (
+        "collection_suffix",
+        "collection_name",
+        "image_format",
+        "optimize_images",
+        "tags",
+        "hentai",
+        "remove_after",
+        "copy_url",
+        "open_after_upload",
+        "shortcut",
+        "webhook",
+    ):
+        assert unsupported_field not in SlowpicsConfig.model_fields
+
+
+def test_current_cli_contract_documents_only_no_upload_slowpics_run_flag() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    cli_contract = (repo_root / "docs" / "current-cli-contract.md").read_text(encoding="utf-8")
+    mapping_heading = "## CLI Flag To Config Mapping"
+    screenshot_heading = "## Config-Only slow.pics Surface"
+    assert mapping_heading in cli_contract, f"Missing heading: {mapping_heading}"
+    assert screenshot_heading in cli_contract, f"Missing heading: {screenshot_heading}"
+
+    mapping_section = cli_contract.split(mapping_heading, maxsplit=1)[1].split(
+        screenshot_heading,
+        maxsplit=1,
+    )[0]
+    normalized_mapping_section = " ".join(mapping_section.split())
+
+    declared_options = _declared_run_options()
+    slowpics_related = {
+        flag
+        for flag in declared_options
+        if (
+            "slowpics" in flag
+            or "slow-pics" in flag
+            or "upload" in flag
+            or "visibility" in flag
+            or "remove" in flag
+            or "delete" in flag
+            or "webhook" in flag
+        )
+    }
+
+    assert slowpics_related == {"--no-upload"}
+    assert "`--no-upload` is the only slow.pics-specific `run` flag." in mapping_section
+    assert "No runtime-only slow.pics `run` flags exist." in normalized_mapping_section
+
+
+def test_current_cli_contract_documents_slowpics_json_shape() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    cli_contract = (repo_root / "docs" / "current-cli-contract.md").read_text(encoding="utf-8")
+    run_heading = "## `run` Command Contract"
+    mapping_heading = "## CLI Flag To Config Mapping"
+    assert run_heading in cli_contract, f"Missing heading: {run_heading}"
+
+    run_section = cli_contract.split(run_heading, maxsplit=1)[1].split(
+        mapping_heading,
+        maxsplit=1,
+    )[0]
+    normalized_run_section = " ".join(run_section.split())
+
+    assert "`slowpics_url`" in run_section
+    assert "only machine-readable slow.pics result field" in normalized_run_section
+    assert "No copy/open/shortcut/webhook result fields" in normalized_run_section
+
+
+def test_current_architecture_documents_slowpics_service_flow_and_upload_plan() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    architecture = (repo_root / "docs" / "current-architecture.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_architecture = " ".join(architecture.split())
+
+    for expected in (
+        "browser-compatible slow.pics client flow",
+        "`frame_compare.services.publishers`",
+        "`frame_compare.services.slowpics_upload_plan`",
+        "explicit upload-plan seam",
+        "current render artifacts",
+        "does not scan the screenshot directory",
+        "`post_report_cleanup`",
+        "exact uploaded planned local file paths",
+        "report-safe local deletion policy",
+    ):
+        assert expected in normalized_architecture
 
 
 def test_current_cli_contract_documents_screenshot_config_only_fields() -> None:

--- a/tests/test_cli_contract_docs.py
+++ b/tests/test_cli_contract_docs.py
@@ -104,6 +104,9 @@ def test_current_cli_contract_documents_slowpics_config_surface_and_defaults() -
         "`delete_after_upload` is local-only",
         "report-safe",
         "`removeAfter`",
+        "`copy_url_to_clipboard` and `open_in_browser` are interactive CLI-owned actions",
+        "`create_url_shortcut` and `webhook_url` run after successful upload",
+        "including `--json` and `--quiet`",
     ):
         assert expected in slowpics_section
     for expected in (
@@ -116,6 +119,8 @@ def test_current_cli_contract_documents_slowpics_config_surface_and_defaults() -
         "These nine fields are the full current public `[slowpics]` config surface"
         in normalized_slowpics_section
     )
+    assert "parsed and defaulted only" not in normalized_slowpics_section
+    assert "warning-only failures remain off JSON stdout" in normalized_slowpics_section
 
     for unsupported_field in (
         "collection_suffix",
@@ -179,6 +184,90 @@ def test_current_cli_contract_documents_slowpics_json_shape() -> None:
     assert "`slowpics_url`" in run_section
     assert "only machine-readable slow.pics result field" in normalized_run_section
     assert "No copy/open/shortcut/webhook result fields" in normalized_run_section
+    for forbidden_field in (
+        "clipboard_result",
+        "browser_result",
+        "shortcut_path",
+        "webhook_status",
+    ):
+        assert forbidden_field not in run_section
+
+
+def test_current_cli_contract_documents_slowpics_post_upload_behavior() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    cli_contract = (repo_root / "docs" / "current-cli-contract.md").read_text(encoding="utf-8")
+    upload_heading = "### slow.pics Upload Behavior"
+    shortcut_heading = "### slow.pics Shortcut Policy"
+    webhook_heading = "### slow.pics Webhook Policy"
+    mapping_heading = "## CLI Flag To Config Mapping"
+
+    upload_section = cli_contract.split(upload_heading, maxsplit=1)[1].split(
+        shortcut_heading,
+        maxsplit=1,
+    )[0]
+    shortcut_section = cli_contract.split(shortcut_heading, maxsplit=1)[1].split(
+        webhook_heading,
+        maxsplit=1,
+    )[0]
+    webhook_section = cli_contract.split(webhook_heading, maxsplit=1)[1].split(
+        mapping_heading,
+        maxsplit=1,
+    )[0]
+    normalized_upload = " ".join(upload_section.split())
+    normalized_shortcut = " ".join(shortcut_section.split())
+    normalized_webhook = " ".join(webhook_section.split())
+
+    for expected in (
+        "`copy_url_to_clipboard` copies the slow.pics URL through the CLI",
+        "`open_in_browser` opens the slow.pics URL through the CLI",
+        "`create_url_shortcut` writes a deterministic `.url` shortcut",
+        "`webhook_url` posts the slow.pics URL to the configured webhook",
+        "including `--json` and `--quiet` runs",
+        "no post-upload action fields are added to the JSON payload",
+        "Disabled or skipped post-upload actions are not listed by default",
+    ):
+        assert expected in normalized_upload
+
+    for expected in (
+        "`frame_compare.services.slowpics_shortcut`",
+        "Repeated writes overwrite the same deterministic shortcut path",
+        "Shortcut files are not members of `slowpics.delete_after_upload` cleanup",
+    ):
+        assert expected in normalized_shortcut
+
+    for expected in (
+        "`frame_compare.services.slowpics_webhook`",
+        "payload is exactly `{\"content\":\"<slowpics_url>\"}`",
+        "strict external HTTPS endpoint",
+        "prevalidated pinned IP address",
+        "does not reuse slow.pics cookies, headers, client state",
+        "fixed 10 second timeout, and 3 attempts",
+        "redacted from warnings and logs",
+        "Delivery failures are warning-only",
+    ):
+        assert expected in normalized_webhook
+
+
+def test_current_cli_contract_documents_slowpics_browser_report_precedence() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    cli_contract = (repo_root / "docs" / "current-cli-contract.md").read_text(encoding="utf-8")
+    report_heading = "### Report Auto-Open Ownership"
+    upload_heading = "### slow.pics Upload Behavior"
+
+    report_section = cli_contract.split(report_heading, maxsplit=1)[1].split(
+        upload_heading,
+        maxsplit=1,
+    )[0]
+    normalized_report_section = " ".join(report_section.split())
+
+    for expected in (
+        "Clipboard copy and slow.pics browser opening are also CLI-owned",
+        "If an enabled slow.pics browser open is attempted",
+        "report auto-open is suppressed for that run",
+        "If slow.pics browser open is not attempted",
+        "existing report auto-open rules above still apply",
+    ):
+        assert expected in normalized_report_section
 
 
 def test_current_architecture_documents_slowpics_service_flow_and_upload_plan() -> None:
@@ -198,8 +287,58 @@ def test_current_architecture_documents_slowpics_service_flow_and_upload_plan() 
         "`post_report_cleanup`",
         "exact uploaded planned local file paths",
         "report-safe local deletion policy",
+        "typed post-upload action results plus warnings",
+        "does not own clipboard, browser, shortcut, or webhook side-effect policy",
+        "The `.url` shortcut is not cleanup membership",
     ):
         assert expected in normalized_architecture
+
+
+def test_current_architecture_documents_slowpics_post_upload_owner_seams() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    architecture = (repo_root / "docs" / "current-architecture.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_architecture = " ".join(architecture.split())
+
+    for expected in (
+        "`frame_compare.services.slowpics_shortcut` owns deterministic `.url` output",
+        "safe common parent of the resolved screenshots/generated directories",
+        "`frame_compare.services.slowpics_webhook` owns isolated outbound webhook",
+        "prevalidated pinned address while preserving TLS verification",
+        "does not reuse slow.pics client cookies, headers",
+        "`frame_compare.cli.entry` and its run-command helper own interactive-only",
+        "precedence rule between slow.pics browser opening and generated-report auto-open",
+        "JSON stdout stays a single object",
+    ):
+        assert expected in normalized_architecture
+
+
+def test_report_confirmed_slowpics_upload_starter_spec_is_historical_only() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    starter_spec = (
+        repo_root
+        / "docs"
+        / "plans"
+        / "2026-06-01-report-confirmed-slowpics-upload-starter-spec.md"
+    )
+    text = starter_spec.read_text(encoding="utf-8")
+    normalized_text = " ".join(text.split())
+
+    assert text.startswith("Status: Historical")
+    assert "Status: Active" not in text
+    for expected in (
+        "This is not an active implementation plan",
+        "This current workstream does not implement report UI controls",
+        "report-owned upload services",
+        "local services",
+        "background processes",
+        "custom protocol handlers",
+        "browser extensions",
+        "Do not add report UI upload controls",
+        "Do not add report-owned upload services",
+    ):
+        assert expected in normalized_text
 
 
 def test_current_cli_contract_documents_screenshot_config_only_fields() -> None:

--- a/tests/test_cli_contract_docs.py
+++ b/tests/test_cli_contract_docs.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from click import Group
 from typer.main import get_command
 
 from frame_compare.cli.entry import app
+from frame_compare.cli.run_command import handle_json_output
 from frame_compare.config.overrides import CLI_OVERRIDE_MAP
 from frame_compare.config.schema import SlowpicsConfig, Visibility
+from frame_compare.orchestration.types import RunResult
 
 
 def _declared_run_options() -> set[str]:
@@ -82,6 +85,7 @@ def test_current_cli_contract_documents_slowpics_config_surface_and_defaults() -
 
     assert list(SlowpicsConfig.model_fields) == [
         "auto_upload",
+        "confirm_upload_after_report",
         "visibility",
         "delete_after_upload",
         "timeout_seconds",
@@ -93,6 +97,7 @@ def test_current_cli_contract_documents_slowpics_config_surface_and_defaults() -
     ]
     for expected in (
         "`auto_upload = false`",
+        "`confirm_upload_after_report = false`",
         '`visibility = "unlisted"`',
         "`delete_after_upload = false`",
         "`timeout_seconds = 60.0`",
@@ -104,19 +109,24 @@ def test_current_cli_contract_documents_slowpics_config_surface_and_defaults() -
         "`delete_after_upload` is local-only",
         "report-safe",
         "`removeAfter`",
+        "`confirm_upload_after_report` is a config-only, interactive-only opt-in",
         "`copy_url_to_clipboard` and `open_in_browser` are interactive CLI-owned actions",
         "`create_url_shortcut` and `webhook_url` run after successful upload",
         "including `--json` and `--quiet`",
+        "The JSON output schema remains unchanged by report-confirmed upload",
     ):
         assert expected in slowpics_section
     for expected in (
         "exact planned local screenshot files that were successfully uploaded",
         "Deletion is skipped for non-embedded reports",
         "warn-only report failures",
+        "adds no `run` flag, no wizard prompt, and no `run --json` stdout field",
+        "incompatible with `--json`, `--quiet`, non-TTY stdin, non-TTY stdout",
+        "`report.enable = false`",
     ):
         assert expected in normalized_slowpics_section
     assert (
-        "These nine fields are the full current public `[slowpics]` config surface"
+        "These ten fields are the full current public `[slowpics]` config surface"
         in normalized_slowpics_section
     )
     assert "parsed and defaulted only" not in normalized_slowpics_section
@@ -164,11 +174,15 @@ def test_current_cli_contract_documents_only_no_upload_slowpics_run_flag() -> No
     }
 
     assert slowpics_related == {"--no-upload"}
+    assert "--confirm-upload-after-report" not in declared_options
+    assert "slowpics.confirm_upload_after_report" not in CLI_OVERRIDE_MAP.values()
     assert "`--no-upload` is the only slow.pics-specific `run` flag." in mapping_section
     assert "No runtime-only slow.pics `run` flags exist." in normalized_mapping_section
 
 
-def test_current_cli_contract_documents_slowpics_json_shape() -> None:
+def test_current_cli_contract_documents_slowpics_json_shape(
+    capsys,
+) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     cli_contract = (repo_root / "docs" / "current-cli-contract.md").read_text(encoding="utf-8")
     run_heading = "## `run` Command Contract"
@@ -184,6 +198,8 @@ def test_current_cli_contract_documents_slowpics_json_shape() -> None:
     assert "`slowpics_url`" in run_section
     assert "only machine-readable slow.pics result field" in normalized_run_section
     assert "No copy/open/shortcut/webhook result fields" in normalized_run_section
+    assert "Report-confirmed upload confirmation status is also not emitted" in run_section
+    assert "success schema remains unchanged" in normalized_run_section
     for forbidden_field in (
         "clipboard_result",
         "browser_result",
@@ -191,6 +207,18 @@ def test_current_cli_contract_documents_slowpics_json_shape() -> None:
         "webhook_status",
     ):
         assert forbidden_field not in run_section
+
+    handle_json_output(
+        RunResult(
+            success=True,
+            slowpics_url=None,
+            slowpics_upload_confirmation_status="declined",
+        )
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert "slowpics_url" in payload
+    assert payload["slowpics_url"] is None
+    assert "slowpics_upload_confirmation_status" not in payload
 
 
 def test_current_cli_contract_documents_slowpics_post_upload_behavior() -> None:
@@ -248,6 +276,44 @@ def test_current_cli_contract_documents_slowpics_post_upload_behavior() -> None:
         assert expected in normalized_webhook
 
 
+def test_current_cli_contract_documents_report_confirmed_slowpics_workflow() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    cli_contract = (repo_root / "docs" / "current-cli-contract.md").read_text(encoding="utf-8")
+    upload_heading = "### slow.pics Upload Behavior"
+    shortcut_heading = "### slow.pics Shortcut Policy"
+
+    upload_section = cli_contract.split(upload_heading, maxsplit=1)[1].split(
+        shortcut_heading,
+        maxsplit=1,
+    )[0]
+    normalized_upload = " ".join(upload_section.split())
+
+    for expected in (
+        "`slowpics.confirm_upload_after_report = true`",
+        "inert unless effective `slowpics.auto_upload = true`",
+        "There is no dedicated `run` flag for report-confirmed upload",
+        "`--no-upload` remains the only slow.pics-specific `run` flag",
+        "normal non-confirmed phase order remains",
+        "`frame_plan -> analyze -> align -> render -> metadata -> dovi -> publish -> report -> post_report_cleanup`",
+        "Report-confirmed upload changes only the opted-in interactive path",
+        "`frame_plan -> analyze -> align -> render -> metadata -> dovi -> report -> confirm_slowpics_upload -> publish -> post_report_cleanup`",
+        "`--json` was passed",
+        "`--quiet` was passed",
+        "stdin is not attached to a TTY",
+        "stdout is not attached to a TTY",
+        "`report.enable = false`",
+        "not regenerated after upload",
+        "`slowpics_url = null`",
+        "slow.pics upload skipped because report confirmation was unavailable",
+        "slow.pics upload skipped by confirmation",
+        "`slowpics_url` remains `None`",
+        "With `report.embed_images = false`, deletion is skipped",
+        "If upload is declined or report confirmation is unavailable",
+        "no slow.pics delete-after-upload cleanup runs",
+    ):
+        assert expected in normalized_upload
+
+
 def test_current_cli_contract_documents_slowpics_browser_report_precedence() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     cli_contract = (repo_root / "docs" / "current-cli-contract.md").read_text(encoding="utf-8")
@@ -266,6 +332,10 @@ def test_current_cli_contract_documents_slowpics_browser_report_precedence() -> 
         "report auto-open is suppressed for that run",
         "If slow.pics browser open is not attempted",
         "existing report auto-open rules above still apply",
+        "Report-confirmed slow.pics upload is the exception to that precedence rule",
+        "CLI presents the local report before prompting for upload",
+        "later confirmed upload will open the slow.pics URL in a browser",
+        "If it is not opened, the CLI prints the report path before prompting",
     ):
         assert expected in normalized_report_section
 
@@ -290,6 +360,36 @@ def test_current_architecture_documents_slowpics_service_flow_and_upload_plan() 
         "typed post-upload action results plus warnings",
         "does not own clipboard, browser, shortcut, or webhook side-effect policy",
         "The `.url` shortcut is not cleanup membership",
+    ):
+        assert expected in normalized_architecture
+
+
+def test_current_architecture_documents_report_confirmed_phase_order_and_owner_seams() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    architecture = (repo_root / "docs" / "current-architecture.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_architecture = " ".join(architecture.split())
+
+    for expected in (
+        "`slowpics.confirm_upload_after_report`",
+        "`frame_plan -> analyze -> align -> render -> metadata -> dovi -> report -> confirm_slowpics_upload -> publish -> post_report_cleanup`",
+        "The non-confirmed flow keeps the normal ordering above",
+        "report-confirmed upload prompting",
+        "Report-confirmed slow.pics upload uses a CLI-owned confirmation callback seam",
+        "`RunDependencies.confirm_slowpics_upload`",
+        "Orchestration owns the typed request, decision, confirmation-status state",
+        "it does not import Typer, open browsers, read stdin, or print prompt text",
+        "raises a typed config error before publish",
+        "`report_unavailable`",
+        "prevents slow.pics upload",
+        "`publish` is skipped and `slowpics_url` stays `None`",
+        "local report is generated before upload and is not regenerated after upload",
+        "report payload therefore has no slow.pics URL",
+        "CLI report presentation happens before the confirmation prompt",
+        "before any later post-upload slow.pics browser opening",
+        "existing non-confirmed rule remains",
+        "It does not own slow.pics upload policy, prompting, or browser side effects",
     ):
         assert expected in normalized_architecture
 

--- a/uv.lock
+++ b/uv.lock
@@ -327,6 +327,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyperclip" },
     { name = "rich" },
     { name = "structlog" },
     { name = "tomli-w" },
@@ -362,6 +363,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
+    { name = "pyperclip", specifier = ">=1.11.0" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "tomli-w", specifier = ">=1.2.0" },
@@ -916,6 +918,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Report-confirmed slow.pics upload (show local HTML report, prompt to confirm before uploading)
  * Post-upload actions: clipboard copy, browser open, deterministic .url shortcut, HTTPS webhook delivery
  * Report viewer: new info modal, overlay toggle, pinch-zoom and swap-clip shortcuts

* **Improvements**
  * Safer CLI/TTY validation; --json/--quiet reject interactive confirm flows
  * Report auto-open suppressed when slow.pics browser open applies
  * Safer webhook validation and deterministic shortcut placement

* **Documentation**
  * Expanded architecture, CLI contract, and design/plans docs

* **Tests**
  * Large expansion of CLI, orchestration, service, renderer, and integration tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->