### PR TITLE
Update release process and documentation for licensing

### DIFF
--- a/.agents/rules/general-guidelines.md
+++ b/.agents/rules/general-guidelines.md
@@ -27,7 +27,8 @@ entrypoint shim only; it must not become a second runbook.
   JSON, config persistence, and report-open behavior.
 - `importlinter.ini` owns import-layer direction.
 - `pyproject.toml` owns local Python tooling policy and pytest markers.
-- `docs/plans/**` is reference-only unless the file starts with `Status: Active`.
+- `docs/plans/**` is reference-only unless the required search-exclusion front
+  matter is followed by `Status: Active`.
 - `.agents/rules/general-guidelines.md` is Antigravity routing material only. If it
   conflicts with the files above, follow those files and update this shim.
 

--- a/.codex/review-context.md
+++ b/.codex/review-context.md
@@ -54,7 +54,8 @@ Current truth:
 
 Historical/reference only:
 - `docs/DECISIONS.md` for historical exceptions/decisions
-- `docs/plans/**` unless the file starts with `Status: Active`
+- `docs/plans/**` unless the file has the required search-exclusion front matter
+  followed by `Status: Active`
 - `.codex/cache/**` local cache only
 
 ## Control-Plane / Config Paths

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,11 +159,43 @@ jobs:
       - name: Run import-linter
         run: uv run --no-sync lint-imports --config importlinter.ini
 
+  package:
+    name: Build and Install Distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - name: Build wheel and source distribution
+        run: uv build --out-dir dist
+
+      - name: Inspect distribution contents
+        run: |
+          uv venv .dist-venv --python ${{ env.PYTHON_VERSION }}
+          .dist-venv/bin/python scripts/verify_distribution.py dist
+
+      - name: Install wheel in fresh environment
+        run: uv pip install --python .dist-venv/bin/python dist/*.whl
+
+      - name: Smoke installed CLI
+        run: |
+          .dist-venv/bin/frame-compare version
+          .dist-venv/bin/frame-compare --help
+
   # All jobs must pass for PR merge
   ci-pass:
     name: CI Pass
     runs-on: ubuntu-latest
-    needs: [lint, security, typecheck, test, import-lints]
+    needs: [lint, security, typecheck, test, import-lints, package]
     if: always()
     steps:
       - name: Check all jobs passed
@@ -172,7 +204,8 @@ jobs:
              [[ "${{ needs.security.result }}" != "success" ]] || \
              [[ "${{ needs.typecheck.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
-             [[ "${{ needs.import-lints.result }}" != "success" ]]; then
+             [[ "${{ needs.import-lints.result }}" != "success" ]] || \
+             [[ "${{ needs.package.result }}" != "success" ]]; then
             echo "One or more CI jobs failed"
             exit 1
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,24 +19,3 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-      - name: Enable auto-merge for release PR (best-effort)
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
-          RELEASE_PLEASE_PR: ${{ steps.release.outputs.pr }}
-        run: |
-          if [ -z "$RELEASE_PLEASE_PR" ]; then
-            echo "release-please reported prs_created=true but did not provide steps.release.outputs.pr"
-            exit 0
-          fi
-
-          pr_number="$(printf '%s' "$RELEASE_PLEASE_PR" | jq -r '.number // empty')"
-          if [ -z "$pr_number" ]; then
-            echo "Could not parse PR number from steps.release.outputs.pr"
-            printf '%s\n' "$RELEASE_PLEASE_PR"
-            exit 0
-          fi
-
-          gh pr merge "$pr_number" --auto --merge --delete-branch

--- a/.github/workflows/windows-portable.yml
+++ b/.github/workflows/windows-portable.yml
@@ -13,8 +13,6 @@ jobs:
   build:
     permissions:
       contents: read
-    outputs:
-      update_signed: ${{ steps.sign_update.outputs.signed }}
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -214,10 +212,9 @@ jobs:
             -OutFile $updateZip
           "UPDATE_ZIP=$updateZip" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
-      # Pull requests prove update zip creation without requiring signing secrets.
-      # Release/manual runs sign only when the private key XML secret is configured.
+      # Pull requests prove unsigned update zip creation without signing secrets.
+      # Release/manual runs require a signed update and fail closed without the key.
       - name: Sign code-only update zip
-        id: sign_update
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         shell: pwsh
         env:
@@ -226,9 +223,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $true
           if ([string]::IsNullOrWhiteSpace($env:WINDOWS_UPDATE_SIGNING_KEY_XML)) {
-            Write-Host "::notice::Skipping signed update zip; WINDOWS_UPDATE_SIGNING_KEY_XML secret is not configured."
-            "signed=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-            exit 0
+            throw "WINDOWS_UPDATE_SIGNING_KEY_XML is required for release and manual runs."
           }
 
           $keyPath = Join-Path $env:RUNNER_TEMP "frame-compare-update-signing-key.xml"
@@ -238,7 +233,6 @@ jobs:
             $env:SIGNING_KEY_XML_PATH = $keyPath
             pwsh -NoProfile -ExecutionPolicy Bypass -File tools/windows_portable/sign_update.ps1 `
               -UpdateZip $env:UPDATE_ZIP
-            "signed=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           } finally {
             Remove-Item Env:\SIGNING_KEY_XML_PATH -ErrorAction SilentlyContinue
             if (Test-Path -LiteralPath $keyPath -PathType Leaf) {
@@ -255,6 +249,8 @@ jobs:
 
       - name: Verify code-only update zip layout
         shell: pwsh
+        env:
+          REQUIRE_SIGNED_UPDATE: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
         run: |
           $ErrorActionPreference = "Stop"
           Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -291,7 +287,7 @@ jobs:
           if ($manifest.signature_file -ne "update-manifest.sig") {
             throw "Unexpected update signature file: $($manifest.signature_file)"
           }
-          if ("${{ steps.sign_update.outputs.signed }}" -eq "true" -and $entries -notcontains "update-manifest.sig") {
+          if ($env:REQUIRE_SIGNED_UPDATE -eq "true" -and $entries -notcontains "update-manifest.sig") {
             throw "Signed update zip is missing update-manifest.sig."
           }
 
@@ -302,6 +298,7 @@ jobs:
           path: |
             dist/frame-compare-portable-win-x64.zip
             dist/frame-compare-portable-win-x64.zip.sha256
+          if-no-files-found: error
 
       - name: Upload code-only update artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -310,6 +307,7 @@ jobs:
           path: |
             dist/frame-compare-update-win-x64-*.zip
             dist/frame-compare-update-win-x64-*.zip.sha256
+          if-no-files-found: error
 
   release-assets:
     if: github.event_name == 'release'
@@ -325,7 +323,6 @@ jobs:
           path: dist/release-assets
 
       - name: Download signed update artifact
-        if: needs.build.outputs.update_signed == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: frame-compare-update-win-x64
@@ -349,7 +346,6 @@ jobs:
           printf '%s  %s\n' "$hash" "$(basename "$zip")" > "$zip.sha256"
 
       - name: Prepare versioned signed update asset
-        if: needs.build.outputs.update_signed == 'true'
         env:
           ASSET_TAG: ${{ steps.release_names.outputs.asset_tag }}
         run: |
@@ -364,21 +360,31 @@ jobs:
           hash="$(sha256sum "$versioned_update_zip" | cut -d ' ' -f 1)"
           printf '%s  %s\n' "$hash" "$(basename "$versioned_update_zip")" > "$versioned_update_zip.sha256"
 
-      - name: Upload release bundle asset
+      - name: Verify required release asset set
+        env:
+          ASSET_TAG: ${{ steps.release_names.outputs.asset_tag }}
+        run: |
+          required=(
+            "dist/release-assets/frame-compare-portable-win-x64-${ASSET_TAG}.zip"
+            "dist/release-assets/frame-compare-portable-win-x64-${ASSET_TAG}.zip.sha256"
+            "dist/release-assets/frame-compare-update-win-x64-${ASSET_TAG}.zip"
+            "dist/release-assets/frame-compare-update-win-x64-${ASSET_TAG}.zip.sha256"
+          )
+          for asset in "${required[@]}"; do
+            if [ ! -f "$asset" ]; then
+              echo "Missing required release asset: $asset" >&2
+              exit 1
+            fi
+          done
+
+      - name: Upload required release assets
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: ${{ github.event.release.tag_name }}
           prerelease: ${{ github.event.release.prerelease || contains(github.event.release.tag_name, '-rc') }}
+          fail_on_unmatched_files: true
           files: |
             dist/release-assets/frame-compare-portable-win-x64-${{ steps.release_names.outputs.asset_tag }}.zip
             dist/release-assets/frame-compare-portable-win-x64-${{ steps.release_names.outputs.asset_tag }}.zip.sha256
-
-      - name: Upload signed update release asset
-        if: needs.build.outputs.update_signed == 'true'
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          tag_name: ${{ github.event.release.tag_name }}
-          prerelease: ${{ github.event.release.prerelease || contains(github.event.release.tag_name, '-rc') }}
-          files: |
             dist/release-assets/frame-compare-update-win-x64-${{ steps.release_names.outputs.asset_tag }}.zip
             dist/release-assets/frame-compare-update-win-x64-${{ steps.release_names.outputs.asset_tag }}.zip.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,128 +1,76 @@
 # Changelog
 
-All notable changes to this project are documented in this file.
+All notable user-facing changes to Frame Compare are documented in this file.
 
-This project follows Conventional Commits and is intended to be released via Release Please.
+Frame Compare follows Conventional Commits, and Release Please turns the
+`Unreleased` section into versioned release notes.
 
 ## Unreleased
 
+This is the first public alpha release of Frame Compare.
+
 ### Added
 
-- **Run Dependencies:** Added `RunDependencies` DI container with lazy default VS/FFmpeg providers (stub-only FFmpeg runner) and orchestration export (Phase 6.7).
-- **Tonemap Wiring:** Added `should_tonemap`, `resolve_tonemap_settings`, and `probe_is_hdr_ffprobe` helpers. Modified `render_screenshots` to require `config: ConfigSchema` and enforce HDR+tonemap fallback policy (Phase 6.5).
-- **VSPreview Integration:** Added `frame_compare.vspreview` module with `is_vspreview_available`, `launch_alignment_verification_session`, `load_manual_overrides`, `save_manual_override`, `ManualOverride`, `VSPreviewConfig`, `VSPreviewNotFoundError` (FC-2008), and `VSPreviewError` (FC-4019). Integrated manual override precedence in `align_clips` (Phase 6.6).
-- **Tonemap Gating Error:** Added `TonemapRequiresVapourSynthError` (FC-2009) for explicit HDR+tonemap renderer-gating failures.
-- **Documentation:** Expanded `README.md` with Docker-first usage examples (`wizard`, `doctor`, `run`) and added deterministic API documentation generation (`scripts/generate_api_docs.py` → `docs/api.md`) with unit tests.
-- FramePlan module (`frame_compare.analysis.frame_plan`) for deterministic frame selection (`--skip-analysis`).
-- `select_reporter()` function for CLI output mode → progress reporter mapping (Phase 6.3).
-- **Preflight Validation:** `prepare_preflight()` for workspace resolution, config loading, and input discovery with `PreflightResult` type (Phase 6.2).
-- **Doctor Diagnostics:** `run_doctor()` for environment validation with deterministic check ordering and `DoctorReport` type (Phase 6.2).
-- **WorkspacePaths Type:** `WorkspacePaths` dataclass in `frame_compare.utils` for resolved paths (Phase 6.2).
-- **NoVideosFoundError Enhancement:** Added `patterns` parameter for deterministic error introspection (Phase 6.2).
-- **Orchestration Package Scaffold:** Created `frame_compare.orchestration` package structure (Phase 6.1). Includes scaffold modules for `preflight`, `doctor`, `progress`, and `phases`. Updated import-linter contract.
-- **Report Generator:**
-  - HTML comparison report generator with Slider, Overlay, Difference, and Blink modes.
-  - Dark theme with modern styling.
-  - Filmstrip thumbnail navigation.
-  - Keyboard shortcuts (←/→ frames, ↑/↓ encodes, S/O/D/B modes).
-  - Basic zoom controls (25%-200%).
-  - Accessibility features (ARIA labels, keyboard navigation).
-- **Publishers Service:**
-  - `SlowpicsPublisher` for uploading screenshots to slow.pics.
-  - Automatic retry logic with exponential backoff and jitter.
-  - Rate limit handling (HTTP 429).
-  - Configurable visibility (public/unlisted/private).
-  - Optional deletion of local files after successful upload.
-- **Metadata Service:**
-- Filename parsing strategy using `guessit` and `anitopy` with anime/western priority heuristics.
-- TMDB API client with API key validation, rate limit handling, and result mapping.
-- Interactive metadata resolution workflow (`resolve_metadata`) with optional user selection callback.
-- Audio alignment service (`services.alignment`) for synchronization of comparison clips to reference.
-- `ProgressReporter` Protocol and implementations (`RichProgressReporter`, `LogProgressReporter`) in `utils.progress`.
-- `render.orchestrator` module for high-level batch rendering and screenshot orchestration
-- `ProgressReporter` Protocol for unified progress reporting
-- `render.encoders` module with VapourSynth and FFmpeg frame extraction strategies
-- `utils.subproc` module for secure subprocess execution
-- `render.overlay` module with text overlay rendering and `pillow` dependency
-- `render.naming` module with screenshot name generation and label sanitization
-- `render.geometry` module with dimension calculation and overlay positioning utilities
-- Added `frame_compare.render` module with type definitions
-- Phase 4 (Render Module) complete: types, geometry, naming, overlay, encoders, orchestrator with integration tests
-- Docker integration verification gate: `tools/verify_docker_integration.sh` + `frame-compare-test` Compose service (real VS+FFmpeg, zero skips)
-- **CI/CD Pipeline:** GitHub Actions workflow with Ruff linting, Pyright type checking, and pytest stages.
-- **CI/CD Pipeline:** Add Docker integration workflow for VS+FFmpeg integration tests on relevant PR changes.
-- **Phase 0 Foundation:** Project scaffolding with `pyproject.toml`, `src/frame_compare/` structure, and development tooling (Pyright strict, Ruff, pytest).
-- CLI entry point with `version` command.
-- PEP 561 `py.typed` marker for typed package support.
-- Dev dependency `pyyaml` for local contract view checks.
-- Dev dependency `import-linter` for running `lint-imports` locally.
-- Complete error hierarchy: DependencyError, InputError, ProcessingError, NetworkError, InternalError
-- `ExitCode` enum for CLI exit code mapping
-- `get_exit_code()` helper function
-- `format_error_console()` and `format_error_json()` formatting utilities
-- Structured logging infrastructure with structlog (json/console formats)
-- Correlation ID tracking for run tracing (`new_run_id`, `get_run_id`)
-- CLI foundation commands: `run` (full signature), `wizard`, `doctor`, `preset` (list/apply/save) stubs.
-- `handle_error` utility mapping FrameCompareError to exit codes.
-- Analysis module types: `ClipIdentity`, `MetricsMetadata`, `FrameMetrics`, `SelectionBreakdown`, `FrameSelection`, `CacheLoadResult`
-- Analysis module frame selection algorithms: quantile, motion, and random modes with minimum gap enforcement.
-- Analysis module metrics calculation: per-frame luminance and motion analysis (`calculate_metrics`).
-- Analysis module cache I/O: deterministic cache key generation, metrics persistence (JSON Schema v2), and failure-resilient cache loading.
-- VapourSynth module foundation (`frame_compare.vs`) with environment detection, plugin checks, and `VSLoader` protocol.
-- Video source loading (`load_source`) with LWLibavSource support.
-- HDR detection from frame properties (PQ, HLG, BT.2020).
-- Frame trimming with inclusive end semantics.
-- `ColorProps` type for color space properties.
-- `get_color_props()` function to extract color properties from clip.
-- `is_hdr()` function to detect HDR clips.
-- Deterministic color metadata inference and conversion logic (`vs/color.py`).
-- `to_rgb24()` utility for high-quality screenshot export with range expansion.
-- Opt-in performance timing logs via `FRAME_COMPARE_PERF=1` spans.
-- HDR tonemapping (`apply_tonemap`) with 7 presets (BT.2390, Spline, Reinhard).
-- libplacebo integration for high-quality tonemapping with automatic Reinhard fallback.
-- VapourSynth module integration (`frame_compare.vs` exports).
-- Public API alias `tonemap` for convenience.
-- Real VapourSynth integration smoke tests (`test_integration.py`).
+- A complete comparison pipeline that discovers video inputs, probes media,
+  selects useful frames, aligns encodes, renders labeled screenshots, and produces
+  a self-contained offline HTML report.
+- Reproducible random selection and quality-oriented dark, bright, and motion frame
+  selection, including reusable analysis and alignment caches.
+- Audio-correlation alignment with saved manual overrides and optional interactive
+  verification through VSPreview.
+- SDR rendering and HDR tonemapping through VapourSynth, vs-placebo, and a
+  deterministic software-Vulkan Docker baseline.
+- Configurable screenshot labels and an offline report with slider, overlay,
+  difference, blink, grid, filmstrip, keyboard navigation, and zoom tools.
+- Guided setup, environment diagnostics, dry-run planning, presets, run history,
+  machine-readable JSON output, and structured logs.
+- Optional slow.pics publishing and Discord-compatible webhook notifications.
+  Network publishing remains disabled until deliberately configured.
+- A Windows 10/11 x64 portable distribution containing Python, FFmpeg,
+  VapourSynth, required plugins, VSPreview, PyQt6, user-level installation, and
+  code-only update tooling.
+- Reproducible Docker and native-source installation routes for macOS and Linux,
+  with separately documented experimental Linux NVIDIA and X11 profiles.
 
 ### Changed
 
-- Workflow: allow auto-generated contract view diffs from `generate_contract_views.py` without blocking review when freshness is verified.
-- Workflow: Coding Agent must run the full local gate suite (pyright/ruff/pytest/import-linter + contract freshness check) before handing off `impl-vN.md` to Verification.
-- Workflow: Verification Agent may apply Ruff auto-fixes (`ruff check --fix` + `ruff format`, no `--unsafe-fixes`) when Ruff is the only failing quality gate, and must record changes via `impl-v(N+1).md`.
-- Workflow: Plan Review may apply mechanical auto-fixes to plans (format/wiring only) and must audit SSOT/spec changes for correctness before approval.
-- Workflow: replaced `AGENTS.md` with a token-efficient SSOT pointer + command canon for IDE agents.
-- `ColorProps` range default aligned with SSOT (missing or unspecified `_ColorRange` defaults to limited/1).
-- Planning/Plan Review prompts: require copy-forward plan revisions and a `## Changes Since plan-vN` summary to reduce churn during plan iteration.
-- Planning/Plan Review/Coding/Review prompts + workflow docs: added SSOT anchoring guardrails (Spec Anchors + one-line signatures + SSOT drift gate), anti-churn line budget + iteration cap, and Review routing rules (implementation defect vs spec drift vs design issue).
-- Verification workflow adds `scripts/validate_spec_anchors.py` as a STOP gate for plan/spec consistency.
-- Planning/Plan Review prompts: do not gate plan approval on exact `docs/DECISIONS.md` prose; allow large parametric tests to anchor to the SSOT deterministic test vector policy instead of listing exhaustive constructor args.
-- Import-linter configuration is treated as SSOT in `importlinter.ini`; docs/workflow updated to match real module paths and require updating `importlinter.ini` whenever new top-level modules are introduced.
-- Coding Agent prompt tightened to stop at `impl-vN.md` handoff (no Verification/Review role bleed).
-- Coding Agent required to run contract-view freshness check (and regenerate if needed) before handing off to Verification to prevent stale-contract churn.
-- Review Agent now outputs a single-line Conventional Commit subject summarizing the full checklist item/run.
-- Verification/Review flow now enforces phase gate updates only when the last item in a phase is completed.
-- VS module SSOT defines Phase 3.4 color operations API (BT.709/BT.2020 + limited/full handling) and clarifies missing `_ColorRange` defaults.
-- Docker build now compiles `zimg` and `l-smash` from official release tarballs with checksum verification, installs Cython via pip for Python 3.13 compatibility, pins L-SMASH-Works to a published tag, and guards SSE2 headers for ARM builds.
-- Docker build adds `python3-jinja2` and `libvulkan-dev` to satisfy libplacebo tooling requirements, pins vs-placebo to a commit with submodules, and pins ffms2 to a FFmpeg 5-compatible commit.
-- Docker runtime image installs `wget` and `ca-certificates` to support DevContainer server bootstrap.
-- Docker runtime image installs `which` so the DevContainer bootstrap can detect `wget`.
-- Docker runtime image installs `procps` to provide `ps` for DevContainer bootstrap.
-- OPUS rebuild docs synced to the container baseline (`Dockerfile`) and updated to match current Bookworm/pin assumptions (deployment/system design/ADR/vs-module/feature parity).
-- Documentation updates L-SMASH Works verification to prefer the `lsmas` namespace with a legacy `lw` fallback.
-- Completed Analysis module public API exports (`calculate_metrics`).
-- Refactored metrics module to use lazy VapourSynth imports for non-VS environments.
+- Frame Compare is licensed under `GPL-3.0-only`, aligning the project with its
+  GPL-licensed PyQt6 desktop runtime.
+- Local reports are the default output. Uploading, webhook delivery, automatic
+  browser opening, and clipboard integration are explicit, route-dependent
+  actions.
+- Release Please release PRs require human review and are never auto-merged by the
+  project workflow.
 
 ### Fixed
 
-- Docker integration tests now include VS-required tests from `tests/vs/`
-- Fixed FFmpeg render paths to raise `TonemapRequiresVapourSynthError` (FC-2009) for HDR+tonemap-required frames, preventing silent untonemapped outputs.
-- Fixed PIL deprecation warning causing test failure in Docker
-- Fixed test collection failure on macOS with partial VapourSynth install
-- Fixed libplacebo tonemapping in Docker (16-bit input conversion)
-- Fixed `vs.core` access pattern in tonemap module
-- Enabled Vulkan in Docker image for libplacebo (Mesa lavapipe)
-- Added runtime fallback when libplacebo fails
-- Added Docker tonemap integration test; libplacebo success is optional (can be required via `FRAME_COMPARE_REQUIRE_LIBPLACEBO=1`)
-- Fixed RGB->RGB conversion error in tonemap module (removed invalid `matrix_in_s` for RGB inputs)
-- Fixed Docker test runner to force deterministic lavapipe selection for Vulkan
-- Added missing `pytest-mock` dependency to Docker image
+- HDR frames that require tonemapping now fail clearly when the selected renderer
+  cannot provide it instead of silently producing untonemapped output.
+- Doctor recovery guidance links to the maintained installation documentation.
+- Docker integration covers the real FFmpeg, VapourSynth, loader-plugin,
+  screenshot, report, and software-tonemapping paths.
+
+### Security and privacy
+
+- External processes are invoked without shell expansion, and release/runtime
+  downloads with pinned inputs are checksum-verified where supported.
+- Slow.pics uploads and webhook notifications are opt-in; an offline comparison
+  does not require publishing video frames or report data.
+- Windows release ZIPs include SHA-256 checksum assets and documented verification
+  instructions.
+
+### Known limitations
+
+- This is alpha software. Review generated frames and alignment before relying on
+  a comparison.
+- The Windows portable distribution supports Windows 10/11 x64 only.
+- Default Docker on macOS and Linux is a headless backend route. It does not include
+  the interactive VSPreview desktop workflow.
+- Linux NVIDIA acceleration and X11 forwarding are experimental, host-dependent,
+  and require their separate proof procedures.
+- Native-source installation requires a compatible host FFmpeg, VapourSynth,
+  loader-plugin, Vulkan, and optional VSPreview toolchain.
+- Host fonts, graphics drivers, and Vulkan implementations can change rendering
+  details; cross-platform output is not promised to be pixel-identical.
+- slow.pics and webhook output depend on third-party network services and their
+  availability.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,13 @@ required verification for the current change.
 
 ---
 
+## Contribution licensing
+
+Submitted contributions are licensed under `GPL-3.0-only`, and contributors affirm
+that they have the right to submit them under those terms.
+
+---
+
 ## Documentation Development
 
 Authored documentation lives under `docs/`. The root `zensical.toml` owns the public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,7 +242,7 @@ Releases are automated from `main` using [Release Please](https://github.com/goo
 
 - On every push to `main`, the Release Please workflow opens or updates a PR like `chore(release): v0.1.1`.
 - Merging that PR publishes the GitHub Release and tag (e.g. `v0.1.1`).
-- If the repo has Auto-merge enabled, the workflow attempts to set the release PR to auto-merge once required checks pass.
+- Release PRs require maintainer review and are never auto-merged by the workflow.
 
 ### CI on release PRs (recommended)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for your interest in contributing! This guide will help you get starte
 - [Prerequisites](#prerequisites)
 - [Development Setup](#development-setup)
 - [Making Changes](#making-changes)
+- [Contribution licensing](#contribution-licensing)
 - [Documentation Development](#documentation-development)
 - [Pull Request Workflow](#pull-request-workflow)
 - [Code Style](#code-style)

--- a/LICENSE
+++ b/LICENSE
@@ -1,190 +1,674 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-   1. Definitions.
+                            Preamble
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+                       TERMS AND CONDITIONS
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+  0. Definitions.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+  "This License" refers to version 3 of the GNU General Public License.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+  1. Source Code.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-   END OF TERMS AND CONDITIONS
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-   Copyright 2025-2026 Tristan <zine96@proton.me>
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+  The Corresponding Source for a work in source code form is that
+same work.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > screenshots, offline reports, and optional publishable outputs.
 
 [![Python 3.13+](https://img.shields.io/badge/python-3.13%2B-3776AB?logo=python&logoColor=white)](#requirements)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 [![CI](https://github.com/TJZine/frame-compare/actions/workflows/ci.yml/badge.svg)](https://github.com/TJZine/frame-compare/actions/workflows/ci.yml)
 
 **[Read the documentation](docs/index.md)** to choose an installation route, run a
@@ -113,7 +113,8 @@ prefix, and Release Please automates releases from `main`.
 ## License
 
 Frame Compare is licensed under the
-[Apache License 2.0](https://github.com/TJZine/frame-compare/blob/main/LICENSE).
+[GNU General Public License v3.0 only](https://github.com/TJZine/frame-compare/blob/main/LICENSE)
+(`GPL-3.0-only`).
 
 ```text
 Copyright 2025-2026 Tristan <zine96@proton.me>

--- a/docs/ENGINEERING_RUNBOOK.md
+++ b/docs/ENGINEERING_RUNBOOK.md
@@ -261,8 +261,10 @@ Current CI ownership:
 - `.github/workflows/windows-portable.yml` is the canonical CI path for the full portable bundle.
 - `.github/workflows/windows-portable.yml` also builds and verifies a code-only
   update zip after the full bundle exists. Pull requests prove unsigned update
-  zip creation and layout. Release and manual runs sign the update zip only when
-  the `WINDOWS_UPDATE_SIGNING_KEY_XML` secret is configured.
+  zip creation and layout. Release and manual runs require
+  `WINDOWS_UPDATE_SIGNING_KEY_XML`; they fail before artifact publication when
+  the secret is absent or signing fails. Every public Windows release includes
+  the signed update zip and its checksum.
 
 When updater or release-package logic changes and the signed-update path cannot
 run locally or in CI with `WINDOWS_UPDATE_SIGNING_KEY_XML`, mark signing as

--- a/docs/ENGINEERING_RUNBOOK.md
+++ b/docs/ENGINEERING_RUNBOOK.md
@@ -36,7 +36,8 @@ If a task needs a broader compatibility promise, the maintainer must confirm it 
   and `pr-commit-review`
 - `README.md`: product overview, install, quickstart
 - `CONTRIBUTING.md`: contributor onboarding and PR mechanics
-- `docs/plans/**`: reference-only unless the file starts with `Status: Active`
+- `docs/plans/**`: reference-only unless the file has the required search-exclusion
+  front matter followed by `Status: Active`
 - `.codex/cache/**`: local cache material only, never current authority
 
 Do not create a second runbook, second architecture summary, or second current CLI contract.
@@ -439,11 +440,17 @@ It becomes authoritative only when all of these are true:
 
 1. The work needs a durable cross-session handoff, or the maintainer explicitly asks for a tracked plan file.
 2. A dated plan file is created or updated under `docs/plans/`.
-3. The plan starts with a metadata block containing `Status: Active`.
+3. The plan has the required Zensical search-exclusion front matter followed by an
+   activation metadata block containing `Status: Active`.
 
-Required active-plan metadata block:
+Required active-plan preamble:
 
 ```text
+---
+search:
+  exclude: true
+---
+
 Status: Active
 Scope: <task scope>
 Owner: <person or session>
@@ -452,6 +459,8 @@ Owner: <person or session>
 Rules:
 
 - If no active-plan marker exists, treat `docs/plans/` as reference-only.
+- Keep `search.exclude: true` on every tracked plan so internal planning material
+  cannot enter the user-documentation search index.
 - For single-session work, keep the plan inline unless a durable handoff is needed.
 - Only one active plan should exist per workstream.
 - When the work closes, change the marker to `Status: Historical` or move the document to historical/reference context in the same pass.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,19 +1,203 @@
 # Choose your installation
 
-Pick one route. Each route runs the same Frame Compare CLI, but the included runtime
-and host integration differ.
+Frame Compare has one CLI and several ways to provide its Python and media runtime.
+The best route depends mainly on your operating system, whether you need the
+VSPreview desktop interface, and how much of the native media toolchain you want to
+manage yourself.
 
-| Situation | Recommended route | Host requirements | Important differences |
-| --- | --- | --- | --- |
-| Windows 10/11 x64 | [Windows portable](../windows-portable.md) | PowerShell; Git and network access only when building from a clone | Most complete distribution. The full bundle includes Python, FFmpeg, VapourSynth R76, plugins, VSPreview, and PyQt6, plus the native installer and updater. |
-| macOS | [Docker](docker.md) | Docker Desktop with Compose | Reproducible headless backend, software Vulkan, HTML reports. No native GPU acceleration or Docker-based VSPreview GUI workflow. |
-| Linux, reproducible headless use | [Docker](docker.md) | Docker Engine or Docker Desktop with Compose | Default deterministic software-Vulkan path. Optional NVIDIA GPU and X11 profiles require separate host setup and proof. |
-| Linux or macOS with an existing media toolchain | [Native source](native.md) | Python 3.13+, FFmpeg, VapourSynth R76, L-SMASH-Works, and `uv` or pip | Advanced route. You own native dependency installation; VSPreview is optional. |
-| Development and contribution | Native contributor environment | Requirements in the contributor guide | Use the repository's locked development workflow; see [Contributing](https://github.com/TJZine/frame-compare/blob/main/CONTRIBUTING.md). |
+## Short answer
 
-VapourSynth is required by the default renderer. An FFmpeg-only configuration can
-set `screenshots.use_ffmpeg = true`, but HDR frames that need tonemapping still use
-the VapourSynth path. VSPreview is separate and optional unless you need interactive
-manual alignment.
+| If you are... | Start here | Why |
+| --- | --- | --- |
+| On Windows 10/11 x64 | [Published Windows portable bundle](../windows-portable.md) | Easiest and most complete route. Python, FFmpeg, VapourSynth, required plugins, VSPreview, PyQt6, installer, and updater are included. |
+| On macOS | [Default Docker route](docker.md) | Reproducible, headless setup without assembling a native media toolchain. |
+| On Linux and want a predictable headless setup | [Default Docker route](docker.md) | Canonical software-Vulkan path and the closest match to runtime integration CI. |
+| On Linux with NVIDIA or X11 requirements | [Advanced Docker environments](../docker-environments.md) | Optional, host-dependent GPU and desktop profiles with separate proof commands. |
+| Comfortable managing FFmpeg and VapourSynth yourself | [Native source with `uv`](native.md#install-with-uv) | Locked Python environment with direct host integration. |
+| Integrating into an existing Python environment | [Native source with pip](native.md#install-with-pip) | Flexible, but you own Python dependency resolution and the full native runtime. |
+| Contributing code | [Contributor setup](https://github.com/TJZine/frame-compare/blob/main/CONTRIBUTING.md) | Includes development, test, lint, typing, and documentation dependencies. |
 
-After installation, continue with [Your First Comparison](../guides/first-comparison.md).
+```mermaid
+flowchart LR
+    A{"Windows x64?"}
+    A -->|Yes| B["Release ZIP<br/>or source-built bundle"]
+    A -->|No| C{"Need desktop VSPreview?"}
+    C -->|Yes| D["Native source<br/>or experimental Linux X11"]
+    C -->|No| E{"Prefer an isolated runtime?"}
+    E -->|No| F["Native source with uv<br/>or pip"]
+    E -->|Yes| G["Default Docker<br/>software Vulkan"]
+    G --> H{"Linux NVIDIA GPU needed?"}
+    H -->|Yes| I["Experimental NVIDIA profile"]
+    H -->|No| J["Use default Docker"]
+```
+
+## Route comparison
+
+### Setup and support profile
+
+| Route | Host | Setup effort | Dependency ownership | Reproducibility | Support posture |
+| --- | --- | ---: | --- | --- | --- |
+| Windows release ZIP | Windows 10/11 x64 | Lowest | Bundle provides the runtime | High; release artifacts and runtime inputs are pinned | Recommended Windows route |
+| Windows source build | Windows 10/11 x64 | Medium to high | Build script downloads and assembles pinned runtime inputs | High after a successful build | Supported, slower fallback |
+| Docker default | macOS or Linux | Low to medium | Image provides Python and media dependencies | High; deterministic software-Vulkan baseline | Recommended headless macOS/Linux route |
+| Docker NVIDIA | Compatible Linux NVIDIA host | High | Image plus host driver and NVIDIA Container Toolkit | Host-dependent | Experimental; separately verified |
+| Docker X11 GUI | Linux X11 desktop | High | Image plus host display, permissions, and optional Xauthority | Host-dependent | Experimental; separately verified |
+| Native source with `uv` | macOS, Linux, or an advanced Windows setup | High | Locked Python environment; you provide native media dependencies | High for Python, host-dependent for media libraries | Advanced |
+| Native source with pip | Any compatible Python host | Highest | You provide and resolve Python and native dependencies | Lower; project requirements are minimum bounds | Advanced/integration-oriented |
+| Contributor environment | Development hosts | High | Locked dev and runtime dependencies plus native tools | High for repository work | Development only |
+
+“High reproducibility” does not mean identical pixels on every operating system.
+Host GPU drivers, Vulkan implementations, and available fonts can affect rendering
+details. Use the same route and runtime when bit-for-bit comparison is important.
+
+### Included runtime
+
+| Route | Python environment | FFmpeg | VapourSynth + loader plugins | VSPreview + PyQt6 | Installer/updater |
+| --- | --- | --- | --- | --- | --- |
+| Windows release ZIP | Included (Python 3.13.13 in the current bundle manifest) | Included, LGPL-only build | Included (VapourSynth R76, L-SMASH-Works, and vs-placebo) | Included | Included |
+| Windows source build | Built into the resulting bundle | Downloaded by the builder | Downloaded/installed by the builder | Installed by the builder | Included |
+| Docker default | Included in image | Included | Included | Not in the default runtime target | Rebuild/pull the image |
+| Docker NVIDIA | Included in image | Included | Included | Not by the GPU profile alone | Rebuild/pull the image |
+| Docker X11 GUI | Included in GUI image target | Included | Included | Included in the optional GUI target | Rebuild/pull the image |
+| Native source with `uv` | Created from `uv.lock` | Host-provided | Host-provided; `vspreview` extra supplies related Python packages | Optional extra | None |
+| Native source with pip | Created/selected by you | Host-provided | Host-provided | Optional extra | None |
+
+The repository currently documents Docker as a build-from-clone route; it does not
+promise a prebuilt public container image. The pip route is also install-from-clone,
+not a promise that a package has been published to PyPI.
+
+### Feature availability
+
+| Capability | Windows portable | Docker default | Docker NVIDIA | Docker X11 | Native source |
+| --- | --- | --- | --- | --- | --- |
+| Frame discovery, selection, analysis, and alignment | Yes | Yes | Yes | Yes | Yes, with required runtime |
+| SDR screenshots and labeled comparison output | Yes | Yes | Yes | Yes | Yes, with required runtime |
+| HDR tonemapping | Yes; uses host Vulkan stack | Yes; software Vulkan | Intended host GPU path | Yes; rendering remains host-dependent | Yes, with compatible VapourSynth/vs-placebo and Vulkan setup |
+| Offline HTML report | Yes | Yes | Yes | Yes | Yes |
+| Run folders, cache, and history commands | Yes | Yes; files remain on host mounts | Yes | Yes | Yes |
+| slow.pics publishing and webhooks | Available; opt-in and network-dependent | Available; opt-in and network-dependent | Same as default Docker | Same as default Docker | Available; opt-in and network-dependent |
+| Interactive VSPreview alignment | Included | No | No, not from GPU profile alone | Experimental, X11-only | Optional and host-managed |
+| Automatically open report/slow.pics URL | Native host behavior | No; use host helper | No; use host helper | Host-dependent | Native host behavior |
+| Clipboard integration | Native host behavior | Do not rely on container-to-host clipboard | Do not rely on container-to-host clipboard | Host-dependent | Native host behavior |
+| Code-only signed updates and rollback | Windows release update assets only | No | No | No | No |
+
+All routes keep slow.pics automatic upload disabled in the first-use configuration.
+Local rendering and report generation do not require publishing. See
+[Publishing and Webhooks](../guides/publishing-and-webhooks.md) before enabling any
+network output.
+
+## What each route is best at
+
+### Windows release ZIP
+
+Choose this for the least setup and the broadest tested feature set on Windows. It
+contains the runtime needed by the application, supports VSPreview for interactive
+manual alignment, and provides user-level install, update, backup, rollback, and
+uninstall commands.
+
+Tradeoffs:
+
+- Windows x64 only;
+- a larger download because the media and UI runtimes are bundled;
+- GPU behavior still depends on the host Vulkan-capable graphics stack;
+- verify the release ZIP against its published `.sha256` file before installing.
+
+Follow [Windows Portable Install](../windows-portable.md).
+
+### Windows source-built portable bundle
+
+Choose this only when no suitable published bundle exists or when validating the
+packaging path. It produces the same bundle layout and installed command as the
+release ZIP, but needs Git, PowerShell, network access, build time, download cache
+space, and access to every pinned upstream artifact.
+
+Follow the [source-build section](../windows-portable.md#from-a-cloned-repo).
+
+### Default Docker
+
+Choose this for an isolated, reproducible, headless setup on macOS or Linux. The
+default path uses software Vulkan, keeps media and configuration read-only during a
+normal run, and writes reports and generated data through explicit host mounts.
+
+Tradeoffs:
+
+- build the image from the repository before first use;
+- no Docker-based VSPreview workflow in the default profile;
+- no native GPU acceleration on macOS Docker Desktop;
+- a container cannot directly open the host browser or reliably use the host
+  clipboard, so use the supplied host-open helper;
+- optional GPU and GUI profiles are not covered by the default support claim.
+
+Follow [Docker](docker.md).
+
+### Docker NVIDIA
+
+This optional Linux-only profile is for a compatible NVIDIA host. It needs the
+NVIDIA Container Toolkit, a sufficiently recent Docker Compose implementation, and
+a successful run of the dedicated GPU proof. It does not add VSPreview by itself.
+
+Treat it as experimental until it passes on your actual host. See
+[NVIDIA GPU Profile](../docker-environments.md#nvidia-gpu-profile).
+
+### Docker X11 GUI
+
+This optional Linux desktop profile supplies VSPreview/PyQt6 and forwards an X11
+session. It needs a live `DISPLAY`, the X11 socket, matching host/container user
+IDs, and sometimes an Xauthority cookie. Wayland-only, VNC, noVNC, and broad
+`xhost +` workflows are outside the documented contract.
+
+Treat it as experimental until the proof passes and a real manual launch succeeds
+on your host. See
+[Linux X11 GUI Profile](../docker-environments.md#linux-x11-gui-profile).
+
+### Native source with `uv`
+
+Choose this when you want native host behavior and can install the media toolchain.
+`uv` reproduces the repository's locked Python dependency graph; you still provide
+FFmpeg, VapourSynth R76, L-SMASH-Works, compatible Vulkan support, and optionally
+VSPreview.
+
+This is the preferred native-source route because its Python environment is locked.
+Follow [Install with uv](native.md#install-with-uv).
+
+### Native source with pip
+
+Choose this when Frame Compare must live in an existing Python environment or `uv`
+is unsuitable. The project declares minimum Python dependency versions, so pip may
+resolve a newer combination than the repository's tested lockfile. Isolate the
+installation in a virtual environment and run `frame-compare doctor` after every
+install or upgrade.
+
+Follow [Install with pip](native.md#install-with-pip).
+
+## Important runtime rules
+
+- Python 3.13 or newer is required for native-source routes.
+- VapourSynth is required by the default renderer.
+- `screenshots.use_ffmpeg = true` can select an FFmpeg-only screenshot path, but HDR
+  frames that need tonemapping still require VapourSynth.
+- VSPreview is optional unless you want interactive manual alignment.
+- Docker default, Docker NVIDIA, and Docker X11 are distinct proof surfaces. Passing
+  the default Docker check does not prove either optional profile.
+- Run `frame-compare doctor` after installation, then perform a dry run before the
+  first real comparison.
+
+## Recommended first-run sequence
+
+Regardless of route:
+
+1. Put at least two supported clips (`.mkv`, `.mp4`, `.avi`, `.m2ts`, or `.ts`) in
+   the route's `comparison_videos/` directory, or provide explicit inputs.
+2. Run `frame-compare wizard` using the command prefix documented for your route.
+3. Run `frame-compare doctor` and resolve failures relevant to your intended
+   features.
+4. Run `frame-compare run --root . --dry-run` to inspect inputs, paths, frame
+   selection, and output intent without rendering.
+5. Run `frame-compare run --root .`.
+6. Open the generated local HTML report. Docker users should use the
+   [host-open helper](../docker-environments.md#host-open-helper).
+7. Enable slow.pics or webhook output only after reviewing the
+   [publishing guide](../guides/publishing-and-webhooks.md).
+
+Continue with [Your First Comparison](../guides/first-comparison.md) for a detailed
+walkthrough.

--- a/docs/plans/2026-07-25-initial-release-remediation.md
+++ b/docs/plans/2026-07-25-initial-release-remediation.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 Status: Active
 Scope: Initial public release readiness and production-review remediation
 Owner: Maintainer

--- a/docs/plans/2026-07-25-initial-release-remediation.md
+++ b/docs/plans/2026-07-25-initial-release-remediation.md
@@ -451,8 +451,8 @@ Implementation approach:
 1. Audit secret presence and token permissions without exposing the token.
 2. Create a disposable prerelease or RC tag through the actual Release Please path.
 3. Observe the release event and Windows workflow.
-4. Require the portable ZIP and checksum; require the signed update ZIP/checksum if
-   updates are part of the release promise.
+4. Require the portable ZIP and checksum, plus the signed update ZIP and checksum,
+   for every public Windows release and release-like manual rehearsal.
 
 Verification:
 
@@ -460,7 +460,7 @@ Verification:
 - Windows workflow starts from the release event without manual intervention.
 - Checkout resolves the exact tag.
 - Versioned portable ZIP and `.sha256` attach to the GitHub release.
-- Signed update ZIP and `.sha256` attach when required.
+- Signed update ZIP and `.sha256` attach for every public Windows release.
 - A deliberately missing required secret or asset produces an explicit failure.
 
 Rollback / safety notes: use a prerelease and delete only the disposable release/tag

--- a/docs/plans/2026-07-25-initial-release-remediation.md
+++ b/docs/plans/2026-07-25-initial-release-remediation.md
@@ -1,0 +1,929 @@
+Status: Active
+Scope: Initial public release readiness and production-review remediation
+Owner: Maintainer
+
+# Initial Release Production Remediation Plan
+
+## Purpose
+
+This plan converts the July 25, 2026 production-readiness review into bounded,
+sequenced work packages for the first public Frame Compare release. It does not
+authorize a release by itself. Each release blocker must be closed with the evidence
+defined below before the first production tag is published.
+
+The review baseline was branch `stage1` at commit
+`eb88cbdb09099ee10e238da365c3d995d3eed20f`. Revalidate findings against the current
+head before implementation if that baseline changes materially.
+
+## Decision record and current status
+
+Decisions recorded July 26, 2026:
+
+| Area | Decision | Status |
+| --- | --- | --- |
+| First public version | Release as `v0.1.0` | Approved; bootstrap implementation remains |
+| Initial squash title | Use a Conventional Commit such as `feat: prepare initial public release`; keep the detailed release inventory in the commit/PR body | Approved; a version-only title would not give Release Please a release type |
+| Release review | Release Please PRs require human review; no automatic merge | Implemented with a workflow contract test |
+| Support posture | Windows portable is the primary, most feature-complete route; default Docker is the primary headless macOS/Linux route; native source is advanced; NVIDIA/X11 remain experimental | Documented |
+| Windows updates | Signed code-only updates are required for the first public Windows release | Approved; key generation, secret setup, and end-to-end proof remain |
+| Release authentication | Configure `RELEASE_PLEASE_TOKEN` as a fine-grained PAT or GitHub App token so release-created events can trigger the Windows asset workflow | Approved; repository secret setup and proof remain |
+| Licensing | Prefer the conservative, no-commercial-license route of aligning Frame Compare with PyQt6 under `GPL-3.0-only` | Recommended; requires final maintainer confirmation before relicensing files |
+| User checksum guidance | Teach users to verify the published Windows ZIP against its `.sha256` asset | Implemented and strictly built |
+| VSPreview recovery links | Point doctor hints to the canonical native-source Zensical guide | Implemented with focused adapter/CLI tests |
+
+The current pre-release `main` head is
+`d4dd09821d9503a583049b173df6210153912390`. If the entire `stage1` workstream is
+squash-merged as the first public-release preparation commit, that `main` commit is
+the intended one-time Release Please `bootstrap-sha`: it is the commit immediately
+before the first changelog commit to include. Recalculate this value if `main`
+advances before the squash merge.
+
+## Scope
+
+### Accepted findings
+
+| ID | Finding | Type | Severity | Confidence | Release effect |
+| --- | --- | --- | --- | --- | --- |
+| F-01 | Windows release public key is still a placeholder | Confirmed defect | S1 | High | Blocks official Windows bundle and update release |
+| F-02 | Release-event authentication may not trigger the Windows asset workflow | Insufficient deployment data / conditional defect | S1 | High in mechanism; environment unknown | Blocks automatic release assets unless a PAT or GitHub App token is configured |
+| F-03 | First-release version and Release Please bootstrap history are ambiguous | Inferred release risk | S2 | High | Could publish an unintended `v0.2.0` or an oversized/misleading changelog |
+| F-04 | PyQt6 redistribution under the project’s intended license posture lacks a recorded compatible-license disposition | Confirmed license mismatch requiring maintainer disposition | S1 | High | Blocks public Windows binary distribution until the project and artifact license posture is aligned |
+| F-05 | Top-level and command-specific CLI help is too sparse for first-time users | Confirmed UX defect | S2 | High | Does not block mechanics, but materially harms first-use quality |
+| F-06 | `CHANGELOG.md` reads as internal phase/scaffold history instead of a public first-release changelog | Confirmed docs/release defect | S2 | High | Release notes would be noisy and misleading |
+| F-07 | Published Windows `.sha256` assets lacked user verification instructions | Confirmed docs defect | S3 | High | Resolved in the documentation package associated with this plan |
+| F-08 | A doctor remediation hint points to a stale README installation anchor | Confirmed UX/docs defect | S3 | High | Resolved by linking to the native-source Zensical guide |
+| F-09 | No clean Apple Silicon Docker proof was available during review | Verification gap | S2 | Medium | Do not claim Apple Silicon confidence until separately proved |
+| F-10 | Optional Linux NVIDIA and X11 routes remain host-dependent and unproved in baseline CI | Known verification limitation | S3 | High | Keep labeled experimental; does not block supported default route |
+| F-11 | Dependency vulnerability status was not independently audited for the release graph/bundle | Verification gap | S2 | Medium | Requires a release-time dependency/security audit |
+| F-12 | Distribution build is not an explicit CI gate, despite clean archive build succeeding locally | Inferred build/release gap | S2 | Medium | A packaging regression could reach `main` unnoticed |
+| F-13 | Overlay font fallback can vary across hosts | Known determinism limitation | S3 | High | Document/test tolerance; do not claim cross-platform pixel identity |
+| F-14 | Docker base image and system package inputs are not fully digest/snapshot pinned | Supply-chain hardening opportunity | S3 | Medium | Track after first-release blockers unless threat model elevates it |
+| F-15 | Release-candidate asset installation and end-to-end use have not been rehearsed from the exact published artifacts | Verification gap | S1 | High | Blocks final go/no-go |
+
+### Finding evidence and closure proof
+
+| ID | Evidence | Risk mechanism | Closure proof |
+| --- | --- | --- | --- |
+| F-01 | `tools/windows_portable/update_public_key.xml` contains replacement markers and a non-release modulus; release/manual builds pass `-RequireReleasePublicKey` | The release path validates a key that cannot qualify as a real release key, so the official Windows build fails closed | Committed real public key validates; matching protected private key signs an update that the installed client accepts |
+| F-02 | `.github/workflows/release-please.yml` falls back to `github.token`; `.github/workflows/windows-portable.yml` listens for a separate release event | GitHub suppresses new workflow runs caused by events created with `GITHUB_TOKEN`, so the release can exist without triggering asset creation | Confirm non-`GITHUB_TOKEN` credential and observe a disposable Release Please prerelease trigger the Windows workflow |
+| F-03 | There are no prior release tags while `pyproject.toml` and `.release-please-manifest.json` already say `0.1.0`; the branch contains extensive feature history | Release Please may interpret `0.1.0` as already released and calculate a later version from all visible history | Previewed release PR/tag/changelog exactly match the maintainer-approved bootstrap version and commit boundary |
+| F-04 | The Windows builder installs PyQt6/PyQt6-Qt6 into the public bundle; PyQt6 package metadata is `GPL-3.0-only` or commercial while the repository is Apache-2.0; repository history shows only the maintainer’s Tristan/TJZine author identities | Redistributing the combined release without an explicit compatible-license posture creates avoidable ambiguity | Maintainer confirms the `GPL-3.0-only` route, all project metadata/notices are updated, and the exact artifact’s licenses and corresponding-source path are inspected |
+| F-05 | Generated CLI help shows command names and options with little or no explanatory text for key first-run surfaces | New users cannot infer safe command intent, defaults, or route-specific invocation from the CLI itself | Human-reviewed top-level and per-command help with focused contract tests |
+| F-06 | `CHANGELOG.md` contains repeated internal phase/scaffold history and obsolete implementation detail | Release notes obscure actual user value and limitations and can misrepresent the initial release | First-release changelog reviewed as a concise user-facing capability/limitation record |
+| F-07 | Workflow publishes `.sha256` assets, while the prior Windows guide only instructed users to download and execute the ZIP | Integrity data exists but users are not told how to use it | Published guide includes copy/paste verification and a fail-closed mismatch instruction |
+| F-08 | A doctor recovery hint uses the old README `#installation` location while installation authority moved into Zensical guides | Diagnostic remediation sends users to stale or missing guidance | Focused diagnostic test asserts a live Zensical installation URL/anchor |
+| F-09 | Linux amd64 Docker CI passed; the review host was Apple Silicon but its Docker daemon was unavailable | Architecture-specific image/plugin/runtime problems could remain undetected behind the broad macOS claim | Clean Apple Silicon Docker build, doctor, dry-run, SDR, and HDR proof—or a narrowed support claim |
+| F-10 | NVIDIA and X11 profiles have dedicated host proof scripts but no compatible baseline CI hardware/session | Default Docker success does not establish GPU passthrough or desktop GUI behavior | Compatible-host proof plus manual GUI/GPU acceptance; otherwise retain experimental/unverified labels |
+| F-11 | Dependabot and static security checks exist, but the review did not run a release-graph vulnerability audit | Known vulnerable transitive dependencies could ship despite source-code scans passing | Policy-defined audit of locked Python, container, and Windows bundle inputs with calibrated exceptions |
+| F-12 | Clean archive `uv build` passed locally, but CI has no explicit wheel/sdist build-install job | Packaging-only regressions can merge even when source tests pass | CI builds both artifacts from clean checkout, inspects contents, installs the wheel fresh, and smokes the CLI |
+| F-13 | Overlay code falls back through available system fonts | Font selection and metrics can vary by host, changing labels or pixels | Documented non-bit-determinism plus cross-route tolerance tests; bundle a controlled font only if product requirements demand it |
+| F-14 | Docker versions are constrained in several places, but the base image and apt repository state are not fully immutable | Rebuilds at different times can consume changed upstream system inputs | Recorded decision and owner; if approved, digest/snapshot pinning plus a tested refresh process |
+| F-15 | PR checks prove source/workflow paths, not a clean install and full workflow from the exact public downloads | Archive layout, signing, extraction, PATH, first-use, report, update, or uninstall defects can escape repository-level tests | Downloaded RC assets pass the complete platform acceptance matrix before the production tag |
+
+### Excluded findings
+
+- A failed `uv build` from one local dirty worktree is excluded as a repository
+  defect. Untracked `.venv-r76-*` directories polluted that local source archive;
+  the clean `git archive` build produced both wheel and sdist successfully.
+- Large cohesive owners are architecture watch items, not release defects. No
+  decomposition is authorized solely because of file length.
+- Optional live TMDB, slow.pics, webhook, NVIDIA, and X11 behavior is not promoted to
+  a default-route release blocker when it remains explicitly opt-in or experimental.
+
+### Assumptions
+
+- The first public release should present a conservative alpha-quality support
+  contract.
+- Windows portable and default headless Docker are intended first-class routes.
+- Native source is an advanced route.
+- PyPI and a public container registry are not promised release channels unless
+  separately approved and implemented.
+- No automatic upload or telemetry is introduced; slow.pics and webhooks remain
+  explicit opt-ins.
+
+### Constraints
+
+- Preserve CLI/config/output contracts unless a package explicitly changes and
+  documents them.
+- Release and Windows portable changes are high risk under the engineering runbook.
+- Signed updater verification requires protected external secret state and a Windows
+  runner.
+- Private signing key material must never enter the repository, task transcript,
+  command line, CI logs, or release artifacts.
+- Licensing changes require explicit maintainer confirmation. The plan may recommend
+  the conservative `GPL-3.0-only` route but implementation agents must not silently
+  relicense the project.
+- Only one active plan should exist for this workstream.
+
+### Non-goals
+
+- Broad architecture rewrites.
+- Publishing to PyPI or a public container registry.
+- Promoting NVIDIA or X11 profiles from experimental to generally supported.
+- Guaranteeing bit-identical screenshots across operating systems and host fonts.
+- Adding speculative compatibility layers or fallback update mechanisms.
+
+## Evidence baseline
+
+### Passed review gates
+
+| Gate | Result at review baseline |
+| --- | --- |
+| Pyright strict warnings gate | Passed: 0 errors, 0 warnings |
+| Ruff | Passed |
+| Bandit, medium severity and above | Passed: no medium/high findings |
+| Full pytest suite | Passed, with expected platform/runtime skips |
+| Branch coverage | 89.87%, above the 80% floor |
+| Import Linter | Passed: 2 contracts kept, 0 broken |
+| Generated API docs check | Passed |
+| Traceability validation | Passed |
+| Clean archive wheel and sdist build | Passed |
+| `git diff --check` | Passed |
+| Current-head GitHub CI, docs, Docker, and Windows PR checks | Passed |
+
+These results establish a strong code-quality baseline but do not prove release
+orchestration, secrets, legal permission, optional hardware routes, or the final
+published artifacts.
+
+### Positive controls to preserve
+
+- Workspace path containment and symlink defenses.
+- Atomic writes, locks, and explicit run lifecycle records.
+- Upload disabled by default and webhook secrets excluded from persisted TOML.
+- SSRF controls and redaction around external integrations.
+- Structured subprocess arguments rather than shell command construction.
+- Hash-pinned Windows runtime downloads and commit-pinned GitHub Actions.
+- Offline HTML reporting with no telemetry found in the review.
+- Signed-update design with file hashing, dependency fingerprint checks, backups,
+  rollback, and fail-closed behavior.
+
+## Plan summary
+
+Overall approach: make release identity and legal/signing prerequisites explicit
+first; repair automation next; improve user-facing release surfaces; add missing
+build/security gates; then perform an exact-artifact release-candidate rehearsal.
+
+Highest-risk package: P1, because the real public/private key relationship and its
+protected secret handling define whether Windows updates can be trusted.
+
+Verification strategy: every package has a focused proof, then the repository-wide
+gate is rerun before the release candidate. The final gate tests downloaded
+artifacts rather than workspace outputs.
+
+Recommended sequence:
+
+```mermaid
+flowchart LR
+    Q["Completed quick fixes<br/>docs, links, manual release review"] --> P2["P2<br/>GPL-compatible distribution"]
+    Q --> P1["P1<br/>Signing key and updater trust"]
+    P2 --> P0["P0<br/>Freeze v0.1.0 identity"]
+    P0 --> P3["P3<br/>Release event and asset automation"]
+    P1 --> P3
+    P2 --> P3
+    P0 --> P4["P4<br/>Public CLI and release notes"]
+    P4 --> P5["P5<br/>Docs and diagnostics polish"]
+    P3 --> P6["P6<br/>Build and security gates"]
+    P5 --> P6
+    P6 --> P7["P7<br/>Cross-route release candidate"]
+    P7 --> P8["P8<br/>Publish and observe"]
+```
+
+## Package overview
+
+| Package | Findings | Risk reduced | Scope size | Exit gate |
+| --- | --- | --- | --- | --- |
+| P0: Freeze first-release identity | F-03 | Wrong version/tag/changelog baseline | Small, decision-heavy | Dry-run Release Please output matches intended first tag |
+| P1: Establish Windows signing trust | F-01 | Broken release build or untrusted updates | Medium, security-sensitive | Manual signed update verifies and applies using committed public key |
+| P2: Resolve binary redistribution posture | F-04 | Ambiguous/incompatible public bundle license posture | Decision plus metadata/distribution changes | Explicit GPL decision and exact-artifact license/source inspection |
+| P3: Prove release-to-asset automation | F-02, F-15 | Tag published without downloadable Windows assets | Medium, release workflow | Disposable prerelease triggers asset workflow and attaches expected assets |
+| P4: Polish public CLI and changelog | F-05, F-06, F-08 | Poor first-use and misleading release notes | Medium | Help snapshots/contracts and public changelog review pass |
+| P5: Complete user install guidance | F-07, F-10, F-13 | Unsafe download handling or inflated support claims | Small | Strict Zensical build and route-doc review |
+| P6: Add release build/security gates | F-11, F-12, F-14 | Undetected package/dependency/supply-chain regression | Medium | Clean package job and documented security audit pass |
+| P7: Rehearse exact release candidate | F-09, F-10, F-15 | Untested first-use experience or platform regression | Large verification package | Exact-asset acceptance matrix passes or unsupported routes are relabeled |
+| P8: Publish and observe | All closed findings | Release execution/rollback risk | Small, operational | Assets, checksums, docs, notes, and smoke tests verified after publication |
+
+## Packages
+
+### P0: Freeze first-release identity
+
+Accepted finding IDs: F-03.
+
+Goal: produce the approved first public tag `v0.1.0` and make Release Please consider
+only the intended squash-merged release-preparation commit.
+
+Risk reduced: unintended SemVer, enormous generated release notes, or a release PR
+that treats unreleased development history as already released.
+
+Scope:
+
+- Use `0.0.0` as the pre-release package/manifest baseline and explicitly set the
+  one-time Release Please target to `0.1.0`.
+- Set top-level `bootstrap-sha` to the full commit immediately before the initial
+  release-preparation squash. Use
+  `d4dd09821d9503a583049b173df6210153912390` only if `main` has not advanced.
+- Use a Conventional Commit squash title such as
+  `feat: prepare initial public release`; put the comprehensive change inventory in
+  the commit/PR description.
+- Keep Release Please PRs human-reviewed. Automatic merge has already been removed
+  and is protected by a focused workflow test.
+- Preview the resulting release PR title, version files, and changelog content.
+- Remove the one-time `bootstrap-sha` and forced `release-as` setting immediately
+  after the successful `v0.1.0` release so later versions return to normal
+  Conventional Commit calculation.
+
+Out of scope: changing the project’s long-term SemVer policy.
+
+Primary files/symbols:
+
+- `.release-please-manifest.json`
+- `release-please-config.json`
+- `.github/workflows/release-please.yml`
+- `pyproject.toml`
+- `src/frame_compare/__init__.py`
+- `CHANGELOG.md`
+
+Expected behavior change: the first release PR proposes exactly the approved tag and
+only the intended public release history.
+
+Implementation approach:
+
+1. Reconfirm the current `main` head immediately before the squash merge.
+2. Align the three version sources at `0.0.0`, configure that commit as
+   `bootstrap-sha`, and force the one-time target `release-as` to `0.1.0`.
+3. Squash-merge with a Conventional Commit title.
+4. Let Release Please open—but never automatically merge—the `0.1.0` release PR.
+5. Review every version and changelog mutation before merging it.
+6. Remove one-time bootstrap/forced-version configuration after the release.
+
+Verification:
+
+- Release Please dry run or disposable branch/repository proof.
+- Confirm version agreement across `pyproject.toml`,
+  `.release-please-manifest.json`, generated tag, and release notes.
+- Confirm no unexpected historical commits appear.
+
+Rollback / safety notes: keep the release PR unmerged until its output is accepted.
+Do not delete or rewrite shared history to solve bootstrap configuration.
+
+Dependencies: none.
+
+Risks: changing version metadata without matching Release Please state can create
+repeated or skipped release PRs.
+
+Open questions: none. Recalculate `bootstrap-sha` if `main` advances.
+
+Suggested owner role: maintainer plus release-workflow implementer.
+
+### P1: Establish Windows signing trust
+
+Accepted finding IDs: F-01.
+
+Goal: replace the placeholder update public key with the public half of a protected
+release keypair and prove the complete signed-update lifecycle.
+
+Risk reduced: official Windows builds currently fail release-key validation, and an
+incorrect key relationship would make legitimate updates unverifiable.
+
+Scope:
+
+- Add a maintainer-only PowerShell key-generation script with explicit public and
+  private output paths and no logging of private parameters.
+- Generate a release RSA keypair using an approved offline process.
+- Commit only the public key with a real key ID and generation date.
+- Store the private key XML as the protected
+  `WINDOWS_UPDATE_SIGNING_KEY_XML` Actions secret.
+- Validate the public key with the repository script.
+- Build, sign, verify, apply, and roll back a code-only update on Windows.
+- Record key custody, backup, rotation, and compromise-response ownership outside
+  the repository’s public source.
+
+Out of scope: committing private key material or redesigning the updater.
+
+Primary files/symbols:
+
+- `tools/windows_portable/update_public_key.xml`
+- `tools/windows_portable/validate_update_public_key.ps1`
+- `tools/windows_portable/sign_update.ps1`
+- `tools/windows_portable/shim/frame-compare-update.ps1`
+- `.github/workflows/windows-portable.yml`
+
+Expected behavior change: release/manual bundle builds accept the committed public
+key, signed update assets contain a valid signature, and installed clients verify
+that signature before applying changes.
+
+Implementation approach:
+
+1. Add and test the maintainer key-generation procedure without creating a real
+   private release key in the repository or task environment.
+2. The maintainer generates and backs up the real keypair on a trusted Windows
+   machine outside CI logs and the repository.
+3. Replace the placeholder public key and metadata.
+4. Configure the private key as `WINDOWS_UPDATE_SIGNING_KEY_XML`.
+5. Use `workflow_dispatch` to exercise the protected signing path.
+6. Download the artifact, verify it offline, apply it to a test bundle, and roll
+   back.
+
+Verification:
+
+- `validate_update_public_key.ps1` passes.
+- `build_portable.ps1 -RequireReleasePublicKey` passes on Windows.
+- Workflow output reports `signed=true`.
+- `update-manifest.sig` exists.
+- Tampering with the manifest or payload is rejected.
+- Valid update apply and rollback both succeed.
+- Logs and uploaded artifacts contain no private key material.
+
+Rollback / safety notes: never rotate the committed public key without a migration
+decision for already-installed clients. Revoke/stop release immediately if private
+key exposure is suspected.
+
+Dependencies: P0 for versioned artifact naming.
+
+Risks: secret formatting, newline encoding, or mismatched key halves can cause a
+false sense of readiness if only the build—not client verification—is tested.
+
+Open questions:
+
+- Which maintainer-controlled encrypted store owns the offline backup?
+- What documented event triggers rotation or release suspension?
+
+Suggested owner role: maintainer and security-aware Windows release implementer.
+
+### P2: Resolve binary redistribution posture
+
+Accepted finding IDs: F-04.
+
+Goal: align the project and Windows distribution with PyQt6’s
+`GPL-3.0-only` terms without buying commercial licenses.
+
+Risk reduced: public distribution without satisfying applicable GPL/commercial and
+Qt obligations.
+
+Scope:
+
+- Obtain explicit maintainer confirmation for the recommended
+  `GPL-3.0-only` project license.
+- Replace the project Apache license with the complete GPLv3 text and update package
+  metadata, classifiers, badges, user documentation, contributor terms, and bundle
+  project-license output.
+- Inventory the exact PyQt6, PyQt6-Qt6, Qt, and related packages shipped.
+- Preserve every applicable third-party license and notice; Apache-2.0 components
+  retain their original notices within the GPLv3 distribution.
+- Make complete corresponding source and build/install scripts available beside or
+  clearly linked from every Windows binary release.
+- Update bundle licenses/notices and user documentation to match the chosen outcome.
+
+Out of scope: purchasing commercial licenses, replacing VSPreview/PyQt6, or
+presenting this engineering plan as legal advice.
+
+Primary files/symbols:
+
+- `uv.lock`
+- `pyproject.toml`
+- `tools/windows_portable/build_portable.ps1`
+- bundled `licenses/` output
+- `docs/windows-portable.md`
+
+Expected behavior change: project licensing and distribution metadata change to
+`GPL-3.0-only`; runtime behavior and the feature-complete Windows bundle remain
+unchanged.
+
+Implementation approach: after explicit maintainer confirmation, implement the
+license change as one reviewable package and freeze public Windows distribution until
+the exact bundle/source pair passes the license inventory.
+
+Verification:
+
+- Exact bundle software bill of materials reviewed.
+- Required license texts, notices, and source/offers are present.
+- Clean extracted artifact is inspected rather than relying on build inputs.
+- Written maintainer approval records the chosen `GPL-3.0-only` basis.
+
+Rollback / safety notes: if unresolved, do not publish the Windows binary. Continue
+with source-only routes only if their own distribution posture is separately clear.
+
+Dependencies: none; run in parallel with P0/P1.
+
+Risks: removing PyQt6 may change the “most complete distribution” promise and require
+same-pass user documentation updates.
+
+Open questions:
+
+- Has the maintainer explicitly approved changing Frame Compare itself to
+  `GPL-3.0-only`?
+- What exact release asset or repository link is the canonical corresponding-source
+  location for each Windows binary tag?
+
+Suggested owner role: maintainer with focused open-source license-compliance review.
+
+### P3: Prove release-to-asset automation
+
+Accepted finding IDs: F-02 and the automation portion of F-15.
+
+Goal: ensure a Release Please-created GitHub release reliably triggers the Windows
+portable workflow and attaches every intended asset.
+
+Risk reduced: a successful tag/release with no Windows binary because GitHub
+suppresses workflow chaining from events created with `GITHUB_TOKEN`.
+
+Scope:
+
+- Confirm `RELEASE_PLEASE_TOKEN` exists and is a PAT or GitHub App token with the
+  minimum required repository permissions.
+- Confirm branch protections and token identity permit release PR creation/merge.
+- Verify a release created by that identity produces a `release: published` event.
+- Make the Windows workflow fail closed when required release assets or signing
+  prerequisites are absent.
+- Require a signed code-only update asset and checksum for every public Windows
+  release.
+
+Out of scope: broad changes to repository permissions unrelated to release.
+
+Primary files/symbols:
+
+- `.github/workflows/release-please.yml`
+- `.github/workflows/windows-portable.yml`
+- repository Actions secrets/settings
+
+Expected behavior change: published releases deterministically launch the asset
+workflow, and release completion clearly fails when mandatory assets are missing.
+
+Implementation approach:
+
+1. Audit secret presence and token permissions without exposing the token.
+2. Create a disposable prerelease or RC tag through the actual Release Please path.
+3. Observe the release event and Windows workflow.
+4. Require the portable ZIP and checksum; require the signed update ZIP/checksum if
+   updates are part of the release promise.
+
+Verification:
+
+- Release Please run identifies the intended token path.
+- Windows workflow starts from the release event without manual intervention.
+- Checkout resolves the exact tag.
+- Versioned portable ZIP and `.sha256` attach to the GitHub release.
+- Signed update ZIP and `.sha256` attach when required.
+- A deliberately missing required secret or asset produces an explicit failure.
+
+Rollback / safety notes: use a prerelease and delete only the disposable release/tag
+after capturing evidence. Do not test workflow chaining for the first time on the
+official stable tag.
+
+Dependencies: P0, P1, and P2.
+
+Risks: a token can create the release PR yet still lack a permission needed later.
+
+Open questions: should release publication be separated from asset readiness to
+avoid a temporary empty release?
+
+Suggested owner role: release-workflow implementer.
+
+### P4: Polish public CLI and changelog
+
+Accepted finding IDs: F-05, F-06, and F-08.
+
+Goal: make the CLI self-explanatory and the first public changelog concise,
+user-oriented, and accurate.
+
+Risk reduced: users cannot discover commands/options from `--help`, encounter a dead
+diagnostic link, or see internal development scaffolding presented as release notes.
+
+Scope:
+
+- Add descriptions to top-level `run`, `wizard`, `doctor`, history, and updater
+  surfaces as applicable.
+- Add concise help for public `run` options, including effects, defaults, and
+  persistence where relevant.
+- Preserve stdout/stderr, exit-code, JSON, and lazy-import contracts.
+- Preserve the completed doctor-link fix to the canonical native-source Zensical
+  guide.
+- Rewrite the unreleased/first-release changelog around user capabilities,
+  limitations, security/privacy posture, install routes, and known issues.
+
+Out of scope: renaming commands or redesigning configuration.
+
+Primary files/symbols:
+
+- `src/frame_compare/cli/entry.py`
+- diagnostic check owners that produce the stale link
+- CLI help/contract tests
+- `docs/current-cli-contract.md`
+- `CHANGELOG.md`
+
+Expected behavior change: `frame-compare --help` and command help provide actionable
+descriptions; diagnostics link to a live page; the changelog reads as a public alpha
+release.
+
+Implementation approach:
+
+- Treat help text as a public contract.
+- Keep descriptions short enough to scan in a terminal.
+- Add focused tests for command descriptions and essential option semantics.
+- Separate end-user changes from internal refactors in the changelog.
+
+Verification:
+
+- Capture and review `frame-compare --help`.
+- Capture and review help for every documented command.
+- Run CLI contract tests and full verification.
+- Build Zensical strictly and check every diagnostic documentation link.
+- Have a first-time user review the changelog and quickstart language.
+
+Rollback / safety notes: help-only changes should not alter callbacks, defaults, or
+option parsing. Inspect generated help and JSON modes for accidental output drift.
+
+Dependencies: P0 for final version/release-note framing.
+
+Risks: Typer annotations can alter parsing behavior if descriptions are added through
+the wrong declaration shape.
+
+Open questions: which known limitations belong in the changelog versus the
+installation chooser and troubleshooting guide?
+
+Suggested owner role: CLI implementer with documentation review.
+
+### P5: Complete user install guidance
+
+Accepted finding IDs: F-07, F-10, and F-13.
+
+Goal: give users one accurate installation decision surface without overstating
+experimental or cross-platform behavior.
+
+Risk reduced: choosing an unsuitable route, trusting an unverified ZIP, assuming
+optional Docker profiles are supported by default, or expecting bit-identical
+cross-platform overlays.
+
+Scope:
+
+- Maintain the route comparison, decision graph, runtime matrix, and feature matrix
+  in `docs/getting-started/index.md`.
+- Maintain Windows checksum instructions.
+- Keep Docker NVIDIA/X11 labeled host-dependent and separately verified.
+- State that native pip and Docker are build/install-from-clone routes until public
+  registries exist.
+- State that host fonts/GPU/runtime can affect rendered details.
+
+Out of scope: changing actual platform support or publishing new distribution
+channels.
+
+Primary files/symbols:
+
+- `docs/getting-started/index.md`
+- `docs/windows-portable.md`
+- `docs/getting-started/docker.md`
+- `docs/getting-started/native.md`
+- `docs/docker-environments.md`
+- `zensical.toml`
+
+Expected behavior change: documentation only.
+
+Implementation approach: keep one summary authority and link to route-specific
+procedures rather than duplicating commands across pages.
+
+Verification:
+
+- `uv run --no-sync zensical build --clean --strict`
+- Manual desktop/mobile review of wide tables and Mermaid rendering.
+- Link check through the strict build.
+- Compare claims against Dockerfiles, Compose files, Windows manifest, and
+  `pyproject.toml`.
+
+Rollback / safety notes: revert individual claims that cannot be traced to code,
+workflow, or a successful host proof.
+
+Dependencies: none; documentation baseline delivered with this plan.
+
+Risks: capability matrices become stale when bundle contents or profiles change.
+Update them in the same pass as those release surfaces.
+
+Open questions: none for the current documented support posture.
+
+Suggested owner role: documentation owner.
+
+### P6: Add release build and security gates
+
+Accepted finding IDs: F-11, F-12, and F-14.
+
+Goal: catch distribution and dependency problems before merge or release and record
+the remaining container pinning decision.
+
+Risk reduced: unbuildable wheel/sdist, vulnerable locked dependencies, or mutable
+system inputs changing release behavior unexpectedly.
+
+Scope:
+
+- Add a clean-tree wheel/sdist build job.
+- Inspect wheel and sdist contents and install the wheel in a fresh environment.
+- Run an appropriate Python dependency vulnerability audit against the locked graph.
+- Produce/review a Windows bundle software bill of materials or equivalent exact
+  dependency inventory.
+- Decide whether Docker base images should be digest-pinned and whether apt inputs
+  need a snapshot strategy.
+- Configure update ownership for audit findings and pin refreshes.
+
+Out of scope: replacing every dependency because a scanner emits an uncalibrated
+warning.
+
+Primary files/symbols:
+
+- `.github/workflows/ci.yml`
+- `pyproject.toml`
+- `uv.lock`
+- `Dockerfile`
+- Windows bundle manifests/build outputs
+
+Expected behavior change: CI rejects broken distributions and policy-defined
+vulnerabilities; Docker input pinning may become stricter if approved.
+
+Implementation approach:
+
+1. Reproduce the already-passing clean archive build in CI.
+2. Validate artifact contents and fresh installation.
+3. Select an audit tool and severity/exception policy.
+4. Calibrate every result; record owner and expiry for accepted exceptions.
+5. Decide Docker digest/snapshot pinning separately from the build-gate change.
+
+Verification:
+
+- Build wheel and sdist from a clean checkout.
+- Install wheel in a new Python 3.13 environment; run version/help smoke tests.
+- Inspect archive paths for local virtualenvs, caches, secrets, and generated output.
+- Dependency audit passes or only documented, time-bounded exceptions remain.
+- Docker integration gate passes after any pinning change.
+
+Rollback / safety notes: do not silently loosen audit thresholds to make CI green.
+Separate unavailable upstream fixes from false positives and accepted risk.
+
+Dependencies: P2 informs bundle dependency policy; P5 captures current user claims.
+
+Risks: digest/snapshot pinning increases maintenance and may reduce automated security
+updates unless paired with an update process.
+
+Open questions:
+
+- Which vulnerability database/tool is the release authority?
+- What severity blocks an alpha release?
+- Who owns recurring base image and system package refreshes?
+
+Suggested owner role: build/release engineer with security review.
+
+### P7: Rehearse the exact release candidate
+
+Accepted finding IDs: F-09, F-10, and F-15.
+
+Goal: test what users will actually download or build, on the supported host matrix,
+before publishing the official tag.
+
+Risk reduced: “works in the repository” but fails after download, extraction,
+installation, first configuration, rendering, report use, update, or uninstall.
+
+Scope:
+
+- Produce a prerelease/RC through the real release path.
+- Test Windows portable from the downloaded ZIP.
+- Test default Docker on Linux amd64 and Apple Silicon/macOS if that support claim is
+  retained.
+- Test native `uv` from a clean clone.
+- Smoke the pip route in a fresh virtual environment.
+- Test optional live integrations only with disposable credentials/content.
+- Run optional NVIDIA/X11 proofs only on compatible hosts; otherwise retain
+  experimental/unverified labels.
+
+Out of scope: claiming support for unavailable hardware.
+
+Primary artifacts:
+
+- Versioned GitHub release ZIPs and checksums
+- Source archive/clean clone
+- Built Docker image from the tagged source
+- Generated reports and run records
+
+Expected behavior change: none unless failures are found; failures return to the
+owning package before release.
+
+Manual Windows acceptance:
+
+1. Download ZIP and `.sha256`; verify before extraction.
+2. Run `install.cmd` from a clean user profile or disposable VM.
+3. Open a new terminal and run version/help.
+4. Run wizard, doctor, and dry-run.
+5. Complete one SDR and one HDR comparison.
+6. Exercise VSPreview/manual alignment.
+7. Open the offline report; check overlays, navigation, run history, and paths.
+8. Apply a signed code-only update, reject a tampered update, and roll back.
+9. Run uninstall and confirm user media/output is retained.
+
+Docker/native acceptance:
+
+1. Follow only the published guide from a clean clone.
+2. Run wizard, doctor, dry-run, SDR, and HDR workflows.
+3. Open the report using the documented host helper for Docker.
+4. Confirm generated files are host-owned and persist after container removal.
+5. Confirm slow.pics remains disabled until explicitly enabled.
+
+Verification:
+
+- Full repository gate passes at the release commit.
+- Documentation strict build passes.
+- Linux amd64 Docker integration passes.
+- Apple Silicon/macOS default Docker first-run passes or the support claim is narrowed.
+- Windows exact-asset checklist passes.
+- Native `uv` and pip smoke checks pass.
+- No blocker or unexplained warning remains.
+
+Rollback / safety notes: use disposable media, accounts, webhooks, and credentials.
+Delete/revoke test integrations after the rehearsal. Never promote an RC tag or
+asset in place; fix and cut a new RC.
+
+Dependencies: P0 through P6.
+
+Risks: optional network services can change independently; record date, region, and
+service response without treating them as deterministic local gates.
+
+Open questions:
+
+- Which maintainers/testers own Windows, Linux amd64, and Apple Silicon acceptance?
+- What sample clips may be redistributed or used privately for repeatable SDR/HDR
+  checks?
+
+Suggested owner role: release manager with platform testers.
+
+### P8: Publish and observe
+
+Accepted finding IDs: all findings after their owning packages close.
+
+Goal: publish the official first release only after the release candidate evidence is
+accepted, then verify the public experience.
+
+Risk reduced: incomplete assets, stale docs, incorrect latest-release pointers, or
+silent first-hour failures.
+
+Scope:
+
+- Merge the reviewed release PR.
+- Observe the tag, GitHub release, Windows workflow, and docs deployment.
+- Verify public asset names, checksums, release notes, and links.
+- Repeat lightweight download/install smoke tests from the public release.
+- Define an issue template/label and response owner for alpha testers.
+- Record known limitations and rollback/yank criteria.
+
+Out of scope: adding features during release execution.
+
+Expected behavior change: the approved release becomes publicly available.
+
+Verification:
+
+- Tag and displayed version match P0.
+- Every mandatory asset and checksum is attached.
+- Windows signature and checksum verify after public download.
+- Documentation points to the correct release and routes.
+- A fresh user can reach a local report using only public instructions.
+- Security contact and issue-reporting links work.
+
+Rollback / safety notes: if a security/signing/licensing blocker appears, stop
+distribution and clearly mark affected assets/releases. Prefer a corrective release
+over mutating an already-used tag.
+
+Dependencies: P7 accepted with no open release blockers.
+
+Risks: GitHub/docs propagation delays; distinguish delays from failed workflows.
+
+Open questions: define the exact stop-distribution and hotfix decision owners before
+merging the release PR.
+
+Suggested owner role: maintainer/release manager.
+
+## Sequencing and concurrency
+
+| Sequence | Work | Parallelism |
+| --- | --- | --- |
+| 0 | User install docs, checksum instructions, stale VSPreview links, and release auto-merge removal | Completed baseline; retain tests and strict docs proof |
+| 1 | Explicitly confirm and implement P2 `GPL-3.0-only` posture | Do before P0 because both packages touch project/package metadata |
+| 2 | P1 signing-key tooling and maintainer key generation | May begin alongside P2 when documentation files do not overlap |
+| 3 | P0 `v0.1.0` bootstrap configuration | Starts after P2 settles `pyproject.toml`; recalculate `bootstrap-sha` immediately before merge |
+| 4 | P4 remaining CLI help and changelog work | CLI help may proceed earlier; final changelog wording waits for P0/P2 |
+| 5 | P3 release authentication and exact event-chain proof | Starts only after P0/P1/P2 have usable release state |
+| 6 | P6 build/security gates | After dependency/license direction is stable |
+| 7 | P7 exact RC rehearsal | Only after every prior blocker package exits |
+| 8 | P8 official publish | Only after explicit maintainer go/no-go |
+
+Do not combine P1 signing changes, P2 licensing changes, and P4 CLI cleanup in one
+pull request. They have different reviewers, rollback strategies, and proof surfaces.
+
+## Verification matrix
+
+| Gate | P0 | P1 | P2 | P3 | P4 | P5 | P6 | P7/P8 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `git diff --check` | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Pyright/Ruff/Bandit/pytest/import-linter | If executable config changes | Yes | If bundle/build changes | Yes | Yes | Docs-only minimum otherwise | Yes | Yes |
+| API docs drift check | If public API docs touched | No | No | No | Yes | Yes | Yes | Yes |
+| Strict Zensical build | If release docs touched | If docs touched | Yes | If docs touched | Yes | Yes | If docs touched | Yes |
+| Windows portable build/smoke | No | Required | Required if bundle changes | Required | No | No | If bundle inputs change | Required |
+| Signed update apply/rollback/tamper | No | Required | If updater composition changes | Required | No | No | No | Required |
+| Default Docker integration | No | No | No | No | No | Docs-only claim audit | Required if Docker changes | Required |
+| Optional NVIDIA/X11 proof | No | No | No | No | No | Only on compatible hosts | If profiles change | Best effort; otherwise keep experimental |
+| Clean wheel/sdist + fresh install | Version check | No | No | No | Yes | No | Required | Required |
+| Dependency/license inventory | No | Windows key tooling only | Required | No | No | No | Required | Confirm final artifacts |
+
+## Review gates
+
+### Gate A: Decisions recorded
+
+- First tag/version and Release Please bootstrap approved.
+- Windows update key owner and custody process approved.
+- PyQt6/Qt redistribution disposition approved.
+- Mandatory first-release asset list approved.
+
+Failure condition: any decision is implied only by code or an agent assumption.
+
+### Gate B: Automation proved
+
+- Actual token identity can trigger downstream workflows.
+- Signed update and portable bundle build from the tagged source.
+- Missing mandatory prerequisites fail explicitly.
+
+Failure condition: any required path is only inferred from a pull-request check.
+
+### Gate C: Public surfaces polished
+
+- CLI help is complete.
+- Changelog is user-oriented.
+- Install chooser and checksum instructions are accurate.
+- No stale recovery links remain.
+
+Failure condition: a first-time user needs repository-internal knowledge to complete
+the quickstart.
+
+### Gate D: Release candidate accepted
+
+- Exact downloaded artifacts pass platform checklists.
+- All first-class route claims have current evidence.
+- Experimental routes remain clearly labeled where evidence is unavailable.
+- No open S1 or S2 release blocker remains.
+
+Failure condition: unresolved signing, licensing, asset automation, supported-host,
+or exact-artifact issue.
+
+## Release go/no-go checklist
+
+### No-go conditions
+
+- Placeholder or mismatched Windows public key.
+- Missing/untested private signing secret when signed updates are promised.
+- No written PyQt6/Qt distribution disposition.
+- Release Please cannot demonstrably trigger the Windows release workflow.
+- Intended first tag/version is unresolved.
+- Exact Windows release ZIP has not passed clean-install acceptance.
+- A first-class platform route fails its documented doctor/dry-run/render path.
+- Mandatory checksums or assets are absent.
+
+### Go conditions
+
+- Gates A through D are signed off.
+- Full verification passes on the release commit.
+- RC notes and artifact contents match the user documentation.
+- Rollback and security-contact owners are available.
+- The maintainer explicitly approves publication.
+
+## Parking lot
+
+These items warrant follow-up but do not block the first release under the current
+support contract:
+
+- Promote NVIDIA GPU support only after repeatable proof on maintained hardware.
+- Promote Docker X11 only after repeatable manual GUI acceptance; do not broaden to
+  Wayland/VNC without a separate design.
+- Evaluate a public container registry after ownership, tagging, scanning, and
+  update policy are defined.
+- Evaluate PyPI publication only after native dependency expectations and package
+  support policy are suitable for users installing without the repository.
+- Consider bundled/project-controlled fonts only if cross-platform overlay
+  determinism becomes a product requirement.
+- Revisit full Docker digest/apt snapshot pinning after measuring maintenance cost
+  and defining update ownership.
+- Continue monitoring cohesive architecture hotspots; split only when a distinct
+  responsibility and contract emerge.
+
+## Handoff record
+
+For each package, the implementation handoff must record:
+
+- current commit and accepted finding IDs;
+- exact files and public contracts in scope;
+- decisions already made and open questions requiring maintainer input;
+- focused and regression commands executed;
+- platform/runtime paths that were not available;
+- artifact names and hashes for any release proof;
+- rollback action;
+- residual risk and whether documentation/support claims changed.
+
+When this workstream closes, change the metadata to `Status: Historical` in the same
+merge that records the final release evidence.
+
+## Official references
+
+- [GitHub Actions `GITHUB_TOKEN` event behavior](https://docs.github.com/en/actions/concepts/security/github_token)
+- [Release Please GitHub credentials](https://github.com/googleapis/release-please-action#github-credentials)
+- [Release Please manifest bootstrapping](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#bootstrapping)
+- [PyQt6 package license metadata](https://pypi.org/project/PyQt6/)
+- [Riverbank commercial licensing FAQ](https://riverbankcomputing.com/commercial/license-faq)

--- a/docs/plans/2026-07-25-initial-release-remediation.md
+++ b/docs/plans/2026-07-25-initial-release-remediation.md
@@ -27,7 +27,7 @@ Decisions recorded July 26, 2026:
 | Support posture | Windows portable is the primary, most feature-complete route; default Docker is the primary headless macOS/Linux route; native source is advanced; NVIDIA/X11 remain experimental | Documented |
 | Windows updates | Signed code-only updates are required for the first public Windows release | Approved; key generation, secret setup, and end-to-end proof remain |
 | Release authentication | Configure `RELEASE_PLEASE_TOKEN` as a fine-grained PAT or GitHub App token so release-created events can trigger the Windows asset workflow | Approved; repository secret setup and proof remain |
-| Licensing | Prefer the conservative, no-commercial-license route of aligning Frame Compare with PyQt6 under `GPL-3.0-only` | Recommended; requires final maintainer confirmation before relicensing files |
+| Licensing | Align Frame Compare with PyQt6 under `GPL-3.0-only`; do not purchase or depend on a commercial PyQt license | Repository relicensing implemented; exact-artifact compliance remains |
 | User checksum guidance | Teach users to verify the published Windows ZIP against its `.sha256` asset | Implemented and strictly built |
 | VSPreview recovery links | Point doctor hints to the canonical native-source Zensical guide | Implemented with focused adapter/CLI tests |
 
@@ -67,7 +67,7 @@ advances before the squash merge.
 | F-01 | `tools/windows_portable/update_public_key.xml` contains replacement markers and a non-release modulus; release/manual builds pass `-RequireReleasePublicKey` | The release path validates a key that cannot qualify as a real release key, so the official Windows build fails closed | Committed real public key validates; matching protected private key signs an update that the installed client accepts |
 | F-02 | `.github/workflows/release-please.yml` falls back to `github.token`; `.github/workflows/windows-portable.yml` listens for a separate release event | GitHub suppresses new workflow runs caused by events created with `GITHUB_TOKEN`, so the release can exist without triggering asset creation | Confirm non-`GITHUB_TOKEN` credential and observe a disposable Release Please prerelease trigger the Windows workflow |
 | F-03 | There are no prior release tags while `pyproject.toml` and `.release-please-manifest.json` already say `0.1.0`; the branch contains extensive feature history | Release Please may interpret `0.1.0` as already released and calculate a later version from all visible history | Previewed release PR/tag/changelog exactly match the maintainer-approved bootstrap version and commit boundary |
-| F-04 | The Windows builder installs PyQt6/PyQt6-Qt6 into the public bundle; PyQt6 package metadata is `GPL-3.0-only` or commercial while the repository is Apache-2.0; repository history shows only the maintainer’s Tristan/TJZine author identities | Redistributing the combined release without an explicit compatible-license posture creates avoidable ambiguity | Maintainer confirms the `GPL-3.0-only` route, all project metadata/notices are updated, and the exact artifact’s licenses and corresponding-source path are inspected |
+| F-04 | The Windows builder installs PyQt6/PyQt6-Qt6 into the public bundle; at the review baseline PyQt6 package metadata was `GPL-3.0-only` or commercial while the repository was Apache-2.0; the project is now `GPL-3.0-only` | Redistributing the combined release without inspecting the exact artifact’s license inventory and corresponding-source path could still leave compliance gaps | Inspect the exact artifact’s licenses, notices, and corresponding-source path after the completed project relicensing |
 | F-05 | Generated CLI help shows command names and options with little or no explanatory text for key first-run surfaces | New users cannot infer safe command intent, defaults, or route-specific invocation from the CLI itself | Human-reviewed top-level and per-command help with focused contract tests |
 | F-06 | `CHANGELOG.md` contains repeated internal phase/scaffold history and obsolete implementation detail | Release notes obscure actual user value and limitations and can misrepresent the initial release | First-release changelog reviewed as a concise user-facing capability/limitation record |
 | F-07 | Workflow publishes `.sha256` assets, while the prior Windows guide only instructed users to download and execute the ZIP | Integrity data exists but users are not told how to use it | Published guide includes copy/paste verification and a fail-closed mismatch instruction |
@@ -110,9 +110,9 @@ advances before the squash merge.
   runner.
 - Private signing key material must never enter the repository, task transcript,
   command line, CI logs, or release artifacts.
-- Licensing changes require explicit maintainer confirmation. The plan may recommend
-  the conservative `GPL-3.0-only` route but implementation agents must not silently
-  relicense the project.
+- The maintainer explicitly approved `GPL-3.0-only` on July 26, 2026. Preserve
+  third-party license texts and do not expand that approval into dual licensing,
+  copyright assignment, a CLA, or a commercial-license path.
 - Only one active plan should exist for this workstream.
 
 ### Non-goals
@@ -356,16 +356,16 @@ Accepted finding IDs: F-04.
 Goal: align the project and Windows distribution with PyQt6’s
 `GPL-3.0-only` terms without buying commercial licenses.
 
+Status: repository relicensing is complete; exact Windows artifact and
+corresponding-source verification remain.
+
 Risk reduced: public distribution without satisfying applicable GPL/commercial and
 Qt obligations.
 
 Scope:
 
-- Obtain explicit maintainer confirmation for the recommended
-  `GPL-3.0-only` project license.
-- Replace the project Apache license with the complete GPLv3 text and update package
-  metadata, classifiers, badges, user documentation, contributor terms, and bundle
-  project-license output.
+- Retain the completed GPLv3 project-license, package metadata, badge, user
+  documentation, contributor terms, and bundle project-license output changes.
 - Inventory the exact PyQt6, PyQt6-Qt6, Qt, and related packages shipped.
 - Preserve every applicable third-party license and notice; Apache-2.0 components
   retain their original notices within the GPLv3 distribution.
@@ -388,9 +388,9 @@ Expected behavior change: project licensing and distribution metadata change to
 `GPL-3.0-only`; runtime behavior and the feature-complete Windows bundle remain
 unchanged.
 
-Implementation approach: after explicit maintainer confirmation, implement the
-license change as one reviewable package and freeze public Windows distribution until
-the exact bundle/source pair passes the license inventory.
+Implementation approach: preserve the approved repository license change and freeze
+public Windows distribution until the exact bundle/source pair passes the license
+inventory.
 
 Verification:
 
@@ -409,8 +409,6 @@ same-pass user documentation updates.
 
 Open questions:
 
-- Has the maintainer explicitly approved changing Frame Compare itself to
-  `GPL-3.0-only`?
 - What exact release asset or repository link is the canonical corresponding-source
   location for each Windows binary tag?
 
@@ -798,7 +796,7 @@ Suggested owner role: maintainer/release manager.
 | Sequence | Work | Parallelism |
 | --- | --- | --- |
 | 0 | User install docs, checksum instructions, stale VSPreview links, and release auto-merge removal | Completed baseline; retain tests and strict docs proof |
-| 1 | Explicitly confirm and implement P2 `GPL-3.0-only` posture | Do before P0 because both packages touch project/package metadata |
+| 1 | Finish P2 exact-artifact license inventory and corresponding-source proof | Repository relicensing is complete; finish before P0/P3 release rehearsal |
 | 2 | P1 signing-key tooling and maintainer key generation | May begin alongside P2 when documentation files do not overlap |
 | 3 | P0 `v0.1.0` bootstrap configuration | Starts after P2 settles `pyproject.toml`; recalculate `bootstrap-sha` immediately before merge |
 | 4 | P4 remaining CLI help and changelog work | CLI help may proceed earlier; final changelog wording waits for P0/P2 |

--- a/docs/plans/2026-07-25-initial-release-remediation.md
+++ b/docs/plans/2026-07-25-initial-release-remediation.md
@@ -49,13 +49,13 @@ advances before the squash merge.
 | F-03 | First-release version and Release Please bootstrap history are ambiguous | Inferred release risk | S2 | High | Could publish an unintended `v0.2.0` or an oversized/misleading changelog |
 | F-04 | PyQt6 redistribution under the project’s intended license posture lacks a recorded compatible-license disposition | Confirmed license mismatch requiring maintainer disposition | S1 | High | Blocks public Windows binary distribution until the project and artifact license posture is aligned |
 | F-05 | Top-level and command-specific CLI help is too sparse for first-time users | Confirmed UX defect | S2 | High | Does not block mechanics, but materially harms first-use quality |
-| F-06 | `CHANGELOG.md` reads as internal phase/scaffold history instead of a public first-release changelog | Confirmed docs/release defect | S2 | High | Release notes would be noisy and misleading |
+| F-06 | `CHANGELOG.md` read as internal phase/scaffold history instead of a public first-release changelog | Confirmed docs/release defect | S2 | High | Resolved with a concise user-facing alpha changelog; re-review the generated release PR |
 | F-07 | Published Windows `.sha256` assets lacked user verification instructions | Confirmed docs defect | S3 | High | Resolved in the documentation package associated with this plan |
 | F-08 | A doctor remediation hint points to a stale README installation anchor | Confirmed UX/docs defect | S3 | High | Resolved by linking to the native-source Zensical guide |
 | F-09 | No clean Apple Silicon Docker proof was available during review | Verification gap | S2 | Medium | Do not claim Apple Silicon confidence until separately proved |
 | F-10 | Optional Linux NVIDIA and X11 routes remain host-dependent and unproved in baseline CI | Known verification limitation | S3 | High | Keep labeled experimental; does not block supported default route |
 | F-11 | Dependency vulnerability status was not independently audited for the release graph/bundle | Verification gap | S2 | Medium | Requires a release-time dependency/security audit |
-| F-12 | Distribution build is not an explicit CI gate, despite clean archive build succeeding locally | Inferred build/release gap | S2 | Medium | A packaging regression could reach `main` unnoticed |
+| F-12 | Distribution build was not an explicit CI gate, despite clean archive build succeeding locally | Inferred build/release gap | S2 | Medium | Resolved with a required clean build, artifact inspection, fresh wheel install, and CLI smoke job |
 | F-13 | Overlay font fallback can vary across hosts | Known determinism limitation | S3 | High | Document/test tolerance; do not claim cross-platform pixel identity |
 | F-14 | Docker base image and system package inputs are not fully digest/snapshot pinned | Supply-chain hardening opportunity | S3 | Medium | Track after first-release blockers unless threat model elevates it |
 | F-15 | Release-candidate asset installation and end-to-end use have not been rehearsed from the exact published artifacts | Verification gap | S1 | High | Blocks final go/no-go |
@@ -480,6 +480,9 @@ Suggested owner role: release-workflow implementer.
 
 Accepted finding IDs: F-05, F-06, and F-08.
 
+Status: the doctor link and public-alpha changelog are complete; CLI command and
+option help remain.
+
 Goal: make the CLI self-explanatory and the first public changelog concise,
 user-oriented, and accurate.
 
@@ -602,6 +605,9 @@ Suggested owner role: documentation owner.
 
 Accepted finding IDs: F-11, F-12, and F-14.
 
+Status: the distribution build/install/inspection CI gate is complete. Dependency
+audit policy, the Windows bundle inventory, and the Docker pinning decision remain.
+
 Goal: catch distribution and dependency problems before merge or release and record
 the remaining container pinning decision.
 
@@ -625,6 +631,7 @@ warning.
 Primary files/symbols:
 
 - `.github/workflows/ci.yml`
+- `scripts/verify_distribution.py`
 - `pyproject.toml`
 - `uv.lock`
 - `Dockerfile`
@@ -799,9 +806,9 @@ Suggested owner role: maintainer/release manager.
 | 1 | Finish P2 exact-artifact license inventory and corresponding-source proof | Repository relicensing is complete; finish before P0/P3 release rehearsal |
 | 2 | P1 signing-key tooling and maintainer key generation | May begin alongside P2 when documentation files do not overlap |
 | 3 | P0 `v0.1.0` bootstrap configuration | Starts after P2 settles `pyproject.toml`; recalculate `bootstrap-sha` immediately before merge |
-| 4 | P4 remaining CLI help and changelog work | CLI help may proceed earlier; final changelog wording waits for P0/P2 |
+| 4 | P4 remaining CLI help and final generated-release-note review | Public alpha changelog is complete; confirm Release Please output after P0 |
 | 5 | P3 release authentication and exact event-chain proof | Starts only after P0/P1/P2 have usable release state |
-| 6 | P6 build/security gates | After dependency/license direction is stable |
+| 6 | P6 dependency audit policy, Windows inventory, and Docker pinning decision | Distribution build/install/inspection CI gate is complete |
 | 7 | P7 exact RC rehearsal | Only after every prior blocker package exits |
 | 8 | P8 official publish | Only after explicit maintainer go/no-go |
 

--- a/docs/windows-portable.md
+++ b/docs/windows-portable.md
@@ -17,11 +17,30 @@ Release bundles are the intended recommended route. If the
 `frame-compare-portable-win-x64-<tag>.zip`, use the source-build route below.
 
 ```powershell
-# 1) Download frame-compare-portable-win-x64-<tag>.zip from the GitHub Release
-# 2) Extract it
+# 1) Download both files from the same GitHub Release:
+#    frame-compare-portable-win-x64-<tag>.zip
+#    frame-compare-portable-win-x64-<tag>.zip.sha256
+# 2) Verify the ZIP as shown below, then extract it.
 # 3) From the extracted folder:
 .\install.cmd
 ```
+
+Verify the ZIP before extracting or running it. Replace `<tag>` in both filenames
+with the release tag shown on GitHub:
+
+```powershell
+$zip = ".\frame-compare-portable-win-x64-<tag>.zip"
+$checksumFile = "$zip.sha256"
+$expected = ((Get-Content -LiteralPath $checksumFile -Raw).Trim() -split "\s+")[0].ToLowerInvariant()
+$actual = (Get-FileHash -LiteralPath $zip -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($actual -ne $expected) {
+    throw "SHA-256 mismatch. Do not install this download."
+}
+"SHA-256 verified: $actual"
+```
+
+The expected and actual hashes must match exactly. Delete and download both files
+again if verification fails; do not bypass a mismatch.
 
 ### From a Cloned Repo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "frame-compare"
 version = "0.1.0"
 description = "Video frame comparison tool with tonemapping and slow.pics integration"
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = "GPL-3.0-only"
 requires-python = ">=3.13"
 authors = [
     { name = "Tristan", email = "zine96@proton.me" }
@@ -13,7 +13,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.13",

--- a/scripts/verify_distribution.py
+++ b/scripts/verify_distribution.py
@@ -77,14 +77,32 @@ def _verify_wheel(wheel: Path) -> str:
     with zipfile.ZipFile(wheel) as archive:
         names = _validate_member_names(archive.namelist(), artifact=wheel)
         metadata_names = [name for name in names if name.endswith(".dist-info/METADATA")]
+        wheel_names = [name for name in names if name.endswith(".dist-info/WHEEL")]
+        record_names = [name for name in names if name.endswith(".dist-info/RECORD")]
         license_names = [name for name in names if name.endswith(".dist-info/licenses/LICENSE")]
-        if len(metadata_names) != 1:
-            _fail(f"{wheel.name} must contain exactly one dist-info METADATA file")
-        if len(license_names) != 1:
-            _fail(f"{wheel.name} must contain exactly one packaged project LICENSE")
+        required_members = {
+            "dist-info METADATA": metadata_names,
+            "dist-info WHEEL": wheel_names,
+            "dist-info RECORD": record_names,
+            "packaged project LICENSE": license_names,
+        }
+        for label, matches in required_members.items():
+            if len(matches) != 1:
+                _fail(f"{wheel.name} must contain exactly one {label} file")
+
+        metadata_name = metadata_names[0]
+        dist_info_dir = PurePosixPath(metadata_name).parent
+        if len(dist_info_dir.parts) != 1:
+            _fail(f"{wheel.name} dist-info directory must be at the archive root")
+        if PurePosixPath(wheel_names[0]).parent != dist_info_dir:
+            _fail(f"{wheel.name} WHEEL is not in the METADATA dist-info directory")
+        if PurePosixPath(record_names[0]).parent != dist_info_dir:
+            _fail(f"{wheel.name} RECORD is not in the METADATA dist-info directory")
+        if PurePosixPath(license_names[0]).parent.parent != dist_info_dir:
+            _fail(f"{wheel.name} LICENSE is not in the METADATA dist-info directory")
         if not any(name.startswith("frame_compare/") for name in names):
             _fail(f"{wheel.name} does not contain the frame_compare package")
-        metadata = _metadata_from_bytes(archive.read(metadata_names[0]), artifact=wheel)
+        metadata = _metadata_from_bytes(archive.read(metadata_name), artifact=wheel)
     return str(metadata["Version"])
 
 
@@ -95,6 +113,11 @@ def _verify_sdist(sdist: Path) -> str:
         linked = [member.name for member in members if member.issym() or member.islnk()]
         if linked:
             _fail(f"{sdist.name} contains links: {linked!r}")
+        unsupported = [
+            member.name for member in members if not member.isfile() and not member.isdir()
+        ]
+        if unsupported:
+            _fail(f"{sdist.name} contains unsupported member types: {unsupported!r}")
         metadata_names = [name for name in names if name.endswith("/PKG-INFO")]
         if len(metadata_names) != 1:
             _fail(f"{sdist.name} must contain exactly one PKG-INFO file")

--- a/scripts/verify_distribution.py
+++ b/scripts/verify_distribution.py
@@ -1,0 +1,141 @@
+"""Validate Frame Compare wheel and source-distribution release contents."""
+
+from __future__ import annotations
+
+import argparse
+import email.policy
+import tarfile
+import zipfile
+from collections.abc import Iterable
+from email.message import Message
+from email.parser import BytesParser
+from pathlib import Path, PurePosixPath
+from typing import NoReturn
+
+EXPECTED_NAME = "frame-compare"
+EXPECTED_LICENSE = "GPL-3.0-only"
+FORBIDDEN_PARTS = {
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+}
+FORBIDDEN_NAMES = {
+    ".DS_Store",
+    ".env",
+    ".pypirc",
+    "id_ed25519",
+    "id_rsa",
+}
+
+
+def _fail(message: str) -> NoReturn:
+    raise SystemExit(f"distribution verification failed: {message}")
+
+
+def _single_artifact(dist_dir: Path, pattern: str, label: str) -> Path:
+    artifacts = sorted(dist_dir.glob(pattern))
+    if len(artifacts) != 1:
+        _fail(f"expected exactly one {label} matching {pattern!r}, found {len(artifacts)}")
+    return artifacts[0]
+
+
+def _validate_member_names(names: Iterable[str], *, artifact: Path) -> list[str]:
+    validated: list[str] = []
+    for name in names:
+        if "\\" in name:
+            _fail(f"{artifact.name} contains a non-portable path: {name!r}")
+        path = PurePosixPath(name)
+        if path.is_absolute() or ".." in path.parts:
+            _fail(f"{artifact.name} contains an unsafe path: {name!r}")
+        if FORBIDDEN_PARTS.intersection(path.parts) or path.name in FORBIDDEN_NAMES:
+            _fail(f"{artifact.name} contains local or sensitive state: {name!r}")
+        if path.suffix == ".pyc":
+            _fail(f"{artifact.name} contains bytecode: {name!r}")
+        validated.append(name)
+    return validated
+
+
+def _metadata_from_bytes(data: bytes, *, artifact: Path) -> Message:
+    metadata = BytesParser(policy=email.policy.default).parsebytes(data)
+    if metadata["Name"] != EXPECTED_NAME:
+        _fail(f"{artifact.name} has unexpected project name {metadata['Name']!r}")
+    if metadata["License-Expression"] != EXPECTED_LICENSE:
+        _fail(
+            f"{artifact.name} has unexpected license expression {metadata['License-Expression']!r}"
+        )
+    if not metadata["Version"]:
+        _fail(f"{artifact.name} has no version metadata")
+    return metadata
+
+
+def _verify_wheel(wheel: Path) -> str:
+    with zipfile.ZipFile(wheel) as archive:
+        names = _validate_member_names(archive.namelist(), artifact=wheel)
+        metadata_names = [name for name in names if name.endswith(".dist-info/METADATA")]
+        license_names = [name for name in names if name.endswith(".dist-info/licenses/LICENSE")]
+        if len(metadata_names) != 1:
+            _fail(f"{wheel.name} must contain exactly one dist-info METADATA file")
+        if len(license_names) != 1:
+            _fail(f"{wheel.name} must contain exactly one packaged project LICENSE")
+        if not any(name.startswith("frame_compare/") for name in names):
+            _fail(f"{wheel.name} does not contain the frame_compare package")
+        metadata = _metadata_from_bytes(archive.read(metadata_names[0]), artifact=wheel)
+    return str(metadata["Version"])
+
+
+def _verify_sdist(sdist: Path) -> str:
+    with tarfile.open(sdist, "r:gz") as archive:
+        members = archive.getmembers()
+        names = _validate_member_names((member.name for member in members), artifact=sdist)
+        linked = [member.name for member in members if member.issym() or member.islnk()]
+        if linked:
+            _fail(f"{sdist.name} contains links: {linked!r}")
+        metadata_names = [name for name in names if name.endswith("/PKG-INFO")]
+        if len(metadata_names) != 1:
+            _fail(f"{sdist.name} must contain exactly one PKG-INFO file")
+        required_suffixes = (
+            "/LICENSE",
+            "/README.md",
+            "/pyproject.toml",
+            "/src/frame_compare/__init__.py",
+        )
+        for suffix in required_suffixes:
+            if not any(name.endswith(suffix) for name in names):
+                _fail(f"{sdist.name} is missing required content ending in {suffix!r}")
+        metadata_file = archive.extractfile(metadata_names[0])
+        if metadata_file is None:
+            _fail(f"{sdist.name} PKG-INFO is not a regular file")
+        metadata = _metadata_from_bytes(metadata_file.read(), artifact=sdist)
+    return str(metadata["Version"])
+
+
+def verify_distribution(dist_dir: Path) -> None:
+    """Validate the single wheel and sdist in ``dist_dir``."""
+    if not dist_dir.is_dir():
+        _fail(f"artifact directory does not exist: {dist_dir}")
+    wheel = _single_artifact(dist_dir, "*.whl", "wheel")
+    sdist = _single_artifact(dist_dir, "*.tar.gz", "source distribution")
+    wheel_version = _verify_wheel(wheel)
+    sdist_version = _verify_sdist(sdist)
+    if wheel_version != sdist_version:
+        _fail(f"artifact versions differ: wheel={wheel_version}, sdist={sdist_version}")
+    print(
+        f"distribution verification passed: version={wheel_version} "
+        f"wheel={wheel.name} sdist={sdist.name}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dist_dir", type=Path, help="Directory containing one wheel and one sdist")
+    args = parser.parse_args()
+    verify_distribution(args.dist_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_distribution.py
+++ b/scripts/verify_distribution.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import csv
 import email.policy
+import hashlib
+import io
 import tarfile
 import zipfile
 from collections.abc import Iterable
@@ -73,6 +77,49 @@ def _metadata_from_bytes(data: bytes, *, artifact: Path) -> Message:
     return metadata
 
 
+def _verify_wheel_record(
+    archive: zipfile.ZipFile,
+    *,
+    record_name: str,
+    artifact: Path,
+) -> None:
+    file_names = [info.filename for info in archive.infolist() if not info.is_dir()]
+    if len(file_names) != len(set(file_names)):
+        _fail(f"{artifact.name} contains duplicate archive members")
+
+    try:
+        record_text = archive.read(record_name).decode("utf-8")
+        reader = csv.reader(io.StringIO(record_text, newline=""))
+        records: dict[str, tuple[str, str]] = {}
+        for row in reader:
+            if len(row) != 3:
+                _fail(f"{artifact.name} RECORD contains a malformed row")
+            path, digest, size = row
+            if path in records:
+                _fail(f"{artifact.name} RECORD contains duplicate path {path!r}")
+            records[path] = (digest, size)
+    except (UnicodeDecodeError, csv.Error) as error:
+        _fail(f"{artifact.name} RECORD is invalid: {error}")
+
+    archived = set(file_names)
+    recorded = set(records)
+    if archived != recorded:
+        missing = sorted(archived - recorded)
+        stale = sorted(recorded - archived)
+        _fail(f"{artifact.name} RECORD paths differ: missing={missing!r} stale={stale!r}")
+    if records[record_name] != ("", ""):
+        _fail(f"{artifact.name} RECORD must not hash itself")
+
+    for name in file_names:
+        if name == record_name:
+            continue
+        data = archive.read(name)
+        digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+        expected = (f"sha256={digest}", str(len(data)))
+        if records[name] != expected:
+            _fail(f"{artifact.name} RECORD mismatch for {name!r}")
+
+
 def _verify_wheel(wheel: Path) -> str:
     with zipfile.ZipFile(wheel) as archive:
         names = _validate_member_names(archive.namelist(), artifact=wheel)
@@ -102,6 +149,11 @@ def _verify_wheel(wheel: Path) -> str:
             _fail(f"{wheel.name} LICENSE is not in the METADATA dist-info directory")
         if not any(name.startswith("frame_compare/") for name in names):
             _fail(f"{wheel.name} does not contain the frame_compare package")
+        _verify_wheel_record(
+            archive,
+            record_name=record_names[0],
+            artifact=wheel,
+        )
         metadata = _metadata_from_bytes(archive.read(metadata_name), artifact=wheel)
     return str(metadata["Version"])
 

--- a/src/frame_compare/vspreview/adapter.py
+++ b/src/frame_compare/vspreview/adapter.py
@@ -99,7 +99,8 @@ def check_vspreview_availability() -> VSPreviewAvailability:
                 status=VSPreviewAvailabilityStatus.MISSING_EXEC_AND_MODULE,
                 message="VSPreview not installed (optional for manual alignment)",
                 hint=(
-                    "Provide VSPreview; see https://github.com/TJZine/frame-compare#installation"
+                    "Provide VSPreview; see "
+                    "https://tjzine.github.io/frame-compare/getting-started/native/"
                 ),
             )
 
@@ -119,7 +120,7 @@ def check_vspreview_availability() -> VSPreviewAvailability:
             message="Qt backend missing for VSPreview (optional for manual alignment)",
             hint=(
                 "Provide a supported Qt backend for VSPreview; see "
-                "https://github.com/TJZine/frame-compare#installation"
+                "https://tjzine.github.io/frame-compare/getting-started/native/"
             ),
         )
     except Exception as exc:
@@ -128,7 +129,7 @@ def check_vspreview_availability() -> VSPreviewAvailability:
             message="VSPreview availability probe failed (optional for manual alignment)",
             hint=(
                 "Check the optional VSPreview setup, then rerun doctor; see "
-                "https://github.com/TJZine/frame-compare#installation"
+                "https://tjzine.github.io/frame-compare/getting-started/native/"
             ),
             error_details={
                 "exception_type": type(exc).__name__,

--- a/tests/cli/test_doctor_command.py
+++ b/tests/cli/test_doctor_command.py
@@ -33,14 +33,14 @@ _AUDITED_HINTS = (
         "Provide an FFmpeg executable on PATH; see "
         "https://github.com/TJZine/frame-compare#requirements"
     ),
-    "Provide VSPreview; see https://github.com/TJZine/frame-compare#installation",
+    ("Provide VSPreview; see https://tjzine.github.io/frame-compare/getting-started/native/"),
     (
         "Provide a supported Qt backend for VSPreview; see "
-        "https://github.com/TJZine/frame-compare#installation"
+        "https://tjzine.github.io/frame-compare/getting-started/native/"
     ),
     (
         "Check the optional VSPreview setup, then rerun doctor; see "
-        "https://github.com/TJZine/frame-compare#installation"
+        "https://tjzine.github.io/frame-compare/getting-started/native/"
     ),
     "Review the returned HTTP status before retrying",
     "Check network access to slow.pics, then retry",

--- a/tests/scripts/test_verify_distribution.py
+++ b/tests/scripts/test_verify_distribution.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 import io
 import subprocess
 import sys
 import tarfile
 import zipfile
 from pathlib import Path
+
+import pytest
 
 METADATA = """\
 Metadata-Version: 2.4
@@ -14,13 +18,52 @@ Version: 0.1.0
 License-Expression: GPL-3.0-only
 """
 
+WHEEL = """\
+Wheel-Version: 1.0
+Generator: frame-compare-test
+Root-Is-Purelib: true
+Tag: py3-none-any
+"""
 
-def _write_wheel(dist_dir: Path) -> None:
+
+def _record_row(name: str, value: str) -> str:
+    data = value.encode()
+    digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+    return f"{name},sha256={digest},{len(data)}"
+
+
+def _write_wheel(
+    dist_dir: Path,
+    *,
+    include_wheel: bool = True,
+    include_record: bool = True,
+    metadata_dist_info: str = "frame_compare-0.1.0.dist-info",
+    wheel_dist_info: str = "frame_compare-0.1.0.dist-info",
+    record_dist_info: str = "frame_compare-0.1.0.dist-info",
+    license_dist_info: str = "frame_compare-0.1.0.dist-info",
+    duplicate_member: str | None = None,
+) -> None:
     wheel = dist_dir / "frame_compare-0.1.0-py3-none-any.whl"
+    contents = {
+        "frame_compare/__init__.py": '__version__ = "0.1.0"\n',
+        f"{metadata_dist_info}/METADATA": METADATA,
+        f"{license_dist_info}/licenses/LICENSE": "GPL text",
+    }
+    if include_wheel:
+        contents[f"{wheel_dist_info}/WHEEL"] = WHEEL
+    if include_record:
+        record_name = f"{record_dist_info}/RECORD"
+        record = "\n".join(
+            [*(_record_row(name, value) for name, value in contents.items()), f"{record_name},,"]
+        )
+        contents[record_name] = f"{record}\n"
+
     with zipfile.ZipFile(wheel, "w") as archive:
-        archive.writestr("frame_compare/__init__.py", '__version__ = "0.1.0"\n')
-        archive.writestr("frame_compare-0.1.0.dist-info/METADATA", METADATA)
-        archive.writestr("frame_compare-0.1.0.dist-info/licenses/LICENSE", "GPL text")
+        for name, value in contents.items():
+            archive.writestr(name, value)
+        if duplicate_member is not None:
+            duplicate_name = f"{metadata_dist_info}/{duplicate_member}"
+            archive.writestr(duplicate_name, contents[duplicate_name])
 
 
 def _add_tar_text(archive: tarfile.TarFile, name: str, value: str) -> None:
@@ -30,10 +73,18 @@ def _add_tar_text(archive: tarfile.TarFile, name: str, value: str) -> None:
     archive.addfile(member, io.BytesIO(data))
 
 
-def _write_sdist(dist_dir: Path, *, extra_name: str | None = None) -> None:
+def _write_sdist(
+    dist_dir: Path,
+    *,
+    extra_name: str | None = None,
+    extra_member_type: bytes | None = None,
+) -> None:
     sdist = dist_dir / "frame_compare-0.1.0.tar.gz"
     root = "frame_compare-0.1.0"
     with tarfile.open(sdist, "w:gz") as archive:
+        root_directory = tarfile.TarInfo(root)
+        root_directory.type = tarfile.DIRTYPE
+        archive.addfile(root_directory)
         _add_tar_text(archive, f"{root}/PKG-INFO", METADATA)
         _add_tar_text(archive, f"{root}/LICENSE", "GPL text")
         _add_tar_text(archive, f"{root}/README.md", "# Frame Compare")
@@ -41,6 +92,12 @@ def _write_sdist(dist_dir: Path, *, extra_name: str | None = None) -> None:
         _add_tar_text(archive, f"{root}/src/frame_compare/__init__.py", "")
         if extra_name is not None:
             _add_tar_text(archive, f"{root}/{extra_name}", "unexpected")
+        if extra_member_type is not None:
+            special = tarfile.TarInfo(f"{root}/special-member")
+            special.type = extra_member_type
+            special.devmajor = 1
+            special.devminor = 3
+            archive.addfile(special)
 
 
 def _run_verifier(repo_root: Path, dist_dir: Path) -> subprocess.CompletedProcess[str]:
@@ -74,3 +131,104 @@ def test_distribution_verifier_rejects_local_environment_state(
 
     assert result.returncode != 0
     assert "contains local or sensitive state" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("include_wheel", "include_record", "missing_label"),
+    [
+        (False, True, "WHEEL"),
+        (True, False, "RECORD"),
+    ],
+)
+def test_distribution_verifier_rejects_missing_required_wheel_metadata(
+    tmp_path: Path,
+    repo_root: Path,
+    *,
+    include_wheel: bool,
+    include_record: bool,
+    missing_label: str,
+) -> None:
+    _write_wheel(tmp_path, include_wheel=include_wheel, include_record=include_record)
+    _write_sdist(tmp_path)
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert f"exactly one dist-info {missing_label} file" in result.stderr
+
+
+@pytest.mark.parametrize("member", ["WHEEL", "RECORD"])
+def test_distribution_verifier_rejects_duplicate_required_wheel_metadata(
+    tmp_path: Path,
+    repo_root: Path,
+    member: str,
+) -> None:
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        _write_wheel(tmp_path, duplicate_member=member)
+    _write_sdist(tmp_path)
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert f"exactly one dist-info {member} file" in result.stderr
+
+
+@pytest.mark.parametrize("member", ["WHEEL", "RECORD", "LICENSE"])
+def test_distribution_verifier_rejects_mismatched_dist_info_directories(
+    tmp_path: Path,
+    repo_root: Path,
+    member: str,
+) -> None:
+    dist_info = "frame_compare-0.1.0.dist-info"
+    other_dist_info = "other-0.1.0.dist-info"
+    _write_wheel(
+        tmp_path,
+        wheel_dist_info=other_dist_info if member == "WHEEL" else dist_info,
+        record_dist_info=other_dist_info if member == "RECORD" else dist_info,
+        license_dist_info=other_dist_info if member == "LICENSE" else dist_info,
+    )
+    _write_sdist(tmp_path)
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert f"{member} is not in the METADATA dist-info directory" in result.stderr
+
+
+def test_distribution_verifier_rejects_nested_dist_info_directory(
+    tmp_path: Path,
+    repo_root: Path,
+) -> None:
+    nested_dist_info = "nested/frame_compare-0.1.0.dist-info"
+    _write_wheel(
+        tmp_path,
+        metadata_dist_info=nested_dist_info,
+        wheel_dist_info=nested_dist_info,
+        record_dist_info=nested_dist_info,
+        license_dist_info=nested_dist_info,
+    )
+    _write_sdist(tmp_path)
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert "dist-info directory must be at the archive root" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "member_type",
+    [tarfile.FIFOTYPE, tarfile.CHRTYPE, tarfile.BLKTYPE],
+    ids=["fifo", "character-device", "block-device"],
+)
+def test_distribution_verifier_rejects_special_sdist_members(
+    tmp_path: Path,
+    repo_root: Path,
+    member_type: bytes,
+) -> None:
+    _write_wheel(tmp_path)
+    _write_sdist(tmp_path, extra_member_type=member_type)
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert "contains unsupported member types" in result.stderr

--- a/tests/scripts/test_verify_distribution.py
+++ b/tests/scripts/test_verify_distribution.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import io
+import subprocess
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+METADATA = """\
+Metadata-Version: 2.4
+Name: frame-compare
+Version: 0.1.0
+License-Expression: GPL-3.0-only
+"""
+
+
+def _write_wheel(dist_dir: Path) -> None:
+    wheel = dist_dir / "frame_compare-0.1.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("frame_compare/__init__.py", '__version__ = "0.1.0"\n')
+        archive.writestr("frame_compare-0.1.0.dist-info/METADATA", METADATA)
+        archive.writestr("frame_compare-0.1.0.dist-info/licenses/LICENSE", "GPL text")
+
+
+def _add_tar_text(archive: tarfile.TarFile, name: str, value: str) -> None:
+    data = value.encode()
+    member = tarfile.TarInfo(name)
+    member.size = len(data)
+    archive.addfile(member, io.BytesIO(data))
+
+
+def _write_sdist(dist_dir: Path, *, extra_name: str | None = None) -> None:
+    sdist = dist_dir / "frame_compare-0.1.0.tar.gz"
+    root = "frame_compare-0.1.0"
+    with tarfile.open(sdist, "w:gz") as archive:
+        _add_tar_text(archive, f"{root}/PKG-INFO", METADATA)
+        _add_tar_text(archive, f"{root}/LICENSE", "GPL text")
+        _add_tar_text(archive, f"{root}/README.md", "# Frame Compare")
+        _add_tar_text(archive, f"{root}/pyproject.toml", "[project]")
+        _add_tar_text(archive, f"{root}/src/frame_compare/__init__.py", "")
+        if extra_name is not None:
+            _add_tar_text(archive, f"{root}/{extra_name}", "unexpected")
+
+
+def _run_verifier(repo_root: Path, dist_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(repo_root / "scripts" / "verify_distribution.py"), str(dist_dir)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_distribution_verifier_accepts_expected_artifacts(tmp_path: Path, repo_root: Path) -> None:
+    _write_wheel(tmp_path)
+    _write_sdist(tmp_path)
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode == 0
+    assert "distribution verification passed: version=0.1.0" in result.stdout
+    assert result.stderr == ""
+
+
+def test_distribution_verifier_rejects_local_environment_state(
+    tmp_path: Path, repo_root: Path
+) -> None:
+    _write_wheel(tmp_path)
+    _write_sdist(tmp_path, extra_name=".venv/bin/python")
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert "contains local or sensitive state" in result.stderr

--- a/tests/scripts/test_verify_distribution.py
+++ b/tests/scripts/test_verify_distribution.py
@@ -66,6 +66,20 @@ def _write_wheel(
             archive.writestr(duplicate_name, contents[duplicate_name])
 
 
+def _replace_wheel_member(wheel: Path, member_name: str, value: str) -> None:
+    replacement = value.encode()
+    with zipfile.ZipFile(wheel) as archive:
+        members = [(info, archive.read(info)) for info in archive.infolist()]
+    with zipfile.ZipFile(wheel, "w") as archive:
+        for info, data in members:
+            archive.writestr(info, replacement if info.filename == member_name else data)
+
+
+def _read_wheel_member(wheel: Path, member_name: str) -> str:
+    with zipfile.ZipFile(wheel) as archive:
+        return archive.read(member_name).decode()
+
+
 def _add_tar_text(archive: tarfile.TarFile, name: str, value: str) -> None:
     data = value.encode()
     member = tarfile.TarInfo(name)
@@ -119,6 +133,134 @@ def test_distribution_verifier_accepts_expected_artifacts(tmp_path: Path, repo_r
     assert result.returncode == 0
     assert "distribution verification passed: version=0.1.0" in result.stdout
     assert result.stderr == ""
+
+
+def test_distribution_verifier_rejects_payload_modified_after_record_generation(
+    tmp_path: Path,
+    repo_root: Path,
+) -> None:
+    _write_wheel(tmp_path)
+    _write_sdist(tmp_path)
+    wheel = tmp_path / "frame_compare-0.1.0-py3-none-any.whl"
+    _replace_wheel_member(wheel, "frame_compare/__init__.py", '__version__ = "0.1.1"\n')
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert "RECORD mismatch for 'frame_compare/__init__.py'" in result.stderr
+
+
+def test_distribution_verifier_rejects_stale_record_entry(
+    tmp_path: Path,
+    repo_root: Path,
+) -> None:
+    _write_wheel(tmp_path)
+    _write_sdist(tmp_path)
+    wheel = tmp_path / "frame_compare-0.1.0-py3-none-any.whl"
+    record_name = "frame_compare-0.1.0.dist-info/RECORD"
+    record = _read_wheel_member(wheel, record_name)
+    _replace_wheel_member(wheel, record_name, f"{record}stale.py,sha256=unused,0\n")
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert "RECORD paths differ" in result.stderr
+    assert "stale.py" in result.stderr
+
+
+def test_distribution_verifier_rejects_incorrect_record_size(
+    tmp_path: Path,
+    repo_root: Path,
+) -> None:
+    _write_wheel(tmp_path)
+    _write_sdist(tmp_path)
+    wheel = tmp_path / "frame_compare-0.1.0-py3-none-any.whl"
+    record_name = "frame_compare-0.1.0.dist-info/RECORD"
+    record = _read_wheel_member(wheel, record_name)
+    rows = record.splitlines()
+    payload_row = next(row for row in rows if row.startswith("frame_compare/__init__.py,"))
+    path, digest, size = payload_row.split(",")
+    rows[rows.index(payload_row)] = f"{path},{digest},{int(size) + 1}"
+    _replace_wheel_member(wheel, record_name, f"{'\n'.join(rows)}\n")
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert "RECORD mismatch for 'frame_compare/__init__.py'" in result.stderr
+
+
+def test_distribution_verifier_rejects_missing_record_entry(
+    tmp_path: Path,
+    repo_root: Path,
+) -> None:
+    _write_wheel(tmp_path)
+    _write_sdist(tmp_path)
+    wheel = tmp_path / "frame_compare-0.1.0-py3-none-any.whl"
+    record_name = "frame_compare-0.1.0.dist-info/RECORD"
+    rows = _read_wheel_member(wheel, record_name).splitlines()
+    rows = [row for row in rows if not row.startswith("frame_compare/__init__.py,")]
+    _replace_wheel_member(wheel, record_name, f"{'\n'.join(rows)}\n")
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert "RECORD paths differ" in result.stderr
+    assert "frame_compare/__init__.py" in result.stderr
+
+
+def test_distribution_verifier_rejects_malformed_record_row(
+    tmp_path: Path,
+    repo_root: Path,
+) -> None:
+    _write_wheel(tmp_path)
+    _write_sdist(tmp_path)
+    wheel = tmp_path / "frame_compare-0.1.0-py3-none-any.whl"
+    record_name = "frame_compare-0.1.0.dist-info/RECORD"
+    record = _read_wheel_member(wheel, record_name)
+    _replace_wheel_member(wheel, record_name, f"{record}malformed\n")
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert "RECORD contains a malformed row" in result.stderr
+
+
+def test_distribution_verifier_rejects_duplicate_record_path(
+    tmp_path: Path,
+    repo_root: Path,
+) -> None:
+    _write_wheel(tmp_path)
+    _write_sdist(tmp_path)
+    wheel = tmp_path / "frame_compare-0.1.0-py3-none-any.whl"
+    record_name = "frame_compare-0.1.0.dist-info/RECORD"
+    record = _read_wheel_member(wheel, record_name)
+    first_row = record.splitlines()[0]
+    _replace_wheel_member(wheel, record_name, f"{record}{first_row}\n")
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert "RECORD contains duplicate path" in result.stderr
+
+
+def test_distribution_verifier_rejects_duplicate_payload_member(
+    tmp_path: Path,
+    repo_root: Path,
+) -> None:
+    _write_wheel(tmp_path)
+    _write_sdist(tmp_path)
+    wheel = tmp_path / "frame_compare-0.1.0-py3-none-any.whl"
+    payload_name = "frame_compare/__init__.py"
+    with (
+        pytest.warns(UserWarning, match="Duplicate name"),
+        zipfile.ZipFile(wheel, "a") as archive,
+    ):
+        archive.writestr(payload_name, archive.read(payload_name))
+
+    result = _run_verifier(repo_root, tmp_path)
+
+    assert result.returncode != 0
+    assert "contains duplicate archive members" in result.stderr
 
 
 def test_distribution_verifier_rejects_local_environment_state(

--- a/tests/vspreview/test_adapter.py
+++ b/tests/vspreview/test_adapter.py
@@ -883,15 +883,15 @@ def test_check_vspreview_availability_by_owner_branch(
     assert expected_message in result.message
     expected_hints = {
         VSPreviewAvailabilityStatus.MISSING_EXEC_AND_MODULE: (
-            "Provide VSPreview; see https://github.com/TJZine/frame-compare#installation"
+            "Provide VSPreview; see https://tjzine.github.io/frame-compare/getting-started/native/"
         ),
         VSPreviewAvailabilityStatus.MISSING_QT_BACKEND: (
             "Provide a supported Qt backend for VSPreview; see "
-            "https://github.com/TJZine/frame-compare#installation"
+            "https://tjzine.github.io/frame-compare/getting-started/native/"
         ),
         VSPreviewAvailabilityStatus.PROBE_FAILED: (
             "Check the optional VSPreview setup, then rerun doctor; see "
-            "https://github.com/TJZine/frame-compare#installation"
+            "https://tjzine.github.io/frame-compare/getting-started/native/"
         ),
     }
     assert result.hint == expected_hints.get(expected_status)

--- a/tests/windows_portable/test_windows_portable_workflow.py
+++ b/tests/windows_portable/test_windows_portable_workflow.py
@@ -152,35 +152,34 @@ def test_windows_portable_workflow_builds_code_only_update_after_bundle(
     assert "UPDATE_ZIP=$updateZip" in workflow
 
 
-def test_windows_portable_workflow_signs_update_only_for_release_like_events(
+def test_windows_portable_workflow_requires_signing_for_release_like_events(
     repo_root: Path,
 ) -> None:
     workflow_path = repo_root / ".github" / "workflows" / "windows-portable.yml"
     workflow = _read_text_or_fail(workflow_path)
 
-    assert "Pull requests prove update zip creation without requiring signing secrets." in workflow
-    assert (
-        "Release/manual runs sign only when the private key XML secret is configured." in workflow
-    )
-    assert "id: sign_update" in workflow
+    assert "Pull requests prove unsigned update zip creation without signing secrets." in workflow
+    assert "Release/manual runs require a signed update and fail closed" in workflow
     assert (
         "if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'" in workflow
     )
     assert (
         "WINDOWS_UPDATE_SIGNING_KEY_XML: ${{ secrets.WINDOWS_UPDATE_SIGNING_KEY_XML }}" in workflow
     )
-    assert "::notice::Skipping signed update zip; WINDOWS_UPDATE_SIGNING_KEY_XML secret" in workflow
+    assert "WINDOWS_UPDATE_SIGNING_KEY_XML is required for release and manual runs." in workflow
     assert "$env:SIGNING_KEY_XML_PATH = $keyPath" in workflow
     assert "tools/windows_portable/sign_update.ps1" in workflow
     assert "-UpdateZip $env:UPDATE_ZIP" in workflow
-    assert "signed=false" in workflow
-    assert "signed=true" in workflow
+    assert "signed=false" not in workflow
+    assert "signed=true" not in workflow
+    assert "update_signed" not in workflow
     sign_update_step = re.search(
         r"- name: Sign code-only update zip[\s\S]*?(?=\n      - name:)",
         workflow,
     )
     assert sign_update_step is not None, "Sign code-only update zip step not found"
     assert "pull_request" not in sign_update_step.group(0)
+    assert "exit 0" not in sign_update_step.group(0)
 
 
 def test_windows_portable_workflow_verifies_and_uploads_update_artifact(
@@ -196,6 +195,10 @@ def test_windows_portable_workflow_verifies_and_uploads_update_artifact(
     assert 'target_platform -ne "windows-x64"' in workflow
     assert 'payload_root -ne "payload"' in workflow
     assert 'signature_file -ne "update-manifest.sig"' in workflow
+    assert (
+        "REQUIRE_SIGNED_UPDATE: ${{ github.event_name == 'release' || "
+        "github.event_name == 'workflow_dispatch' }}"
+    ) in workflow
     assert "Signed update zip is missing update-manifest.sig." in workflow
     assert "Upload code-only update artifact" in workflow
     assert "name: frame-compare-update-win-x64" in workflow
@@ -203,17 +206,20 @@ def test_windows_portable_workflow_verifies_and_uploads_update_artifact(
     assert "dist/frame-compare-update-win-x64-*.zip.sha256" in workflow
 
 
-def test_windows_portable_workflow_uploads_signed_update_release_asset_conditionally(
+def test_windows_portable_workflow_requires_signed_update_release_assets(
     repo_root: Path,
 ) -> None:
     workflow_path = repo_root / ".github" / "workflows" / "windows-portable.yml"
     workflow = _read_text_or_fail(workflow_path)
 
-    assert "update_signed: ${{ steps.sign_update.outputs.signed }}" in workflow
     assert "Download signed update artifact" in workflow
     assert "Prepare versioned signed update asset" in workflow
-    assert "Upload signed update release asset" in workflow
-    assert workflow.count("if: needs.build.outputs.update_signed == 'true'") == 3
+    assert "Verify required release asset set" in workflow
+    assert "Upload required release assets" in workflow
+    assert "if: needs.build.outputs.update_signed == 'true'" not in workflow
+    assert workflow.count("if-no-files-found: error") == 2
+    assert workflow.count("fail_on_unmatched_files: true") == 1
+    assert "Missing required release asset: $asset" in workflow
     assert "mapfile -t update_zips" in workflow
     assert "Expected exactly one signed update zip artifact, found ${#update_zips[@]}." in workflow
     assert "frame-compare-update-win-x64-${ASSET_TAG}.zip" in workflow

--- a/tests/windows_portable/test_windows_portable_workflow.py
+++ b/tests/windows_portable/test_windows_portable_workflow.py
@@ -212,24 +212,39 @@ def test_windows_portable_workflow_requires_signed_update_release_assets(
     repo_root: Path,
 ) -> None:
     workflow_path = repo_root / ".github" / "workflows" / "windows-portable.yml"
-    workflow = _read_text_or_fail(workflow_path)
+    workflow = _load_workflow(workflow_path)
+    build = workflow["jobs"]["build"]
+    release_assets = workflow["jobs"]["release-assets"]
+    upload_bundle = _step_by_name(build, "Upload bundle artifact")
+    upload_update = _step_by_name(build, "Upload code-only update artifact")
+    download = _step_by_name(release_assets, "Download signed update artifact")
+    prepare = _step_by_name(release_assets, "Prepare versioned signed update asset")
+    verify_assets = _step_by_name(release_assets, "Verify required release asset set")
+    upload = _step_by_name(release_assets, "Upload required release assets")
 
-    assert "Download signed update artifact" in workflow
-    assert "Prepare versioned signed update asset" in workflow
-    assert "Verify required release asset set" in workflow
-    assert "Upload required release assets" in workflow
-    assert "if: needs.build.outputs.update_signed == 'true'" not in workflow
-    assert workflow.count("if-no-files-found: error") == 2
-    assert workflow.count("fail_on_unmatched_files: true") == 1
-    assert "Missing required release asset: $asset" in workflow
-    assert "mapfile -t update_zips" in workflow
-    assert "Expected exactly one signed update zip artifact, found ${#update_zips[@]}." in workflow
-    assert "frame-compare-update-win-x64-${ASSET_TAG}.zip" in workflow
+    assert release_assets["if"] == "github.event_name == 'release'"
+    assert "outputs" not in build
+    assert "if" not in download
+    assert download["with"] == {
+        "name": "frame-compare-update-win-x64",
+        "path": "dist/release-assets",
+    }
+    assert "if" not in prepare
+    assert upload_bundle["with"]["if-no-files-found"] == "error"
+    assert upload_update["with"]["if-no-files-found"] == "error"
+    assert "mapfile -t update_zips" in prepare["run"]
+    assert (
+        "Expected exactly one signed update zip artifact, found ${#update_zips[@]}."
+        in prepare["run"]
+    )
+    assert "frame-compare-update-win-x64-${ASSET_TAG}.zip" in prepare["run"]
+    assert "Missing required release asset: $asset" in verify_assets["run"]
+    assert upload["with"]["fail_on_unmatched_files"] == "true"
     assert (
         "dist/release-assets/frame-compare-update-win-x64-${{ "
         "steps.release_names.outputs.asset_tag }}.zip"
-    ) in workflow
+    ) in upload["with"]["files"]
     assert (
         "dist/release-assets/frame-compare-update-win-x64-${{ "
         "steps.release_names.outputs.asset_tag }}.zip.sha256"
-    ) in workflow
+    ) in upload["with"]["files"]

--- a/tests/windows_portable/test_windows_portable_workflow.py
+++ b/tests/windows_portable/test_windows_portable_workflow.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from tests.workflow_helpers import (
     assert_release_asset_name_hardening as _assert_release_asset_name_hardening,
 )
+from tests.workflow_helpers import load_workflow as _load_workflow
+from tests.workflow_helpers import step_by_name as _step_by_name
 
 from ._helpers import read_text_or_fail as _read_text_or_fail
 
@@ -156,30 +158,30 @@ def test_windows_portable_workflow_requires_signing_for_release_like_events(
     repo_root: Path,
 ) -> None:
     workflow_path = repo_root / ".github" / "workflows" / "windows-portable.yml"
-    workflow = _read_text_or_fail(workflow_path)
+    source = _read_text_or_fail(workflow_path)
+    workflow = _load_workflow(workflow_path)
+    sign_update_step = _step_by_name(workflow["jobs"]["build"], "Sign code-only update zip")
+    sign_update_run = sign_update_step["run"]
 
-    assert "Pull requests prove unsigned update zip creation without signing secrets." in workflow
-    assert "Release/manual runs require a signed update and fail closed" in workflow
-    assert (
-        "if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'" in workflow
+    assert "Pull requests prove unsigned update zip creation without signing secrets." in source
+    assert "Release/manual runs require a signed update and fail closed" in source
+    assert sign_update_step["if"] == (
+        "github.event_name == 'release' || github.event_name == 'workflow_dispatch'"
     )
-    assert (
-        "WINDOWS_UPDATE_SIGNING_KEY_XML: ${{ secrets.WINDOWS_UPDATE_SIGNING_KEY_XML }}" in workflow
+    assert sign_update_step["env"]["WINDOWS_UPDATE_SIGNING_KEY_XML"] == (
+        "${{ secrets.WINDOWS_UPDATE_SIGNING_KEY_XML }}"
     )
-    assert "WINDOWS_UPDATE_SIGNING_KEY_XML is required for release and manual runs." in workflow
-    assert "$env:SIGNING_KEY_XML_PATH = $keyPath" in workflow
-    assert "tools/windows_portable/sign_update.ps1" in workflow
-    assert "-UpdateZip $env:UPDATE_ZIP" in workflow
-    assert "signed=false" not in workflow
-    assert "signed=true" not in workflow
-    assert "update_signed" not in workflow
-    sign_update_step = re.search(
-        r"- name: Sign code-only update zip[\s\S]*?(?=\n      - name:)",
-        workflow,
+    assert "WINDOWS_UPDATE_SIGNING_KEY_XML is required for release and manual runs." in (
+        sign_update_run
     )
-    assert sign_update_step is not None, "Sign code-only update zip step not found"
-    assert "pull_request" not in sign_update_step.group(0)
-    assert "exit 0" not in sign_update_step.group(0)
+    assert "$env:SIGNING_KEY_XML_PATH = $keyPath" in sign_update_run
+    assert "tools/windows_portable/sign_update.ps1" in sign_update_run
+    assert "-UpdateZip $env:UPDATE_ZIP" in sign_update_run
+    assert "pull_request" not in sign_update_step["if"]
+    assert "exit 0" not in sign_update_run
+    assert "signed=false" not in sign_update_run
+    assert "signed=true" not in sign_update_run
+    assert "update_signed" not in source
 
 
 def test_windows_portable_workflow_verifies_and_uploads_update_artifact(

--- a/tests/workflow_helpers.py
+++ b/tests/workflow_helpers.py
@@ -2,11 +2,26 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any, cast
+
+import yaml
 
 
 def read_text_or_fail(path: Path) -> str:
     assert path.exists(), f"Required file not found: {path}"
     return path.read_text(encoding="utf-8")
+
+
+def load_workflow(path: Path) -> dict[str, Any]:
+    parsed = yaml.load(read_text_or_fail(path), Loader=yaml.BaseLoader)
+    assert isinstance(parsed, dict), f"Workflow must be a mapping: {path}"
+    return cast(dict[str, Any], parsed)
+
+
+def step_by_name(job: dict[str, Any], name: str) -> dict[str, Any]:
+    matches = [step for step in job["steps"] if step["name"] == name]
+    assert len(matches) == 1, f"Expected exactly one workflow step named {name!r}"
+    return cast(dict[str, Any], matches[0])
 
 
 def assert_release_asset_name_hardening(workflow: str) -> None:

--- a/tests/workflows/test_docs_workflow.py
+++ b/tests/workflows/test_docs_workflow.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any, cast
 
-import yaml
+from tests.workflow_helpers import load_workflow as _load_workflow
+from tests.workflow_helpers import step_by_name as _step_by_name
 
 from ._helpers import read_text_or_fail
 
@@ -36,19 +36,8 @@ EXPECTED_DEPLOY_GATE = (
 )
 
 
-def _load_workflow(repo_root: Path) -> tuple[str, dict[str, Any]]:
-    source = read_text_or_fail(repo_root / ".github" / "workflows" / "docs.yml")
-    parsed = yaml.load(source, Loader=yaml.BaseLoader)
-    assert isinstance(parsed, dict)
-    return source, cast(dict[str, Any], parsed)
-
-
-def _step_by_name(job: dict[str, Any], name: str) -> dict[str, Any]:
-    return cast(dict[str, Any], next(step for step in job["steps"] if step["name"] == name))
-
-
 def test_docs_workflow_events_and_paths_are_scoped(repo_root: Path) -> None:
-    _, workflow = _load_workflow(repo_root)
+    workflow = _load_workflow(repo_root / ".github" / "workflows" / "docs.yml")
     events = workflow["on"]
 
     assert set(events) == {"pull_request", "push", "workflow_dispatch"}
@@ -59,7 +48,7 @@ def test_docs_workflow_events_and_paths_are_scoped(repo_root: Path) -> None:
 
 
 def test_docs_workflow_permissions_and_concurrency_are_isolated(repo_root: Path) -> None:
-    _, workflow = _load_workflow(repo_root)
+    workflow = _load_workflow(repo_root / ".github" / "workflows" / "docs.yml")
     build = workflow["jobs"]["build"]
     deploy = workflow["jobs"]["deploy"]
 
@@ -74,7 +63,9 @@ def test_docs_workflow_permissions_and_concurrency_are_isolated(repo_root: Path)
 
 
 def test_docs_workflow_builds_strictly_from_locked_docs_group(repo_root: Path) -> None:
-    source, workflow = _load_workflow(repo_root)
+    workflow_path = repo_root / ".github" / "workflows" / "docs.yml"
+    source = read_text_or_fail(workflow_path)
+    workflow = _load_workflow(workflow_path)
     build = workflow["jobs"]["build"]
 
     assert _step_by_name(build, "Set up Python")["with"]["python-version"] == "3.13"
@@ -96,7 +87,7 @@ def test_docs_workflow_builds_strictly_from_locked_docs_group(repo_root: Path) -
 
 
 def test_docs_workflow_gates_pages_steps_and_deployment(repo_root: Path) -> None:
-    _, workflow = _load_workflow(repo_root)
+    workflow = _load_workflow(repo_root / ".github" / "workflows" / "docs.yml")
     build = workflow["jobs"]["build"]
     deploy = workflow["jobs"]["deploy"]
 
@@ -114,7 +105,9 @@ def test_docs_workflow_gates_pages_steps_and_deployment(repo_root: Path) -> None
 
 
 def test_docs_workflow_pins_actions_to_expected_full_shas(repo_root: Path) -> None:
-    source, workflow = _load_workflow(repo_root)
+    workflow_path = repo_root / ".github" / "workflows" / "docs.yml"
+    source = read_text_or_fail(workflow_path)
+    workflow = _load_workflow(workflow_path)
     action_uses = [
         step["uses"] for job in workflow["jobs"].values() for step in job["steps"] if "uses" in step
     ]

--- a/tests/workflows/test_github_workflows.py
+++ b/tests/workflows/test_github_workflows.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from tests.workflow_helpers import (
     assert_release_asset_name_hardening as _assert_release_asset_name_hardening,
 )
+from tests.workflow_helpers import load_workflow as _load_workflow
 from tests.workflow_helpers import read_text_or_fail as _read_text_or_fail
+from tests.workflow_helpers import step_by_name as _step_by_name
 
 
 def test_release_please_owns_python_version_sources(repo_root: Path) -> None:
@@ -291,28 +293,45 @@ def test_windows_portable_workflow_requires_signed_update_release_assets(
     repo_root: Path,
 ) -> None:
     workflow_path = repo_root / ".github" / "workflows" / "windows-portable.yml"
-    workflow = _read_text_or_fail(workflow_path)
+    source = _read_text_or_fail(workflow_path)
+    workflow = _load_workflow(workflow_path)
+    build = workflow["jobs"]["build"]
+    release_assets = workflow["jobs"]["release-assets"]
+    sign = _step_by_name(build, "Sign code-only update zip")
+    verify = _step_by_name(build, "Verify code-only update zip layout")
+    download = _step_by_name(release_assets, "Download signed update artifact")
+    prepare = _step_by_name(release_assets, "Prepare versioned signed update asset")
+    verify_assets = _step_by_name(release_assets, "Verify required release asset set")
+    upload = _step_by_name(release_assets, "Upload required release assets")
 
-    assert (
-        "WINDOWS_UPDATE_SIGNING_KEY_XML: ${{ secrets.WINDOWS_UPDATE_SIGNING_KEY_XML }}" in workflow
+    assert release_assets["if"] == "github.event_name == 'release'"
+    assert sign["env"]["WINDOWS_UPDATE_SIGNING_KEY_XML"] == (
+        "${{ secrets.WINDOWS_UPDATE_SIGNING_KEY_XML }}"
     )
-    assert "WINDOWS_UPDATE_SIGNING_KEY_XML is required for release and manual runs." in workflow
-    assert "tools/windows_portable/sign_update.ps1" in workflow
-    assert "update_signed" not in workflow
-    assert "Download signed update artifact" in workflow
-    assert "Prepare versioned signed update asset" in workflow
-    assert "Verify required release asset set" in workflow
-    assert "Upload required release assets" in workflow
-    assert "Missing required release asset: $asset" in workflow
-    assert "fail_on_unmatched_files: true" in workflow
-    assert "mapfile -t update_zips" in workflow
-    assert "Expected exactly one signed update zip artifact, found ${#update_zips[@]}." in workflow
-    assert "frame-compare-update-win-x64-${ASSET_TAG}.zip" in workflow
+    assert "WINDOWS_UPDATE_SIGNING_KEY_XML is required for release and manual runs." in sign["run"]
+    assert "tools/windows_portable/sign_update.ps1" in sign["run"]
+    assert verify["env"]["REQUIRE_SIGNED_UPDATE"] == (
+        "${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}"
+    )
+    assert "Signed update zip is missing update-manifest.sig." in verify["run"]
+    assert download["with"] == {
+        "name": "frame-compare-update-win-x64",
+        "path": "dist/release-assets",
+    }
+    assert "mapfile -t update_zips" in prepare["run"]
+    assert (
+        "Expected exactly one signed update zip artifact, found ${#update_zips[@]}."
+        in (prepare["run"])
+    )
+    assert "frame-compare-update-win-x64-${ASSET_TAG}.zip" in prepare["run"]
+    assert "Missing required release asset: $asset" in verify_assets["run"]
+    assert upload["with"]["fail_on_unmatched_files"] == "true"
     assert (
         "dist/release-assets/frame-compare-update-win-x64-${{ "
         "steps.release_names.outputs.asset_tag }}.zip"
-    ) in workflow
+    ) in upload["with"]["files"]
     assert (
         "dist/release-assets/frame-compare-update-win-x64-${{ "
         "steps.release_names.outputs.asset_tag }}.zip.sha256"
-    ) in workflow
+    ) in upload["with"]["files"]
+    assert "update_signed" not in source

--- a/tests/workflows/test_github_workflows.py
+++ b/tests/workflows/test_github_workflows.py
@@ -43,6 +43,19 @@ def test_release_please_workflow_requires_human_review(repo_root: Path) -> None:
     assert "--auto" not in workflow
 
 
+def test_ci_requires_clean_distribution_build_and_install(repo_root: Path) -> None:
+    workflow_path = repo_root / ".github" / "workflows" / "ci.yml"
+    workflow = _read_text_or_fail(workflow_path)
+
+    assert "uv build --out-dir dist" in workflow
+    assert ".dist-venv/bin/python scripts/verify_distribution.py dist" in workflow
+    assert "uv pip install --python .dist-venv/bin/python dist/*.whl" in workflow
+    assert ".dist-venv/bin/frame-compare version" in workflow
+    assert ".dist-venv/bin/frame-compare --help" in workflow
+    assert "needs: [lint, security, typecheck, test, import-lints, package]" in workflow
+    assert '[[ "${{ needs.package.result }}" != "success" ]]' in workflow
+
+
 def test_docker_integration_workflow_covers_supported_pull_request_bases(repo_root: Path) -> None:
     workflow_path = repo_root / ".github" / "workflows" / "docker-integration.yml"
     workflow = _read_text_or_fail(workflow_path)

--- a/tests/workflows/test_github_workflows.py
+++ b/tests/workflows/test_github_workflows.py
@@ -35,6 +35,14 @@ def test_release_please_owns_python_version_sources(repo_root: Path) -> None:
     assert release_manifest["."] == project["version"] == package_version
 
 
+def test_release_please_workflow_requires_human_review(repo_root: Path) -> None:
+    workflow_path = repo_root / ".github" / "workflows" / "release-please.yml"
+    workflow = _read_text_or_fail(workflow_path)
+
+    assert "gh pr merge" not in workflow
+    assert "--auto" not in workflow
+
+
 def test_docker_integration_workflow_covers_supported_pull_request_bases(repo_root: Path) -> None:
     workflow_path = repo_root / ".github" / "workflows" / "docker-integration.yml"
     workflow = _read_text_or_fail(workflow_path)

--- a/tests/workflows/test_github_workflows.py
+++ b/tests/workflows/test_github_workflows.py
@@ -281,32 +281,38 @@ def test_windows_portable_workflow_proves_code_only_update_without_pr_secrets(
     assert "tools/windows_portable/build_update.ps1" in workflow
     assert "frame-compare-update-win-x64-$version.zip" in workflow
     assert "UPDATE_ZIP=$updateZip" in workflow
-    assert "Pull requests prove update zip creation without requiring signing secrets." in workflow
+    assert "Pull requests prove unsigned update zip creation without signing secrets." in workflow
     assert "Upload code-only update artifact" in workflow
     assert "name: frame-compare-update-win-x64" in workflow
     assert "dist/frame-compare-update-win-x64-*.zip" in workflow
 
 
-def test_windows_portable_workflow_gates_signed_update_release_assets(
+def test_windows_portable_workflow_requires_signed_update_release_assets(
     repo_root: Path,
 ) -> None:
     workflow_path = repo_root / ".github" / "workflows" / "windows-portable.yml"
     workflow = _read_text_or_fail(workflow_path)
 
-    assert "update_signed: ${{ steps.sign_update.outputs.signed }}" in workflow
     assert (
         "WINDOWS_UPDATE_SIGNING_KEY_XML: ${{ secrets.WINDOWS_UPDATE_SIGNING_KEY_XML }}" in workflow
     )
-    assert "::notice::Skipping signed update zip; WINDOWS_UPDATE_SIGNING_KEY_XML secret" in workflow
+    assert "WINDOWS_UPDATE_SIGNING_KEY_XML is required for release and manual runs." in workflow
     assert "tools/windows_portable/sign_update.ps1" in workflow
-    assert "if: needs.build.outputs.update_signed == 'true'" in workflow
+    assert "update_signed" not in workflow
     assert "Download signed update artifact" in workflow
     assert "Prepare versioned signed update asset" in workflow
-    assert "Upload signed update release asset" in workflow
+    assert "Verify required release asset set" in workflow
+    assert "Upload required release assets" in workflow
+    assert "Missing required release asset: $asset" in workflow
+    assert "fail_on_unmatched_files: true" in workflow
     assert "mapfile -t update_zips" in workflow
     assert "Expected exactly one signed update zip artifact, found ${#update_zips[@]}." in workflow
     assert "frame-compare-update-win-x64-${ASSET_TAG}.zip" in workflow
     assert (
         "dist/release-assets/frame-compare-update-win-x64-${{ "
         "steps.release_names.outputs.asset_tag }}.zip"
+    ) in workflow
+    assert (
+        "dist/release-assets/frame-compare-update-win-x64-${{ "
+        "steps.release_names.outputs.asset_tag }}.zip.sha256"
     ) in workflow


### PR DESCRIPTION
New Features
- Initial Frame Compare release with complete video frame comparison pipeline, including HDR-to-SDR tonemapping, audio alignment, overlay rendering, HTML report generation with interactive viewer, and deterministic frame selection
- Interactive CLI with configuration wizard, diagnostic tools, and preset management

Documentation
- Comprehensive API reference and contributing guidelines
- Security policy and project architecture documentation

Chores
- Docker containerization with VapourSynth and FFmpeg integration
- GitHub Actions CI/CD workflows for linting, type checking, testing, and releases
- Pre-commit hooks and project configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked getting-started install decision guide (route comparison, first-run steps, runtime rules).
  * Added/updated release alpha changelog, contribution licensing, and engineering plan documentation.
  * Updated VSPreview/doctor documentation links.
* **Changed**
  * Project licensing updated to **GPL-3.0-only** (including README, pyproject, and LICENSE).
  * Release PRs now require human maintainer review and are never auto-merged by automation.
* **Quality Improvements**
  * CI now builds, content-validates, installs in a clean environment, and smoke-tests distribution packages before gates pass.
  * Windows portable release assets require signed update artifacts with checksum verification.
* **Bug Fixes**
  * Improved VSPreview-related guidance text and link accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->