### PR TITLE
build(deps): migrate CLI to Typer 0.27.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "typer>=0.25.1,<0.26",
+    "typer>=0.27.1",
     "rich>=14.2.0",
     "numpy>=2.5.1",
     "httpx>=0.28.1",

--- a/tests/cli/cli_helpers.py
+++ b/tests/cli/cli_helpers.py
@@ -1,16 +1,39 @@
 # pyright: reportUnusedFunction=false
 
+import contextlib
 import re
+from collections.abc import Iterator
 from pathlib import Path
 
-from click.testing import Result
-from typer.testing import CliRunner
+import pytest
+from typer.testing import CliRunner, Result
 
 from frame_compare.cli.entry import app
 
 runner = CliRunner()
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 RICH_BOX_DRAWING_RE = re.compile(r"[\u2500-\u257f]")
+
+
+@contextlib.contextmanager
+def isolated_cli_filesystem(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Path]:
+    """Run one CLI test block in a pytest-owned temporary working directory."""
+    index = 0
+    while True:
+        working_directory = tmp_path / f"cli-cwd-{index}"
+        try:
+            working_directory.mkdir()
+        except FileExistsError:
+            index += 1
+            continue
+        break
+
+    with monkeypatch.context() as scoped_monkeypatch:
+        scoped_monkeypatch.chdir(working_directory)
+        yield working_directory
 
 
 def _normalize_cli_output(text: str) -> str:
@@ -43,11 +66,13 @@ def _write_minimal_config(root: Path) -> Path:
 def _invoke_run_with_minimal_workspace(
     args: list[str],
     *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     color: bool = False,
     terminal_width: int | None = None,
     env: dict[str, str] | None = None,
 ) -> Result:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_minimal_config(root)
         return runner.invoke(

--- a/tests/cli/test_help_and_import.py
+++ b/tests/cli/test_help_and_import.py
@@ -1,6 +1,5 @@
 import pytest
 import typer.rich_utils as typer_rich_utils
-from click import Group
 from pytest import MonkeyPatch
 from typer.main import get_command
 
@@ -61,8 +60,10 @@ def test_run_help_shows_all_options():
         "-v",
     ]
     command = get_command(app)
-    assert isinstance(command, Group)
-    run_command = command.commands["run"]
+    commands = getattr(command, "commands", None)
+    assert isinstance(commands, dict)
+    assert "run" in commands
+    run_command = commands["run"]
     declared_options = {
         opt
         for param in run_command.params
@@ -119,7 +120,9 @@ def test_run_rejects_retired_frame_count_options(
 
     assert result.exit_code == 2
     assert result.stdout == ""
-    assert f"No such option '{retired_option}'" in _normalize_cli_output(result.stderr)
+    error_output = _normalize_cli_output(result.stderr)
+    assert "No such option" in error_output
+    assert retired_option in error_output
 
 
 @pytest.mark.parametrize(
@@ -196,6 +199,30 @@ def test_public_help_explains_commands_and_option_effects(
     assert result.exit_code == 0
     for fragment in expected_fragments:
         assert fragment in output
+
+
+def test_root_generates_shell_completion_source() -> None:
+    result = runner.invoke(
+        app,
+        ["--show-completion"],
+        color=False,
+        env={
+            "SHELL": "/bin/bash",
+            "NO_COLOR": "1",
+            "TERM": "dumb",
+        },
+    )
+
+    assert result.exit_code == 0
+    assert result.stderr == ""
+    assert "frame-compare" in result.stdout
+    supported_shell_markers = (
+        "complete -o default -F",
+        "compdef ",
+        "complete --no-files --command",
+        "Register-ArgumentCompleter -Native -CommandName",
+    )
+    assert any(marker in result.stdout for marker in supported_shell_markers)
 
 
 def test_stabilize_typer_help_width_backfills_import_order_gap(monkeypatch: MonkeyPatch) -> None:

--- a/tests/cli/test_preset_command.py
+++ b/tests/cli/test_preset_command.py
@@ -8,11 +8,13 @@ from frame_compare.cli.entry import app
 from frame_compare.cli.errors import ExitCode
 from frame_compare.config.errors import ConfigNotFoundError
 
-from .cli_helpers import MINIMAL_CONFIG, _write_minimal_config, runner
+from .cli_helpers import MINIMAL_CONFIG, _write_minimal_config, isolated_cli_filesystem, runner
 
 
-def test_preset_apply_missing_preset_exits_with_error_code() -> None:
-    with runner.isolated_filesystem():
+def test_preset_apply_missing_preset_exits_with_error_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path(".")
         config_path = _write_minimal_config(root)
         result = runner.invoke(
@@ -32,8 +34,10 @@ def test_preset_apply_missing_preset_exits_with_error_code() -> None:
         assert "FC-1004" in result.stderr
 
 
-def test_preset_apply_invalid_name_exits_with_error_code() -> None:
-    with runner.isolated_filesystem():
+def test_preset_apply_invalid_name_exits_with_error_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path(".")
         config_path = _write_minimal_config(root)
         result = runner.invoke(
@@ -53,8 +57,8 @@ def test_preset_apply_invalid_name_exits_with_error_code() -> None:
         assert "FC-1006" in result.stderr
 
 
-def test_preset_list_stub():
-    with runner.isolated_filesystem():
+def test_preset_list_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         presets_dir = root / "config" / "presets"
         presets_dir.mkdir(parents=True, exist_ok=True)
@@ -67,8 +71,8 @@ def test_preset_list_stub():
         assert result.stderr == ""
 
 
-def test_preset_apply_stub():
-    with runner.isolated_filesystem():
+def test_preset_apply_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "config" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -91,8 +95,8 @@ def test_preset_apply_stub():
         assert data["analysis"]["random_frame_count"] == 12
 
 
-def test_preset_save_stub():
-    with runner.isolated_filesystem():
+def test_preset_save_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "config" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -113,6 +117,7 @@ def test_preset_save_stub():
 def test_preset_config_writes_reject_external_config_before_load_or_write(
     operation: str,
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _unexpected(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("external config must be rejected before load or write")
@@ -122,7 +127,7 @@ def test_preset_config_writes_reject_external_config_before_load_or_write(
     monkeypatch.setattr("frame_compare.cli.entry.apply_preset", _unexpected)
     monkeypatch.setattr("frame_compare.cli.entry.save_preset", _unexpected)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         root.mkdir()
         external_config = (Path("outside") / "config.toml").resolve()
@@ -149,8 +154,9 @@ def test_preset_config_writes_reject_external_config_before_load_or_write(
 def test_preset_config_writes_allow_exact_windows_portable_state_config(
     operation: str,
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         root.mkdir()
         portable_config = Path("portable-state") / "config.toml"
@@ -191,8 +197,10 @@ def test_preset_config_writes_allow_exact_windows_portable_state_config(
 
 
 @pytest.mark.parametrize("operation", ["apply", "save"])
-def test_preset_config_rejects_removed_report_output_directory(operation: str) -> None:
-    with runner.isolated_filesystem():
+def test_preset_config_rejects_removed_report_output_directory(
+    operation: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "config" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -226,8 +234,10 @@ def test_preset_config_rejects_removed_report_output_directory(operation: str) -
 
 
 @pytest.mark.parametrize("operation", ["apply", "save"])
-def test_preset_config_writes_preserve_external_generated_root(operation: str) -> None:
-    with runner.isolated_filesystem():
+def test_preset_config_writes_preserve_external_generated_root(
+    operation: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "config" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -262,8 +272,10 @@ def test_preset_config_writes_preserve_external_generated_root(operation: str) -
         assert persisted["paths"]["generated_dir"] == "../../out"
 
 
-def test_preset_apply_preserves_external_generated_root_added_by_preset() -> None:
-    with runner.isolated_filesystem():
+def test_preset_apply_preserves_external_generated_root_added_by_preset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_minimal_config(root)
         presets_dir = root / "config" / "presets"
@@ -291,8 +303,10 @@ def test_preset_apply_preserves_external_generated_root_added_by_preset() -> Non
         assert persisted["paths"]["generated_dir"] == "../../out"
 
 
-def test_preset_list_prints_names_sorted_case_insensitive() -> None:
-    with runner.isolated_filesystem():
+def test_preset_list_prints_names_sorted_case_insensitive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         presets_dir = root / "config" / "presets"
         presets_dir.mkdir(parents=True, exist_ok=True)
@@ -306,8 +320,10 @@ def test_preset_list_prints_names_sorted_case_insensitive() -> None:
         assert result.stderr == ""
 
 
-def test_preset_list_uses_root_presets_even_when_config_path_is_nondefault() -> None:
-    with runner.isolated_filesystem():
+def test_preset_list_uses_root_presets_even_when_config_path_is_nondefault(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "configs" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -378,13 +394,14 @@ def test_preset_list_error_uses_default_terminal_color_policy(
 
 def test_preset_save_respects_root_and_config_writes_secret_safe_preset(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setenv(
         "FRAME_COMPARE_SLOWPICS__WEBHOOK_URL",
         "https://discord.com/api/webhooks/env-id/env-secret",
     )
     monkeypatch.setenv("FRAME_COMPARE_TMDB__API_KEY", "sentinel-tmdb-api-key")
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "configs" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -412,13 +429,14 @@ def test_preset_save_respects_root_and_config_writes_secret_safe_preset(
 
 def test_preset_save_write_error_uses_cli_error_contract(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _write_text_atomic(_path: Path, _content: str, *, encoding: str = "utf-8") -> None:
         raise PermissionError("permission denied")
 
     monkeypatch.setattr("frame_compare.config.presets.write_text_atomic", _write_text_atomic)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "config" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -438,13 +456,14 @@ def test_preset_save_write_error_uses_cli_error_contract(
 
 def test_preset_apply_updates_config_and_strips_webhook_secret(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setenv(
         "FRAME_COMPARE_SLOWPICS__WEBHOOK_URL",
         "https://discord.com/api/webhooks/env-id/env-secret",
     )
     monkeypatch.setenv("FRAME_COMPARE_TMDB__API_KEY", "sentinel-tmdb-api-key")
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "configs" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/cli/test_run_dry_run.py
+++ b/tests/cli/test_run_dry_run.py
@@ -6,13 +6,13 @@ import sys
 from pathlib import Path
 
 import pytest
-from click.testing import Result
 from pytest import MonkeyPatch
+from typer.testing import Result
 
 from frame_compare.cli.entry import app
 from frame_compare.cli.errors import ExitCode
 
-from .cli_helpers import MINIMAL_CONFIG, runner
+from .cli_helpers import MINIMAL_CONFIG, isolated_cli_filesystem, runner
 
 
 def _write_workspace(root: Path, *, config_suffix: str = "") -> Path:
@@ -44,6 +44,7 @@ def _unexpected(*_args: object, **_kwargs: object) -> None:
 
 def test_run_dry_run_json_has_exact_allowlisted_shape_and_no_secrets(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(
         "frame_compare.cli.run_command.build_run_request_from_cli",
@@ -51,7 +52,7 @@ def test_run_dry_run_json_has_exact_allowlisted_shape_and_no_secrets(
     )
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _unexpected)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_workspace(
             root,
@@ -163,8 +164,10 @@ api_key = "sentinel-api-key"
     assert "secret.invalid" not in result.stdout
 
 
-def test_run_dry_run_human_and_quiet_follow_current_quiet_semantics() -> None:
-    with runner.isolated_filesystem():
+def test_run_dry_run_human_and_quiet_follow_current_quiet_semantics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_workspace(root)
         input_dir = root / "comparison_videos"
@@ -185,8 +188,10 @@ def test_run_dry_run_human_and_quiet_follow_current_quiet_semantics() -> None:
     assert quiet.stderr == ""
 
 
-def test_run_dry_run_always_reserves_a_run_folder_when_execution_proceeds() -> None:
-    with runner.isolated_filesystem():
+def test_run_dry_run_always_reserves_a_run_folder_when_execution_proceeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_workspace(root)
         input_dir = root / "comparison_videos"
@@ -203,8 +208,10 @@ def test_run_dry_run_always_reserves_a_run_folder_when_execution_proceeds() -> N
     }
 
 
-def test_run_dry_run_accepts_external_input_override_and_reports_only_that_absolute_path() -> None:
-    with runner.isolated_filesystem():
+def test_run_dry_run_accepts_external_input_override_and_reports_only_that_absolute_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_workspace(root)
         external_input = Path("external-media").resolve()
@@ -231,8 +238,10 @@ def test_run_dry_run_accepts_external_input_override_and_reports_only_that_absol
 def test_run_dry_run_rejects_missing_or_empty_input(
     setup_input: bool,
     expected_code: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_workspace(root)
         if setup_input:
@@ -247,8 +256,10 @@ def test_run_dry_run_rejects_missing_or_empty_input(
     assert json.loads(result.stdout)["error"]["code"] == expected_code
 
 
-def test_run_dry_run_validates_reference_selector_without_runtime() -> None:
-    with runner.isolated_filesystem():
+def test_run_dry_run_validates_reference_selector_without_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_workspace(
             root,
@@ -271,9 +282,10 @@ def test_run_dry_run_validates_reference_selector_without_runtime() -> None:
 def test_run_dry_run_rejects_other_early_exit_modes(
     early_mode: str,
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _unexpected)
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_workspace(root)
 
@@ -288,9 +300,10 @@ def test_run_dry_run_rejects_other_early_exit_modes(
 
 def test_run_dry_run_validates_existing_cache_and_interactive_contracts(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _unexpected)
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_workspace(root)
 
@@ -318,8 +331,10 @@ def test_run_dry_run_validates_existing_cache_and_interactive_contracts(
     )
 
 
-def test_run_dry_run_preserves_fastest_analysis_cache_only_conflict() -> None:
-    with runner.isolated_filesystem():
+def test_run_dry_run_preserves_fastest_analysis_cache_only_conflict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_workspace(
             root,
@@ -345,13 +360,14 @@ dark_frame_count = 1
 
 def test_run_dry_run_invalid_choice_uses_standard_json_error_and_skips_request(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(
         "frame_compare.cli.run_command.build_run_request_from_cli",
         _unexpected,
     )
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _unexpected)
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_workspace(root)
 
@@ -379,8 +395,10 @@ def test_run_dry_run_rejects_invalid_config_and_frame_selectors(
     config_suffix: str,
     extra_args: tuple[str, ...],
     expected_loc: list[str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_workspace(root, config_suffix=config_suffix)
 

--- a/tests/cli/test_run_json_errors.py
+++ b/tests/cli/test_run_json_errors.py
@@ -13,19 +13,23 @@ from .cli_helpers import (
     MINIMAL_CONFIG,
     _invoke_run_with_minimal_workspace,
     _write_minimal_config,
+    isolated_cli_filesystem,
     runner,
 )
 
 
 def test_run_write_config_json_write_error_outputs_error_schema(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _write_text_atomic(_path: Path, _content: str, *, encoding: str = "utf-8") -> None:
         raise PermissionError("permission denied")
 
     monkeypatch.setattr("frame_compare.cli.entry.write_text_atomic", _write_text_atomic)
 
-    result = _invoke_run_with_minimal_workspace(["--write-config", "--json"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--write-config", "--json"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == int(ExitCode.CONFIG_ERROR)
     assert result.stderr == ""
@@ -40,6 +44,7 @@ def test_run_write_config_json_write_error_outputs_error_schema(
 
 def test_run_json_rejects_external_config_before_load_write_or_runner(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _unexpected(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("external config must be rejected before side effects")
@@ -48,7 +53,7 @@ def test_run_json_rejects_external_config_before_load_write_or_runner(
     monkeypatch.setattr("frame_compare.cli.entry.write_config_to", _unexpected)
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _unexpected)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         root.mkdir()
         external_config = Path("outside") / "config.toml"
@@ -79,6 +84,7 @@ def test_run_json_rejects_external_config_before_load_write_or_runner(
 
 def test_run_json_outputs_pinned_success_schema_and_stdout_is_pure_json(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         return RunResult(
@@ -95,7 +101,9 @@ def test_run_json_outputs_pinned_success_schema_and_stdout_is_pure_json(
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--json"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--json"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload == {
@@ -113,6 +121,7 @@ def test_run_json_outputs_pinned_success_schema_and_stdout_is_pure_json(
 
 def test_run_json_success_omits_warnings_from_stdout(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         return RunResult(
@@ -122,7 +131,9 @@ def test_run_json_success_omits_warnings_from_stdout(
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--json"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--json"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == 0
     assert result.stderr == ""
@@ -133,13 +144,14 @@ def test_run_json_success_omits_warnings_from_stdout(
 
 def test_run_json_rejects_interactive_alignment_from_config_before_runner(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for invalid CLI/config combinations")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_minimal_config(root)
         config_path.write_text(
@@ -176,13 +188,16 @@ def test_run_json_rejects_interactive_alignment_from_config_before_runner(
 
 def test_run_json_rejects_force_interactive_alignment_before_runner(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for invalid CLI/config combinations")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--json", "--force-interactive-alignment"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--json", "--force-interactive-alignment"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == int(ExitCode.CONFIG_ERROR)
     assert result.stderr == ""
@@ -198,13 +213,14 @@ def test_run_json_rejects_force_interactive_alignment_before_runner(
 
 def test_run_json_aggregates_previous_offset_prompt_conflicts_before_runner(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for invalid CLI/config combinations")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_minimal_config(root)
         config_path.write_text(
@@ -253,13 +269,14 @@ cache_results = false
 
 def test_run_json_rejects_report_confirmed_slowpics_before_runner(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for invalid CLI/config combinations")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_minimal_config(root)
         config_path.write_text(
@@ -298,13 +315,14 @@ def test_run_json_rejects_report_confirmed_slowpics_before_runner(
 
 def test_run_json_report_confirmed_slowpics_message_uses_actual_failure(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for invalid CLI/config combinations")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_minimal_config(root)
         config_path.write_text(
@@ -351,13 +369,16 @@ confirm_upload_after_report = true
 
 def test_run_json_outputs_error_schema_and_exit_code(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise ConfigNotFoundError(Path("missing.toml"))
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--json"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--json"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
     assert result.exit_code == int(get_exit_code(ConfigNotFoundError(Path("missing.toml"))))
     assert result.stderr == ""
     payload = json.loads(result.stdout)
@@ -367,6 +388,7 @@ def test_run_json_outputs_error_schema_and_exit_code(
 
 def test_run_exit_code_maps_by_error_category_prefix_in_json_mode(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     error = FrameCompareError(
         ErrorContext(code="FC-3001", name="GENERIC_INPUT", message="bad input")
@@ -377,7 +399,9 @@ def test_run_exit_code_maps_by_error_category_prefix_in_json_mode(
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--json"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--json"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
     assert result.exit_code == int(ExitCode.INPUT_ERROR)
     payload = json.loads(result.stdout)
     assert payload == format_error_json(error)
@@ -385,13 +409,16 @@ def test_run_exit_code_maps_by_error_category_prefix_in_json_mode(
 
 def test_run_json_invalid_tm_preset_outputs_config_error_schema(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for invalid CLI choices")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--json", "--tm-preset", "invalid"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--json", "--tm-preset", "invalid"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == int(ExitCode.CONFIG_ERROR)
     assert result.stderr == ""
@@ -404,13 +431,16 @@ def test_run_json_invalid_tm_preset_outputs_config_error_schema(
 
 def test_run_json_invalid_overlay_outputs_config_error_schema(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for invalid CLI choices")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--json", "--overlay", "invalid"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--json", "--overlay", "invalid"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == int(ExitCode.CONFIG_ERROR)
     assert result.stderr == ""
@@ -426,13 +456,16 @@ def test_run_json_invalid_overlay_outputs_config_error_schema(
 
 def test_run_json_invalid_frames_outputs_config_error_schema(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for invalid frame selectors")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--json", "--frames", "abc"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--json", "--frames", "abc"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == int(ExitCode.CONFIG_ERROR)
     assert result.stderr == ""
@@ -446,6 +479,7 @@ def test_run_json_invalid_frames_outputs_config_error_schema(
 
 def test_run_json_skip_analysis_rejects_metric_frame_count_before_runner(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for --skip-analysis conflict")
@@ -453,7 +487,9 @@ def test_run_json_skip_analysis_rejects_metric_frame_count_before_runner(
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
     result = _invoke_run_with_minimal_workspace(
-        ["--json", "--skip-analysis", "--dark-frame-count", "1"]
+        ["--json", "--skip-analysis", "--dark-frame-count", "1"],
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
     )
 
     assert result.exit_code == int(ExitCode.CONFIG_ERROR)
@@ -468,13 +504,14 @@ def test_run_json_skip_analysis_rejects_metric_frame_count_before_runner(
 
 def test_run_json_stale_analysis_config_keys_fail_before_runner(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for stale analysis config")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_minimal_config(root)
         config_path.write_text(
@@ -504,25 +541,30 @@ def test_run_json_stale_analysis_config_keys_fail_before_runner(
     }
 
 
-def test_run_exit_code_is_130_on_keyboard_interrupt(monkeypatch: MonkeyPatch) -> None:
+def test_run_exit_code_is_130_on_keyboard_interrupt(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise KeyboardInterrupt()
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace([])
+    result = _invoke_run_with_minimal_workspace([], tmp_path=tmp_path, monkeypatch=monkeypatch)
     assert result.exit_code == int(ExitCode.INTERRUPTED)
 
 
 def test_run_no_color_error_output_has_no_rich_markup(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise ConfigNotFoundError(Path("missing.toml"))
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--no-color"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--no-color"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
     assert result.exit_code == int(get_exit_code(ConfigNotFoundError(Path("missing.toml"))))
     assert "\x1b[" not in result.stderr
     assert "[red]" not in result.stderr
@@ -531,6 +573,7 @@ def test_run_no_color_error_output_has_no_rich_markup(
 
 def test_run_env_no_color_error_output_has_no_rich_markup(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise ConfigNotFoundError(Path("missing.toml"))
@@ -540,6 +583,8 @@ def test_run_env_no_color_error_output_has_no_rich_markup(
     result = _invoke_run_with_minimal_workspace(
         [],
         env={"NO_COLOR": "1", "TERM": "dumb"},
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
     )
     assert result.exit_code == int(get_exit_code(ConfigNotFoundError(Path("missing.toml"))))
     assert "\x1b[" not in result.stderr
@@ -549,6 +594,7 @@ def test_run_env_no_color_error_output_has_no_rich_markup(
 
 def test_run_no_color_error_output_preserves_literal_brackets(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     error = FrameCompareError(
         ErrorContext(
@@ -564,7 +610,9 @@ def test_run_no_color_error_output_preserves_literal_brackets(
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--quiet", "--no-color"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--quiet", "--no-color"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == int(ExitCode.INPUT_ERROR)
     assert result.stdout == ""

--- a/tests/cli/test_run_output.py
+++ b/tests/cli/test_run_output.py
@@ -15,11 +15,14 @@ from .cli_helpers import (
     _invoke_run_with_minimal_workspace,
     _normalize_cli_output,
     _write_minimal_config,
+    isolated_cli_filesystem,
     runner,
 )
 
 
-def test_run_respects_no_color_env_var_presence_even_if_empty(monkeypatch: MonkeyPatch) -> None:
+def test_run_respects_no_color_env_var_presence_even_if_empty(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
     captured: dict[str, object] = {}
 
     class FakeConsole:
@@ -43,6 +46,8 @@ def test_run_respects_no_color_env_var_presence_even_if_empty(monkeypatch: Monke
         color=False,
         terminal_width=200,
         env={"NO_COLOR": "", "TERM": "dumb"},
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
     )
 
     assert result.exit_code == 0
@@ -51,6 +56,7 @@ def test_run_respects_no_color_env_var_presence_even_if_empty(monkeypatch: Monke
 
 def test_run_human_output_routes_summaries_and_runtime_diagnostics(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         assert dependencies is None
@@ -64,7 +70,7 @@ def test_run_human_output_routes_summaries_and_runtime_diagnostics(
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace([])
+    result = _invoke_run_with_minimal_workspace([], tmp_path=tmp_path, monkeypatch=monkeypatch)
 
     assert result.exit_code == 0
     stdout = _normalize_cli_output(result.stdout)
@@ -83,6 +89,7 @@ def test_run_human_output_routes_summaries_and_runtime_diagnostics(
 
 def test_run_quiet_suppresses_at_a_glance_but_keeps_minimal_summary(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(
         "frame_compare.cli.entry.runner.run",
@@ -91,7 +98,9 @@ def test_run_quiet_suppresses_at_a_glance_but_keeps_minimal_summary(
         ),
     )
 
-    result = _invoke_run_with_minimal_workspace(["--quiet"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--quiet"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == 0
     output = _normalize_cli_output(result.stdout)
@@ -101,6 +110,7 @@ def test_run_quiet_suppresses_at_a_glance_but_keeps_minimal_summary(
 
 def test_run_json_is_machine_only_and_omits_post_upload_actions(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     warning = "slow.pics webhook: delivery failed"
 
@@ -123,7 +133,9 @@ def test_run_json_is_machine_only_and_omits_post_upload_actions(
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--json"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--json"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
@@ -137,7 +149,7 @@ def test_run_json_is_machine_only_and_omits_post_upload_actions(
     assert result.stderr == ""
 
 
-def test_run_env_no_color_propagates_to_request(monkeypatch: MonkeyPatch) -> None:
+def test_run_env_no_color_propagates_to_request(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     captured: dict[str, RunRequest] = {}
 
     def _run(request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
@@ -146,7 +158,9 @@ def test_run_env_no_color_propagates_to_request(monkeypatch: MonkeyPatch) -> Non
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace([], env={"NO_COLOR": "1", "TERM": "dumb"})
+    result = _invoke_run_with_minimal_workspace(
+        [], env={"NO_COLOR": "1", "TERM": "dumb"}, tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == 0
     assert captured["request"].no_color is True
@@ -169,6 +183,7 @@ def test_run_logging_config_and_cli_precedence(
     args: list[str],
     expected_level: str,
     expected_format: str,
+    tmp_path: Path,
 ) -> None:
     captured: dict[str, str] = {}
 
@@ -182,7 +197,7 @@ def test_run_logging_config_and_cli_precedence(
         lambda _request, dependencies=None: RunResult(success=True),
     )
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_minimal_config(root)
         with config_path.open("a", encoding="utf-8") as config_file:

--- a/tests/cli/test_run_report_open.py
+++ b/tests/cli/test_run_report_open.py
@@ -14,12 +14,14 @@ from .cli_helpers import (
     MINIMAL_CONFIG,
     _invoke_run_with_minimal_workspace,
     _write_minimal_config,
+    isolated_cli_filesystem,
     runner,
 )
 
 
 def test_run_opens_report_for_interactive_tty_when_auto_open_enabled(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     opened: list[Path] = []
 
@@ -36,7 +38,7 @@ def test_run_opens_report_for_interactive_tty_when_auto_open_enabled(
         lambda report_path: opened.append(report_path) is None,
     )
 
-    result = _invoke_run_with_minimal_workspace([])
+    result = _invoke_run_with_minimal_workspace([], tmp_path=tmp_path, monkeypatch=monkeypatch)
 
     assert result.exit_code == 0
     assert opened == [Path("report.html")]
@@ -44,10 +46,11 @@ def test_run_opens_report_for_interactive_tty_when_auto_open_enabled(
 
 def test_run_reloads_config_after_runner_and_respects_auto_open_change(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     opened: list[Path] = []
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_minimal_config(root)
 
@@ -82,6 +85,7 @@ def test_run_reloads_config_after_runner_and_respects_auto_open_change(
 
 def test_run_confirmed_slowpics_opens_report_before_later_slowpics_browser(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     events: list[str] = []
     opened_reports: list[Path] = []
@@ -125,7 +129,7 @@ def test_run_confirmed_slowpics_opens_report_before_later_slowpics_browser(
         lambda report_path: opened_reports.append(report_path) is None,
     )
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = _write_minimal_config(root)
         config_path.write_text(

--- a/tests/cli/test_run_request_config.py
+++ b/tests/cli/test_run_request_config.py
@@ -14,23 +14,25 @@ from frame_compare.orchestration import RunDependencies, RunRequest, RunResult
 from .cli_helpers import (
     MINIMAL_CONFIG,
     _invoke_run_with_minimal_workspace,
+    isolated_cli_filesystem,
     runner,
 )
 
 
 def test_run_exits_processing_error_when_runner_returns_unsuccessful(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         return RunResult(success=False)
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace([])
+    result = _invoke_run_with_minimal_workspace([], tmp_path=tmp_path, monkeypatch=monkeypatch)
     assert result.exit_code == 5
 
 
-def test_run_builds_run_request_from_cli_args(monkeypatch: MonkeyPatch) -> None:
+def test_run_builds_run_request_from_cli_args(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     captured: dict[str, RunRequest] = {}
 
     def _run(request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
@@ -46,7 +48,9 @@ def test_run_builds_run_request_from_cli_args(monkeypatch: MonkeyPatch) -> None:
             "--overlay",
             "diagnostic",
             "--force-interactive-alignment",
-        ]
+        ],
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
     )
     assert result.exit_code == 0
 
@@ -58,6 +62,7 @@ def test_run_builds_run_request_from_cli_args(monkeypatch: MonkeyPatch) -> None:
 
 def test_run_builds_run_request_with_typed_choice_overrides(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     captured: dict[str, RunRequest] = {}
 
@@ -75,7 +80,9 @@ def test_run_builds_run_request_with_typed_choice_overrides(
             "spline",
             "--overlay",
             "diagnostic",
-        ]
+        ],
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
     )
 
     assert result.exit_code == 0
@@ -163,7 +170,7 @@ def test_cli_and_runtime_preserve_absent_and_explicit_empty_overrides() -> None:
     assert build_run_request_from_cli(options).cli_config_overrides() == expected
 
 
-def test_run_builds_run_request_with_input_dir(monkeypatch: MonkeyPatch) -> None:
+def test_run_builds_run_request_with_input_dir(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     captured: dict[str, RunRequest] = {}
 
     def _run(request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
@@ -172,13 +179,16 @@ def test_run_builds_run_request_with_input_dir(monkeypatch: MonkeyPatch) -> None
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--input", "custom_inputs"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--input", "custom_inputs"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
     assert result.exit_code == 0
     assert captured["request"].input_dir == Path("custom_inputs")
 
 
 def test_run_write_config_respects_root_and_config_and_does_not_invoke_runner(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for --write-config")
@@ -190,7 +200,7 @@ def test_run_write_config_respects_root_and_config_and_does_not_invoke_runner(
     )
     monkeypatch.setenv("FRAME_COMPARE_TMDB__API_KEY", "sentinel-tmdb-api-key")
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "configs" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -263,13 +273,14 @@ api_key = "sentinel-tmdb-api-key"
 
 def test_run_write_config_json_preserves_previous_offsets_and_writes_config(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for --write-config")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "config" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -305,6 +316,7 @@ previous_offsets = "prompt"
 
 def test_run_write_config_json_rejects_cache_conflict_before_disk_write(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for invalid --write-config")
@@ -315,7 +327,7 @@ def test_run_write_config_json_rejects_cache_conflict_before_disk_write(
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
     monkeypatch.setattr("frame_compare.cli.entry.write_text_atomic", _write_text_atomic)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "config" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -353,13 +365,16 @@ previous_offsets = "always"
 
 def test_run_invalid_frames_uses_owned_human_error_contract(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for invalid frame selectors")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--frames", "-1"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--frames", "-1"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == int(ExitCode.CONFIG_ERROR)
     assert result.stdout == ""
@@ -370,13 +385,16 @@ def test_run_invalid_frames_uses_owned_human_error_contract(
 
 def test_run_negative_metric_count_uses_owned_human_error_contract(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for invalid metric count")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--motion-frame-count", "-1"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--motion-frame-count", "-1"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == int(ExitCode.CONFIG_ERROR)
     assert result.stdout == ""
@@ -387,13 +405,16 @@ def test_run_negative_metric_count_uses_owned_human_error_contract(
 
 def test_run_skip_analysis_metric_count_uses_owned_human_error_contract(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for --skip-analysis conflict")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    result = _invoke_run_with_minimal_workspace(["--skip-analysis", "--dark-frame-count", "1"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--skip-analysis", "--dark-frame-count", "1"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == int(ExitCode.CONFIG_ERROR)
     assert result.stdout == ""
@@ -404,13 +425,16 @@ def test_run_skip_analysis_metric_count_uses_owned_human_error_contract(
 
 def test_run_write_config_write_error_uses_cli_error_contract(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _write_text_atomic(_path: Path, _content: str, *, encoding: str = "utf-8") -> None:
         raise PermissionError("permission denied")
 
     monkeypatch.setattr("frame_compare.cli.entry.write_text_atomic", _write_text_atomic)
 
-    result = _invoke_run_with_minimal_workspace(["--write-config"])
+    result = _invoke_run_with_minimal_workspace(
+        ["--write-config"], tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
 
     assert result.exit_code == int(ExitCode.CONFIG_ERROR)
     assert result.stdout == ""
@@ -421,13 +445,14 @@ def test_run_write_config_write_error_uses_cli_error_contract(
 
 def test_run_diagnose_paths_outputs_pinned_json_schema_and_does_not_invoke_runner(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     def _run(_request: RunRequest, dependencies: RunDependencies | None = None) -> RunResult:
         raise AssertionError("runner.run should not be invoked for --diagnose-paths")
 
     monkeypatch.setattr("frame_compare.cli.entry.runner.run", _run)
 
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root = Path("workspace")
         config_path = root / "config" / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/cli/test_run_slowpics_options.py
+++ b/tests/cli/test_run_slowpics_options.py
@@ -1,4 +1,3 @@
-from click import Group
 from typer.main import get_command
 
 from frame_compare.cli.entry import app
@@ -30,8 +29,10 @@ UNSUPPORTED_SLOWPICS_RUN_FLAGS = (
 
 def _declared_run_options() -> set[str]:
     command = get_command(app)
-    assert isinstance(command, Group)
-    run_command = command.commands["run"]
+    commands = getattr(command, "commands", None)
+    assert isinstance(commands, dict)
+    assert "run" in commands
+    run_command = commands["run"]
     return {
         opt
         for param in run_command.params

--- a/tests/cli/test_wizard_command.py
+++ b/tests/cli/test_wizard_command.py
@@ -18,7 +18,7 @@ from frame_compare.config.loader import TomlPayload, load_config
 from frame_compare.orchestration.errors import InputDiscoveryError
 from frame_compare.orchestration.preflight import resolve_paths
 
-from .cli_helpers import runner
+from .cli_helpers import isolated_cli_filesystem, runner
 
 
 @pytest.fixture(autouse=True)
@@ -44,8 +44,9 @@ def _invoke(root: Path, input_text: str, *extra: str, env: dict[str, str] | None
 
 def test_first_use_writes_random_goal_minimal_payload_and_honest_privacy_copy(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         monkeypatch.setenv("FRAME_COMPARE_SLOWPICS__AUTO_UPLOAD", "true")
 
@@ -76,8 +77,10 @@ def test_first_use_writes_random_goal_minimal_payload_and_honest_privacy_copy(
         assert load_config(config_path=config_path).slowpics.auto_upload is True
 
 
-def test_first_use_one_file_retries_menus_without_reporting_automatic_as_a_change() -> None:
-    with runner.isolated_filesystem():
+def test_first_use_one_file_retries_menus_without_reporting_automatic_as_a_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         (root / "comparison_videos" / "Only.mkv").touch()
 
@@ -94,8 +97,10 @@ def test_first_use_one_file_retries_menus_without_reporting_automatic_as_a_chang
 @pytest.mark.parametrize("generated_value", ["persistent-generated", "../review-output"])
 def test_first_use_persists_authored_relative_generated_directory(
     generated_value: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
 
         result = _invoke(root, f"\n{generated_value}\n\ny\n")
@@ -106,8 +111,10 @@ def test_first_use_persists_authored_relative_generated_directory(
         assert "Generated data location:" in result.stdout
 
 
-def test_wizard_persists_authored_absolute_generated_directory_without_creating_it() -> None:
-    with runner.isolated_filesystem():
+def test_wizard_persists_authored_absolute_generated_directory_without_creating_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         external = (Path("outside") / "persistent-generated").resolve()
 
@@ -120,8 +127,10 @@ def test_wizard_persists_authored_absolute_generated_directory_without_creating_
         assert resolve_paths(load_config(config_path=config_path), root).generated_root == external
 
 
-def test_existing_config_edit_persists_authored_generated_directory_and_reviews_change() -> None:
-    with runner.isolated_filesystem():
+def test_existing_config_edit_persists_authored_generated_directory_and_reviews_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         config_path.write_text(
@@ -141,8 +150,9 @@ def test_existing_config_edit_persists_authored_generated_directory_and_reviews_
 
 def test_missing_generated_directory_is_not_probed_or_created(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         external = (Path("missing") / "generated").resolve()
         original_exists = Path.exists
@@ -166,8 +176,9 @@ def test_missing_generated_directory_is_not_probed_or_created(
 
 def test_wizard_accepts_environment_expanded_generated_value_and_preserves_authored_text(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         external = (Path("outside") / "env-generated").resolve()
         monkeypatch.setenv("GENERATED_SENTINEL", str(external))
@@ -180,8 +191,10 @@ def test_wizard_accepts_environment_expanded_generated_value_and_preserves_autho
         assert payload["paths"]["generated_dir"] == "$GENERATED_SENTINEL"
 
 
-def test_eof_at_generated_location_prompt_preserves_existing_bytes() -> None:
-    with runner.isolated_filesystem():
+def test_eof_at_generated_location_prompt_preserves_existing_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         original = b'[paths]\ninput_dir = "comparison_videos"\ngenerated_dir = "generated"\n'
@@ -194,8 +207,10 @@ def test_eof_at_generated_location_prompt_preserves_existing_bytes() -> None:
         assert config_path.read_bytes() == original
 
 
-def test_first_use_multiple_files_uses_canonical_order_and_coverage_patch() -> None:
-    with runner.isolated_filesystem():
+def test_first_use_multiple_files_uses_canonical_order_and_coverage_patch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         input_dir = root / "comparison_videos"
         for name in ("b.MKV", "A.mkv", "c.MKV"):
@@ -222,8 +237,9 @@ def test_first_use_multiple_files_uses_canonical_order_and_coverage_patch() -> N
 
 def test_existing_config_preserves_raw_values_but_strips_generated_secrets(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         config_path.write_text(
@@ -282,8 +298,9 @@ name = "first"
 
 def test_existing_config_ignores_environment_only_values_during_review(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         config_path.write_text(
@@ -317,8 +334,10 @@ def test_existing_config_ignores_environment_only_values_during_review(
         (",".join(str(value) for value in range(101)), "between 1 and 100"),
     ],
 )
-def test_specific_frames_retry_then_sort_without_probing(invalid: str, message: str) -> None:
-    with runner.isolated_filesystem():
+def test_specific_frames_retry_then_sort_without_probing(
+    invalid: str, message: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
 
         result = _invoke(root, f"\n\n3\n{invalid}\n+24, 0,120\ny\n")
@@ -334,8 +353,10 @@ def test_specific_frames_retry_then_sort_without_probing(invalid: str, message: 
         assert payload["analysis"]["motion_frame_count"] == 0
 
 
-def test_specific_frames_accepts_100_values() -> None:
-    with runner.isolated_filesystem():
+def test_specific_frames_accepts_100_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         frames = ",".join(str(value) for value in reversed(range(100)))
 
@@ -348,8 +369,9 @@ def test_specific_frames_accepts_100_values() -> None:
 
 def test_existing_keep_is_true_noop_without_confirmation_or_write(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         original = (
@@ -370,8 +392,8 @@ def test_existing_keep_is_true_noop_without_confirmation_or_write(
         assert config_path.read_bytes() == original
 
 
-def test_final_no_preserves_existing_bytes() -> None:
-    with runner.isolated_filesystem():
+def test_final_no_preserves_existing_bytes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         original = b'[paths]\ninput_dir = "comparison_videos"\n'
@@ -384,8 +406,10 @@ def test_final_no_preserves_existing_bytes() -> None:
         assert config_path.read_bytes() == original
 
 
-def test_atomic_config_write_failure_preserves_existing_bytes(monkeypatch: MonkeyPatch) -> None:
-    with runner.isolated_filesystem():
+def test_atomic_config_write_failure_preserves_existing_bytes(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         original = b'[paths]\ninput_dir = "comparison_videos"\ngenerated_dir = "generated"\n'
@@ -405,8 +429,10 @@ def test_atomic_config_write_failure_preserves_existing_bytes(monkeypatch: Monke
 
 
 @pytest.mark.parametrize("input_text", ["", "\n", "\n\n", "\n\n3\n", "\n\n3\n0,1\n"])
-def test_eof_at_each_prompt_boundary_exits_130_without_write(input_text: str) -> None:
-    with runner.isolated_filesystem():
+def test_eof_at_each_prompt_boundary_exits_130_without_write(
+    input_text: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
 
         result = _invoke(root, input_text)
@@ -416,12 +442,14 @@ def test_eof_at_each_prompt_boundary_exits_130_without_write(input_text: str) ->
         assert not config_path.exists()
 
 
-def test_typer_abort_uses_exact_cancellation_contract(monkeypatch: MonkeyPatch) -> None:
+def test_typer_abort_uses_exact_cancellation_contract(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.setattr(
         "frame_compare.cli.entry._prompt_input_dir",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(typer.Abort()),
     )
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
 
         result = _invoke(root, "")
@@ -433,12 +461,13 @@ def test_typer_abort_uses_exact_cancellation_contract(monkeypatch: MonkeyPatch) 
 
 def test_typer_abort_at_generated_location_uses_exact_cancellation_contract(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(
         "frame_compare.cli.entry._prompt_generated_dir",
         lambda *_args: (_ for _ in ()).throw(typer.Abort()),
     )
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
 
         result = _invoke(root, "\n")
@@ -448,12 +477,14 @@ def test_typer_abort_at_generated_location_uses_exact_cancellation_contract(
         assert not config_path.exists()
 
 
-def test_keyboard_interrupt_uses_exact_cancellation_contract(monkeypatch: MonkeyPatch) -> None:
+def test_keyboard_interrupt_uses_exact_cancellation_contract(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
     def _interrupt(*_args: object, **_kwargs: object) -> str:
         raise KeyboardInterrupt
 
     monkeypatch.setattr("frame_compare.cli.entry._prompt_input_dir", _interrupt)
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
 
         result = _invoke(root, "")
@@ -463,8 +494,10 @@ def test_keyboard_interrupt_uses_exact_cancellation_contract(monkeypatch: Monkey
         assert not config_path.exists()
 
 
-def test_eof_at_reference_prompt_exits_130_without_write() -> None:
-    with runner.isolated_filesystem():
+def test_eof_at_reference_prompt_exits_130_without_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         (root / "comparison_videos" / "clip.mkv").touch()
 
@@ -482,12 +515,13 @@ def test_noninteractive_matrix_fails_before_config_read_or_prompt(
     monkeypatch: MonkeyPatch,
     stdin_tty: bool,
     stdout_tty: bool,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(
         "frame_compare.cli.entry._sys_stream_isatty",
         lambda name: stdin_tty if name == "stdin" else stdout_tty,
     )
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         config_path.write_text("secret = [", encoding="utf-8")
@@ -506,9 +540,10 @@ def test_noninteractive_matrix_fails_before_config_read_or_prompt(
 
 def test_external_config_is_rejected_before_tty_check_or_prompt(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setattr("frame_compare.cli.entry._sys_stream_isatty", lambda _name: False)
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, _ = _workspace()
         external_config = (Path("outside") / "config.toml").resolve()
 
@@ -520,8 +555,10 @@ def test_external_config_is_rejected_before_tty_check_or_prompt(
         assert "FC-3017" not in result.stderr
 
 
-def test_invalid_existing_secret_is_redacted_before_prompts() -> None:
-    with runner.isolated_filesystem():
+def test_invalid_existing_secret_is_redacted_before_prompts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         config_path.write_text(
@@ -538,8 +575,10 @@ def test_invalid_existing_secret_is_redacted_before_prompts() -> None:
         assert "do-not-leak-this" not in result.stderr
 
 
-def test_invalid_utf8_existing_config_uses_typed_parse_error_and_preserves_bytes() -> None:
-    with runner.isolated_filesystem():
+def test_invalid_utf8_existing_config_uses_typed_parse_error_and_preserves_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         original = b'[paths]\ninput_dir = "comparison_videos"\n\xff'
@@ -556,8 +595,9 @@ def test_invalid_utf8_existing_config_uses_typed_parse_error_and_preserves_bytes
 
 def test_existing_environment_expanded_input_is_validated_without_rewriting(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         external = Path("external-media").resolve()
         external.mkdir()
@@ -574,8 +614,10 @@ def test_existing_environment_expanded_input_is_validated_without_rewriting(
         assert config_path.read_bytes() == original
 
 
-def test_invalid_existing_contained_path_fails_before_prompts() -> None:
-    with runner.isolated_filesystem():
+def test_invalid_existing_contained_path_fails_before_prompts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         config_path.write_text(
@@ -593,8 +635,10 @@ def test_invalid_existing_contained_path_fails_before_prompts() -> None:
 @pytest.mark.parametrize("generated_value", ["/", "C:\\", "\\\\server\\share"])
 def test_generated_filesystem_roots_are_rejected_without_replacing_existing_config(
     generated_value: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         config_path.parent.mkdir()
         original = b'[paths]\ninput_dir = "comparison_videos"\ngenerated_dir = "generated"\n'
@@ -608,8 +652,10 @@ def test_generated_filesystem_roots_are_rejected_without_replacing_existing_conf
         assert config_path.read_bytes() == original
 
 
-def test_automatic_reference_removes_existing_explicit_key() -> None:
-    with runner.isolated_filesystem():
+def test_automatic_reference_removes_existing_explicit_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         (root / "comparison_videos" / "clip.mkv").touch()
         config_path.parent.mkdir()
@@ -628,8 +674,9 @@ def test_automatic_reference_removes_existing_explicit_key() -> None:
 
 def test_exact_windows_portable_config_exception_is_preserved(
     monkeypatch: MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    with runner.isolated_filesystem():
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, _ = _workspace()
         portable_config = (Path("portable-state") / "config.toml").resolve()
         monkeypatch.setattr(
@@ -644,8 +691,10 @@ def test_exact_windows_portable_config_exception_is_preserved(
         assert "Configuration written" in result.stderr
 
 
-def test_duplicate_stems_fail_before_reference_prompt() -> None:
-    with runner.isolated_filesystem():
+def test_duplicate_stems_fail_before_reference_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         (root / "comparison_videos" / "clip.mkv").touch()
         (root / "comparison_videos" / "clip.mp4").touch()
@@ -658,8 +707,10 @@ def test_duplicate_stems_fail_before_reference_prompt() -> None:
         assert not config_path.exists()
 
 
-def test_stale_reference_keep_warns_in_menu_and_review() -> None:
-    with runner.isolated_filesystem():
+def test_stale_reference_keep_warns_in_menu_and_review(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         (root / "comparison_videos" / "present.mkv").touch()
         config_path.parent.mkdir()
@@ -675,8 +726,10 @@ def test_stale_reference_keep_warns_in_menu_and_review() -> None:
         assert config_path.read_text(encoding="utf-8").endswith('reference = "gone.mkv"\n')
 
 
-def test_external_input_is_allowed_and_discovery_error_is_typed(monkeypatch: MonkeyPatch) -> None:
-    with runner.isolated_filesystem():
+def test_external_input_is_allowed_and_discovery_error_is_typed(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    with isolated_cli_filesystem(tmp_path, monkeypatch):
         root, config_path = _workspace()
         external = Path("external").resolve()
         external.mkdir()

--- a/uv.lock
+++ b/uv.lock
@@ -440,7 +440,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.2.0" },
     { name = "structlog", specifier = ">=26.1.0" },
     { name = "tomli-w", specifier = ">=1.2.0" },
-    { name = "typer", specifier = ">=0.25.1,<0.26" },
+    { name = "typer", specifier = ">=0.27.1" },
     { name = "vspreview", marker = "extra == 'vspreview'" },
 ]
 provides-extras = ["vspreview"]
@@ -1601,17 +1601,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Migrates Frame Compare from the pre-vendored-Click Typer line to **Typer 0.27.1**, released **January 19, 2026**, while preserving the project’s supported CLI behavior and removing test coupling to the independently installed external Click implementation.

- Base: `dev/v.0.20`
- Final production commit: `a9275a1535877815a30cb4b026377f9c4be4b58c`
- Dependency policy: `typer>=0.27.1`
- Locked version: `typer==0.27.1`
- External Click remains installed in the development environment; this PR does not remove it because other environment dependencies may still require it.

## Why Typer 0.26+ was breaking

Typer 0.26.0 deliberately began vendoring Click instead of relying on the separately installed `click` package. That architectural change invalidated several assumptions in Frame Compare’s test infrastructure:

- Typer-generated command and group objects are not classes from the external `click` package.
- `typer.testing.CliRunner` and `Result` are Typer-owned implementations rather than external Click testing classes.
- Typer’s runner does not expose Click’s `CliRunner.isolated_filesystem()` helper.
- Rich help, error, metavar, wrapping, and quoting details changed.
- Shell-completion output is shell- and platform-specific.

Primary upstream references reviewed:

- Typer release notes covering 0.26.0 through 0.27.1: https://typer.tiangolo.com/release-notes/
- Typer testing documentation: https://typer.tiangolo.com/tutorial/testing/
- Typer 0.27.1 testing implementation: https://github.com/fastapi/typer/blob/0.27.1/typer/testing.py
- Typer 0.27.1 release: https://github.com/fastapi/typer/releases/tag/0.27.1

## Compatibility inventory and decisions

### Test-only incompatibilities

- Replaced `click.testing.Result` imports with `typer.testing.Result`.
- Replaced all `runner.isolated_filesystem()` usage with a typed project-owned pytest helper using `tmp_path`, `monkeypatch.context()`, and `chdir()`.
- Replaced external `click.Group` identity assertions with behavioral command-registration and option assertions.
- Relaxed one retired-option assertion that depended on exact Rich quoting while preserving exit code, stream, semantic message, and option-name checks.
- Added shell-completion coverage that recognizes valid Bash, Zsh, Fish, and PowerShell completion source.

### Application compatibility issues

No application-source adaptation was required. Existing public Typer usage remains compatible with 0.27.1, including the custom `FrameCompareTyperGroup` and help-width stabilization behavior.

### Intentional upstream presentation changes

Typer 0.27.1 may render Rich borders, whitespace, wrapping, metavars, and option quoting differently. Tests continue to validate semantic content, exit status, and stdout/stderr routing without treating incidental presentation as a stable API.

### Genuine regressions

None found. Exit codes, JSON output, stream routing, command registration, interactive behavior, no-color output, installed entry points, and portable wrappers remain correct.

## Dependency and lockfile changes

- Removed the temporary `<0.26` ceiling.
- Updated the project dependency to `typer>=0.27.1`, consistent with the repository’s minimum-version dependency policy.
- Regenerated `uv.lock` with uv `0.12.2` and explicitly targeted `typer==0.27.1` during migration validation.
- Confirmed the resolved and installed Typer version is exactly `0.27.1`.

## CLI contracts preserved

- Exit codes
- stdout/stderr separation
- JSON stdout purity and structured JSON failures
- `--no-color` and `NO_COLOR=1`
- quiet and verbose behavior
- unknown-option, missing-argument, and invalid-value handling
- root and subcommand help
- retired `--frame-count` and `-n` rejection
- interactive and non-interactive behavior
- domain-error and unexpected-exception handling
- installed `frame-compare` console script
- `python -m frame_compare.cli.entry`
- shell-completion generation
- Windows portable wrapper, extracted installation, and update ZIP behavior

## Validation

### Baseline

- Existing Typer 0.25.1 CLI suite: **231 passed**

### Focused Typer 0.27.1 validation

- Migrated CLI suite: **232 passed**
- Root help, subcommand help, installed version command, module entry point, `NO_COLOR=1`, shell completion, and `doctor --json` smoke checks passed.

### Full Linux validation

- `uv lock --check`: passed
- `uv sync --all-groups --frozen`: passed
- `ruff check .`: passed
- `ruff format --check .`: passed; 444 files formatted
- `pyright --warnings`: **0 errors, 0 warnings**
- Bandit medium/high gate: passed; **0 medium, 0 high**
- Import-linter: **2 contracts kept, 0 broken**
- Full pytest: **2,408 passed, 18 skipped**
- API documentation generation check: passed
- Zensical strict documentation build: passed
- Source distribution and wheel build: passed
- Strict hash-based dependency audit: **no known vulnerabilities found**
- Migration scope guard: passed

### Exact-final-SHA Windows portable validation

Validated commit `a9275a1535877815a30cb4b026377f9c4be4b58c` successfully:

- Full mocked-VapourSynth pytest suite
- Portable bundle build
- Bundle workspace validation
- `doctor --json` smoke
- Portable ZIP packaging and layout validation
- Extracted ZIP workspace validation
- Extracted install shim, installed CLI help, and version smoke
- Code-only update ZIP build, hash, and layout validation
- Bundle and update artifact uploads

## CodeRabbit review

Both valid findings were addressed:

1. Temporary validation used an environment expression for the setup-uv version; it was changed to the required literal `0.12.2`.
2. Migration lock generation was made deterministic with an exact `typer==0.27.1` upgrade target while retaining the repository-standard published lower bound `typer>=0.27.1`.

The temporary migration workflows and controller were removed before the final production commit, so both review threads are now outdated and no migration scaffolding remains.

## Scope guard

The media runtime was not modified. The final diff and automated scope checks confirm no changes to:

- VapourSynth R76
- FFmpeg
- FFMS2
- L-SMASH
- L-SMASH-Works
- vs-placebo 2.0.2
- `Dockerfile`
- Windows portable runtime manifest

No unrelated dependency upgrades are included.

## User-visible behavior

No intentional command, option, exit-code, JSON-schema, or stream-routing changes were introduced. Users may see minor Typer/Rich presentation differences in help and parse-error output, and completion source is correctly generated for the detected shell on each platform.